### PR TITLE
adjust min cards played to blitz

### DIFF
--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -47,12 +47,12 @@ describe("Game Rules", () => {
 
     it("should require blitzed players to play minimum cards", () => {
       const invalidBlitzScores = createValidScores([
-        { blitzPile: 0, cardsPlayed: 5 }, // Invalid: Blitzed but not enough cards
+        { blitzPile: 0, cardsPlayed: 3 }, // Invalid: Blitzed but not enough cards
         { blitzPile: 5, cardsPlayed: 10 }, // Valid non-blitz score
       ]);
 
       expect(() => validateGameRules(invalidBlitzScores)).toThrow(
-        "Players who blitz must play at least 6 cards"
+        "Players who blitz must play at least 4 cards"
       );
     });
 
@@ -67,7 +67,7 @@ describe("Game Rules", () => {
 
     it("should handle edge cases", () => {
       const edgeCaseScores = createValidScores([
-        { blitzPile: 0, cardsPlayed: 6 }, // Minimum valid blitz
+        { blitzPile: 0, cardsPlayed: 4 }, // Minimum valid blitz
         { blitzPile: 0, cardsPlayed: 40 }, // Maximum cards played
         { blitzPile: 10, cardsPlayed: 0 }, // No cards played
       ]);
@@ -101,10 +101,10 @@ describe("Game Rules", () => {
     });
 
     it("should identify valid blitz scores", () => {
-      expect(isValidBlitz({ blitzPileRemaining: 0, totalCardsPlayed: 6 })).toBe(
+      expect(isValidBlitz({ blitzPileRemaining: 0, totalCardsPlayed: 4 })).toBe(
         true
       );
-      expect(isValidBlitz({ blitzPileRemaining: 0, totalCardsPlayed: 5 })).toBe(
+      expect(isValidBlitz({ blitzPileRemaining: 0, totalCardsPlayed: 3 })).toBe(
         false
       );
       expect(isValidBlitz({ blitzPileRemaining: 5, totalCardsPlayed: 0 })).toBe(

--- a/src/lib/validation/gameRules.ts
+++ b/src/lib/validation/gameRules.ts
@@ -3,7 +3,7 @@ import { type Score, type ScoreValidation } from "./schema";
 
 // Game constants
 export const GAME_RULES = {
-  MIN_CARDS_FOR_BLITZ: 6,
+  MIN_CARDS_FOR_BLITZ: 4,
   POINTS_TO_WIN: 75,
   BLITZ_PENALTY_MULTIPLIER: 2,
   MAX_BLITZ_PILE: 10,
@@ -13,7 +13,7 @@ export const GAME_RULES = {
 // Game error messages
 export const ERROR_MESSAGES = {
   NO_BLITZ: "At least one player must blitz (have 0 cards remaining)",
-  INVALID_BLITZ: "Players who blitz must play at least 6 cards",
+  INVALID_BLITZ: "Players who blitz must play at least 4 cards",
   INVALID_SCORE:
     "Invalid scores: Blitz pile must be 0-10 cards, total cards played must be 0-40",
 } as const;


### PR DESCRIPTION
Playing two player, I ran into cases where I blitzed but played less than 6 cards which wasn't allowed by validation. This comes from extreme stacking. 