### PR TITLE
Winner modal: celebratory overlay + clear Play again

### DIFF
--- a/src/app/games/[id]/GameOver.tsx
+++ b/src/app/games/[id]/GameOver.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 
 export default function GameOver({
   gameId,
@@ -12,6 +20,8 @@ export default function GameOver({
   winner: string;
 }) {
   const router = useRouter();
+  const [open, setOpen] = useState(true);
+
   const handleClone = async () => {
     const res = await fetch(`/games/clone/${gameId}`, {});
 
@@ -24,12 +34,25 @@ export default function GameOver({
   };
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4">
-      <p className="flex justify-center">{winner} won the game!</p>
-      <Button onClick={handleClone}>Play again</Button>
-      <p className="text-xs">
-        This will start a new game with the same players
-      </p>
-    </div>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-center text-2xl">
+            🎉 {winner} won the game!
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            Great round — want a rematch with the same players?
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-2 flex flex-col items-center gap-3">
+          <Button size="lg" onClick={handleClone} className="w-full">
+            Play again
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Starts a new game with the same players
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/games/[id]/scoreEntry.tsx
+++ b/src/app/games/[id]/scoreEntry.tsx
@@ -100,9 +100,8 @@ function ScoreEntry({
     validateScores();
   }, [playerScores, validateScores]);
 
-  if (winner) {
-    return <GameOver gameId={game.id} winner={winner.username} />;
-  }
+  // If a winner exists, we will render a modal overlay below while keeping
+  // the current screen visible in the background.
 
   const stripLeadingZeros = (value: string) => {
     return value.replace(/^0+(?=\d)/, "");
@@ -236,10 +235,12 @@ function ScoreEntry({
   };
 
   return (
-    <form
-      className="bg-white dark:bg-gray-950 rounded-lg shadow-lg p-6 max-w-md mx-auto"
-      onSubmit={handleSubmit}
-    >
+    <>
+      {winner && <GameOver gameId={game.id} winner={winner.username} />}
+      <form
+        className="bg-white dark:bg-gray-950 rounded-lg shadow-lg p-6 max-w-md mx-auto"
+        onSubmit={handleSubmit}
+      >
       {error && (
         <Alert variant="destructive" className="mb-6">
           <AlertCircle className="h-4 w-4" />
@@ -302,7 +303,8 @@ function ScoreEntry({
           Save Scores
         </Button>
       </div>
-    </form>
+      </form>
+    </>
   );
 }
 


### PR DESCRIPTION
This PR replaces the inline game-over message with a modal overlay to improve discoverability of the rematch action and lightly celebrate the winner.\n\nChanges\n- Converts GameOver into a Shadcn/Radix Dialog that opens automatically when a winner is present.\n- Adds a celebratory title and concise prompt.\n- Prominent primary "Play again" button preserves existing clone-and-navigate behavior.\n- Modal is dismissible via the X, overlay click, or Escape.\n- Keeps the game screen visible beneath the modal (context is preserved).\n\nFiles\n- src/app/games/[id]/GameOver.tsx\n- src/app/games/[id]/scoreEntry.tsx\n\nFuture tweaks\n- Optional confetti burst on open.\n- Option to make the dialog non-dismissible if preferred.