### PR TITLE
Fix cumulative score calc when sums are zero

### DIFF
--- a/src/server/__tests__/queries.test.ts
+++ b/src/server/__tests__/queries.test.ts
@@ -500,6 +500,28 @@ describe("Queries", () => {
         expect(result).toBe(0);
       });
 
+      it("should handle zero values correctly", async () => {
+        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
+          _sum: {
+            totalCardsPlayed: 0,
+            blitzPileRemaining: 20,
+          },
+        });
+
+        let result = await getCumulativeScore();
+        expect(result).toBe(-40);
+
+        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
+          _sum: {
+            totalCardsPlayed: 100,
+            blitzPileRemaining: 0,
+          },
+        });
+
+        result = await getCumulativeScore();
+        expect(result).toBe(100);
+      });
+
       it("should return 0 for no scores", async () => {
         (prisma.score.aggregate as jest.Mock).mockResolvedValue({
           _sum: {

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -329,7 +329,7 @@ export async function getCumulativeScore() {
   const totalCardsPlayed = cumulativeScore._sum.totalCardsPlayed;
   const blitzPileRemaining = cumulativeScore._sum.blitzPileRemaining;
 
-  if (!totalCardsPlayed || !blitzPileRemaining) {
+  if (totalCardsPlayed === null || blitzPileRemaining === null) {
     return 0;
   }
 


### PR DESCRIPTION
## Summary
- handle zero sums in `getCumulativeScore`
- add tests for zero-sum cases

## Testing
- `npm test --silent` *(fails: jest not found)*