### PR TITLE
Scoring revamp Plan 1: Foundation + Score Entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ claude_desktop_config.json
 
 # clerk configuration (can include secrets)
 /.clerk/
+
+# worktrees
+.worktrees/

--- a/src/app/dev/workbench/page.tsx
+++ b/src/app/dev/workbench/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { ScoreEntryCard } from "@/components/scoring/ScoreEntryCard";
+import { ColorPicker } from "@/components/scoring/ColorPicker";
+import { getEntryStatus, type PlayerEntry } from "@/components/scoring/types";
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
 
 // --- Types ---
 
@@ -11,23 +15,7 @@ type Player = {
   colorLabel: string;
 };
 
-type RoundEntry = {
-  blitzRemaining: number | null;
-  cardsPlayed: number | null;
-};
-
 type RoundData = Record<string, { blitzRemaining: number; cardsPlayed: number }>;
-
-// --- Dutch Blitz Colors ---
-
-const DUTCH_BLITZ_COLORS = [
-  { value: "#3b82f6", label: "Blue" },
-  { value: "#ef4444", label: "Red" },
-  { value: "#eab308", label: "Yellow" },
-  { value: "#22c55e", label: "Green" },
-  { value: "#8b5cf6", label: "Purple" },
-  { value: "#f97316", label: "Orange" },
-];
 
 // --- Score Calculation ---
 
@@ -138,71 +126,6 @@ function RaceTrack({ players, scores, winThreshold = 75, pillThreshold = 8 }: {
         })}
       </div>
       <div className="h-5" />
-    </div>
-  );
-}
-
-// --- Color Picker ---
-
-function ColorPicker({ value, onChange, usedColors }: { value: string; onChange: (color: string) => void; usedColors: string[] }) {
-  return (
-    <div className="flex gap-1.5 flex-wrap">
-      {DUTCH_BLITZ_COLORS.map((c) => {
-        const isUsed = usedColors.includes(c.value) && c.value !== value;
-        return (
-          <button key={c.value} onClick={() => !isUsed && onChange(c.value)}
-            className={`w-7 h-7 rounded-full border-2 transition-all ${value === c.value ? "border-[#290806] scale-110" : isUsed ? "border-transparent opacity-25 cursor-not-allowed" : "border-transparent hover:border-[#d1bfa8] cursor-pointer"}`}
-            style={{ backgroundColor: c.value }} title={isUsed ? `${c.label} (taken)` : c.label} disabled={isUsed} />
-        );
-      })}
-    </div>
-  );
-}
-
-// --- Score Entry Card ---
-
-function ScoreEntryCard({ player, score, entry, onUpdate, status }: {
-  player: Player; score: number; entry: RoundEntry;
-  onUpdate: (field: "blitzRemaining" | "cardsPlayed", value: number | null) => void;
-  status: "empty" | "partial" | "complete";
-}) {
-  const statusIcon = {
-    empty: { bg: "bg-[#f0e6d2]", text: "text-[#d1bfa8]", icon: "○" },
-    partial: { bg: "bg-[#fef3c7]", text: "text-[#b45309]", icon: "½" },
-    complete: { bg: "bg-[#dcfce7]", text: "text-[#2a6517]", icon: "✓" },
-  }[status];
-
-  return (
-    <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3 flex items-center gap-2.5" style={{ borderLeftWidth: "5px", borderLeftColor: player.color }}>
-      <div className="w-16 flex-shrink-0">
-        <div className="text-sm font-semibold text-[#290806]">{player.name}</div>
-        <div className={`text-[11px] ${score < 0 ? "text-[#b91c1c]" : "text-[#8b5e3c]"}`}>{score} pts</div>
-      </div>
-      <div className="flex gap-2 flex-1">
-        <div className="flex-1">
-          <label className="block text-[9px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-1">Blitz left</label>
-          <input type="text" inputMode="numeric" pattern="[0-9]*" value={entry.blitzRemaining !== null ? String(entry.blitzRemaining) : ""}
-            onChange={(e) => {
-              const raw = e.target.value.replace(/[^0-9]/g, "");
-              if (raw === "") { onUpdate("blitzRemaining", null); return; }
-              const n = parseInt(raw, 10);
-              if (!isNaN(n)) onUpdate("blitzRemaining", Math.min(10, Math.max(0, n)));
-            }}
-            className="w-full h-11 bg-[#fff7ea] border-[1.5px] border-[#e6d7c3] rounded-lg text-[#290806] text-xl font-semibold text-center focus:border-[#8b5e3c] focus:outline-none transition-colors" placeholder="—" />
-        </div>
-        <div className="flex-1">
-          <label className="block text-[9px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-1">Cards played</label>
-          <input type="text" inputMode="numeric" pattern="[0-9]*" value={entry.cardsPlayed !== null ? String(entry.cardsPlayed) : ""}
-            onChange={(e) => {
-              const raw = e.target.value.replace(/[^0-9]/g, "");
-              if (raw === "") { onUpdate("cardsPlayed", null); return; }
-              const n = parseInt(raw, 10);
-              if (!isNaN(n)) onUpdate("cardsPlayed", Math.min(40, Math.max(0, n)));
-            }}
-            className="w-full h-11 bg-[#fff7ea] border-[1.5px] border-[#e6d7c3] rounded-lg text-[#290806] text-xl font-semibold text-center focus:border-[#8b5e3c] focus:outline-none transition-colors" placeholder="—" />
-        </div>
-      </div>
-      <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0 ${statusIcon.bg} ${statusIcon.text}`}>{statusIcon.icon}</div>
     </div>
   );
 }
@@ -333,29 +256,21 @@ const DEFAULT_PLAYERS: Player[] = [
 export default function WorkbenchPage() {
   const [players, setPlayers] = useState<Player[]>(DEFAULT_PLAYERS);
   const [rounds, setRounds] = useState<RoundData[]>([]);
-  const [roundEntries, setRoundEntries] = useState<Record<string, RoundEntry>>(
+  const [roundEntries, setRoundEntries] = useState<Record<string, PlayerEntry>>(
     () => Object.fromEntries(DEFAULT_PLAYERS.map((p) => [p.id, { blitzRemaining: null, cardsPlayed: null }]))
   );
   const [winThreshold, setWinThreshold] = useState(75);
   const [pillThreshold, setPillThreshold] = useState(8);
   const [editingPlayers, setEditingPlayers] = useState(false);
   const [editingRound, setEditingRound] = useState<number | null>(null);
-  const [undoState, setUndoState] = useState<{ roundNumber: number; previousRounds: RoundData[]; previousEntries: Record<string, RoundEntry> } | null>(null);
+  const [undoState, setUndoState] = useState<{ roundNumber: number; previousRounds: RoundData[]; previousEntries: Record<string, PlayerEntry> } | null>(null);
 
   const usedColors = players.map((p) => p.color);
   const scores = useMemo(() => calcScores(players, rounds), [players, rounds]);
   const roundNumber = rounds.length + 1;
 
-  const getEntryStatus = useCallback((entry: RoundEntry): "empty" | "partial" | "complete" => {
-    const hasBlitz = entry.blitzRemaining !== null && !isNaN(entry.blitzRemaining);
-    const hasCards = entry.cardsPlayed !== null && !isNaN(entry.cardsPlayed);
-    if (hasBlitz && hasCards) return "complete";
-    if (hasBlitz || hasCards) return "partial";
-    return "empty";
-  }, []);
-
-  const allComplete = useMemo(() => Object.values(roundEntries).every((e) => getEntryStatus(e) === "complete"), [roundEntries, getEntryStatus]);
-  const remainingCount = useMemo(() => Object.values(roundEntries).filter((e) => getEntryStatus(e) !== "complete").length, [roundEntries, getEntryStatus]);
+  const allComplete = useMemo(() => Object.values(roundEntries).every((e) => getEntryStatus(e) === "complete"), [roundEntries]);
+  const remainingCount = useMemo(() => Object.values(roundEntries).filter((e) => getEntryStatus(e) !== "complete").length, [roundEntries]);
   const winner = useMemo(() => players.find((p) => (scores[p.id] ?? 0) >= winThreshold), [players, scores, winThreshold]);
 
   const handleUpdateEntry = useCallback((playerId: string, field: "blitzRemaining" | "cardsPlayed", value: number | null) => {
@@ -406,7 +321,7 @@ export default function WorkbenchPage() {
   }, [players]);
 
   const handleAddPlayer = useCallback(() => {
-    const availableColor = DUTCH_BLITZ_COLORS.find((c) => !usedColors.includes(c.value));
+    const availableColor = ACCENT_COLORS.find((c) => !usedColors.includes(c.value));
     if (!availableColor) return;
     const id = String(Date.now());
     const newPlayer: Player = { id, name: `Player ${players.length + 1}`, color: availableColor.value, colorLabel: availableColor.label };
@@ -425,7 +340,7 @@ export default function WorkbenchPage() {
   }, []);
 
   const handleUpdatePlayerColor = useCallback((id: string, color: string) => {
-    const label = DUTCH_BLITZ_COLORS.find((c) => c.value === color)?.label ?? "";
+    const label = ACCENT_COLORS.find((c) => c.value === color)?.label ?? "";
     setPlayers((prev) => prev.map((p) => (p.id === id ? { ...p, color, colorLabel: label } : p)));
   }, []);
 
@@ -514,7 +429,7 @@ export default function WorkbenchPage() {
               {/* Player cards */}
               <div className="px-4 pt-2 pb-2 space-y-2.5">
                 {players.map((player) => (
-                  <ScoreEntryCard key={player.id} player={player} score={scores[player.id] ?? 0} entry={roundEntries[player.id]}
+                  <ScoreEntryCard key={player.id} name={player.name} color={player.color} score={scores[player.id] ?? 0} entry={roundEntries[player.id]}
                     onUpdate={(field, value) => handleUpdateEntry(player.id, field, value)} status={getEntryStatus(roundEntries[player.id])} />
                 ))}
               </div>

--- a/src/app/dev/workbench/page.tsx
+++ b/src/app/dev/workbench/page.tsx
@@ -141,7 +141,8 @@ function UndoToast({ roundNumber, onUndo, onDismiss }: { roundNumber: number; on
       setTimeLeft((prev) => {
         if (prev <= 0) {
           if (timerRef.current) clearInterval(timerRef.current);
-          onDismiss();
+          // Defer dismiss to avoid setState during render
+          setTimeout(onDismiss, 0);
           return 0;
         }
         return prev - 2;
@@ -279,6 +280,13 @@ export default function WorkbenchPage() {
 
   const handleSubmitRound = useCallback(() => {
     if (!allComplete) return;
+
+    // Validate: at least one player must have blitzed (0 remaining)
+    const hasBlitz = players.some((p) => roundEntries[p.id].blitzRemaining === 0);
+    if (!hasBlitz) {
+      alert("At least one player must blitz (have 0 cards remaining)");
+      return;
+    }
 
     // Save state for undo
     const previousRounds = [...rounds];

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,5 +1,6 @@
 import ScoreEntry from "./scoreEntry";
 import ScoreDisplay from "./scoreDisplay";
+import GameOver from "./GameOver";
 import { ScoringShell } from "@/components/scoring/ScoringShell";
 import { getGameById } from "@/server/queries";
 import { notFound } from "next/navigation";
@@ -118,30 +119,41 @@ export default async function GameView(props: {
         gameId={game.id}
         isFinished={game.isFinished}
       />
-      {canEnterScores &&
-        (useScoringRevamp ? (
-          <ScoringShell
-            gameId={game.id}
-            currentRoundNumber={currentRoundNumber}
-            players={scoringPlayers}
-            winThreshold={game.winThreshold}
-            isFinished={game.isFinished}
-            rounds={game.rounds.map((r) => ({
-              scores: r.scores.map((s) => ({
-                userId: s.userId,
-                guestId: s.guestId,
-                blitzPileRemaining: s.blitzPileRemaining,
-                totalCardsPlayed: s.totalCardsPlayed,
-              })),
-            }))}
-          />
-        ) : (
+      {useScoringRevamp ? (
+        <>
+          {canEnterScores && (
+            <ScoringShell
+              gameId={game.id}
+              currentRoundNumber={currentRoundNumber}
+              players={scoringPlayers}
+              winThreshold={game.winThreshold}
+              isFinished={game.isFinished}
+              rounds={game.rounds.map((r) => ({
+                scores: r.scores.map((s) => ({
+                  userId: s.userId,
+                  guestId: s.guestId,
+                  blitzPileRemaining: s.blitzPileRemaining,
+                  totalCardsPlayed: s.totalCardsPlayed,
+                })),
+              }))}
+            />
+          )}
+          {game.isFinished && displayScores.find((s) => s.isWinner) && (
+            <GameOver
+              gameId={game.id}
+              winner={displayScores.find((s) => s.isWinner)!.username}
+            />
+          )}
+        </>
+      ) : (
+        canEnterScores && (
           <ScoreEntry
             game={game}
             currentRoundNumber={currentRoundNumber}
             displayScores={displayScores}
           />
-        ))}
+        )
+      )}
     </section>
   );
 }

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,8 +1,14 @@
 import ScoreEntry from "./scoreEntry";
 import ScoreDisplay from "./scoreDisplay";
+import { ScoringShell } from "@/components/scoring/ScoringShell";
 import { getGameById } from "@/server/queries";
 import { notFound } from "next/navigation";
 import transformGameData, { GameWithPlayersAndScores } from "@/lib/gameLogic";
+import { isFeatureEnabled } from "@/featureFlags";
+import {
+  resolvePlayerColor,
+  assignColorsToPlayers,
+} from "@/lib/scoring/colors";
 import { auth } from "@clerk/nextjs/server";
 
 export default async function GameView(props: {
@@ -41,6 +47,7 @@ export default async function GameView(props: {
       gameId: player.gameId,
       userId: player.userId || undefined,
       guestId: player.guestId || undefined,
+      accentColor: player.accentColor ?? undefined,
       user: player.user || undefined,
       guestUser: player.guestUser || undefined,
     })),
@@ -58,6 +65,35 @@ export default async function GameView(props: {
 
   // calculate the current round number
   const currentRoundNumber = game.rounds.length + 1;
+
+  const useScoringRevamp = await isFeatureEnabled("scoring-revamp");
+
+  // Resolve accent colors for all players
+  const playerColorInputs = game.players.map((p) => ({
+    id: p.id,
+    resolvedColor: resolvePlayerColor({
+      gameColor: p.accentColor ?? null,
+      userDefault: p.user?.accentColor ?? null,
+    }),
+  }));
+  const colorAssignments = assignColorsToPlayers(playerColorInputs);
+
+  // Build PlayerWithScore array for the new scoring shell
+  // DisplayScores.id is the participant's userId or guestId (stable ID from gameLogic.ts)
+  const scoringPlayers = displayScores.map((ds) => {
+    const gamePlayer = game.players.find(
+      (p) => p.userId === ds.id || p.guestId === ds.id
+    );
+    return {
+      id: ds.id,
+      name: ds.username,
+      color: colorAssignments[gamePlayer?.id ?? ds.id] ?? "#3b82f6",
+      isGuest: ds.isGuest,
+      userId: gamePlayer?.userId ?? undefined,
+      guestId: gamePlayer?.guestId ?? undefined,
+      score: ds.total,
+    };
+  });
 
   const { userId, orgId } = await auth();
   const isAuthenticated = !!userId;
@@ -82,13 +118,30 @@ export default async function GameView(props: {
         gameId={game.id}
         isFinished={game.isFinished}
       />
-      {canEnterScores && (
-        <ScoreEntry
-          game={game}
-          currentRoundNumber={currentRoundNumber}
-          displayScores={displayScores}
-        />
-      )}
+      {canEnterScores &&
+        (useScoringRevamp ? (
+          <ScoringShell
+            gameId={game.id}
+            currentRoundNumber={currentRoundNumber}
+            players={scoringPlayers}
+            winThreshold={game.winThreshold}
+            isFinished={game.isFinished}
+            rounds={game.rounds.map((r) => ({
+              scores: r.scores.map((s) => ({
+                userId: s.userId,
+                guestId: s.guestId,
+                blitzPileRemaining: s.blitzPileRemaining,
+                totalCardsPlayed: s.totalCardsPlayed,
+              })),
+            }))}
+          />
+        ) : (
+          <ScoreEntry
+            game={game}
+            currentRoundNumber={currentRoundNumber}
+            displayScores={displayScores}
+          />
+        ))}
     </section>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,18 @@
     --ring: 240 10% 3.9%;
 
     --radius: 0.5rem;
+
+    /* Scoring design tokens */
+    --scoring-bg: #fff7ea;
+    --scoring-bg-muted: #f0e6d2;
+    --scoring-bg-subtle: #faf5ed;
+    --scoring-border: #e6d7c3;
+    --scoring-border-muted: #d1bfa8;
+    --scoring-text: #290806;
+    --scoring-text-muted: #8b5e3c;
+    --scoring-text-negative: #b91c1c;
+    --scoring-success: #2a6517;
+    --scoring-success-hover: #1d4a10;
   }
 
   .dark {

--- a/src/components/scoring/ColorPicker.tsx
+++ b/src/components/scoring/ColorPicker.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
+
+export function ColorPicker({
+  value,
+  onChange,
+  usedColors = [],
+}: {
+  value: string | null;
+  onChange: (color: string) => void;
+  usedColors?: string[];
+}) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {ACCENT_COLORS.map((c) => {
+        const isUsed = usedColors.includes(c.value) && c.value !== value;
+        const isSelected = value === c.value;
+        return (
+          <button
+            key={c.value}
+            onClick={() => !isUsed && onChange(c.value)}
+            className={`w-9 h-9 rounded-full border-2 transition-all ${
+              isSelected
+                ? "border-[#290806] scale-110 shadow-sm"
+                : isUsed
+                  ? "border-transparent opacity-25 cursor-not-allowed"
+                  : "border-transparent hover:border-[#d1bfa8] cursor-pointer"
+            }`}
+            style={{ backgroundColor: c.value }}
+            title={isUsed ? `${c.label} (taken)` : c.label}
+            disabled={isUsed}
+            aria-label={`${c.label}${isSelected ? " (selected)" : ""}${isUsed ? " (taken)" : ""}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/scoring/ColorPrompt.tsx
+++ b/src/components/scoring/ColorPrompt.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { ColorPicker } from "./ColorPicker";
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
+
+interface ColorPromptProps {
+  playerName: string;
+  usedColors: string[];
+  onSelect: (color: string, saveAsDefault: boolean) => void;
+}
+
+export function ColorPrompt({
+  playerName,
+  usedColors,
+  onSelect,
+}: ColorPromptProps) {
+  const firstAvailable = ACCENT_COLORS.find(
+    (c) => !usedColors.includes(c.value)
+  );
+  const [selected, setSelected] = useState<string | null>(
+    firstAvailable?.value ?? null
+  );
+  const [saveAsDefault, setSaveAsDefault] = useState(true);
+
+  return (
+    <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
+      <div className="text-sm font-bold text-[#290806] mb-1">
+        Choose your color, {playerName}
+      </div>
+      <div className="text-xs text-[#8b5e3c] mb-3">
+        Pick the color that matches your Dutch Blitz deck
+      </div>
+
+      <ColorPicker
+        value={selected}
+        onChange={setSelected}
+        usedColors={usedColors}
+      />
+
+      <label className="flex items-center gap-2 mt-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={saveAsDefault}
+          onChange={(e) => setSaveAsDefault(e.target.checked)}
+          className="w-4 h-4 rounded border-[#e6d7c3] accent-[#290806]"
+        />
+        <span className="text-xs text-[#8b5e3c]">
+          Save as my default color
+        </span>
+      </label>
+
+      <button
+        onClick={() => selected && onSelect(selected, saveAsDefault)}
+        disabled={!selected}
+        className={`w-full mt-3 py-2.5 rounded-lg text-sm font-bold transition-colors ${
+          selected
+            ? "bg-[#290806] text-white cursor-pointer"
+            : "bg-[#f0e6d2] text-[#d1bfa8] cursor-not-allowed"
+        }`}
+      >
+        Confirm
+      </button>
+    </div>
+  );
+}

--- a/src/components/scoring/FloatingCTA.tsx
+++ b/src/components/scoring/FloatingCTA.tsx
@@ -19,7 +19,7 @@ export function FloatingCTA({
 
   if (state.mode === "editing") {
     return (
-      <div className="fixed bottom-0 left-0 right-0 z-40 p-4 bg-gradient-to-t from-[#fff7ea] via-[#fff7ea] to-transparent pt-8">
+      <div className="sticky bottom-0 z-40 p-4 bg-gradient-to-t from-[#fff7ea] via-[#fff7ea] to-transparent pt-8">
         <div className="max-w-[440px] mx-auto flex gap-2">
           <button
             onClick={onCancel}
@@ -47,7 +47,7 @@ export function FloatingCTA({
     : `Enter Round ${state.roundNumber} Scores`;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 p-4 bg-gradient-to-t from-[#fff7ea] via-[#fff7ea] to-transparent pt-8">
+    <div className="sticky bottom-0 z-40 p-4 bg-gradient-to-t from-[#fff7ea] via-[#fff7ea] to-transparent pt-8">
       <div className="max-w-[440px] mx-auto">
         <button
           onClick={onAction}

--- a/src/components/scoring/FloatingCTA.tsx
+++ b/src/components/scoring/FloatingCTA.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+export type CTAState =
+  | { mode: "submit"; remainingCount: number; allComplete: boolean }
+  | { mode: "nextRound"; roundNumber: number }
+  | { mode: "editing" }
+  | { mode: "gameOver" };
+
+export function FloatingCTA({
+  state,
+  onAction,
+  onCancel,
+}: {
+  state: CTAState;
+  onAction: () => void;
+  onCancel?: () => void;
+}) {
+  if (state.mode === "gameOver") return null;
+
+  if (state.mode === "editing") {
+    return (
+      <div className="fixed bottom-0 left-0 right-0 z-40 p-4 bg-gradient-to-t from-[#fff7ea] via-[#fff7ea] to-transparent pt-8">
+        <div className="max-w-[440px] mx-auto flex gap-2">
+          <button
+            onClick={onCancel}
+            className="flex-1 py-3.5 rounded-xl text-[15px] font-bold bg-[#f0e6d2] text-[#8b5e3c] cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onAction}
+            className="flex-1 py-3.5 rounded-xl text-[15px] font-bold bg-[#2a6517] text-white cursor-pointer hover:bg-[#1d4a10] transition-colors"
+          >
+            Save Changes
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const isSubmit = state.mode === "submit";
+  const disabled = isSubmit && !state.allComplete;
+  const label = isSubmit
+    ? state.allComplete
+      ? "Submit Round"
+      : `Submit Round (${state.remainingCount} remaining)`
+    : `Enter Round ${state.roundNumber} Scores`;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-40 p-4 bg-gradient-to-t from-[#fff7ea] via-[#fff7ea] to-transparent pt-8">
+      <div className="max-w-[440px] mx-auto">
+        <button
+          onClick={onAction}
+          disabled={disabled}
+          className={`w-full py-3.5 rounded-xl text-[15px] font-bold transition-all ${
+            disabled
+              ? "bg-[#f0e6d2] text-[#d1bfa8] cursor-not-allowed"
+              : isSubmit
+                ? "bg-[#2a6517] text-white hover:bg-[#1d4a10] cursor-pointer"
+                : "bg-[#290806] text-white hover:bg-[#3d1a0a] cursor-pointer"
+          }`}
+        >
+          {label}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/RoundHeader.tsx
+++ b/src/components/scoring/RoundHeader.tsx
@@ -1,0 +1,13 @@
+interface RoundHeaderProps {
+  title: string;
+  subtitle: string;
+}
+
+export function RoundHeader({ title, subtitle }: RoundHeaderProps) {
+  return (
+    <div className="px-5 pt-4 pb-2 bg-[#fff7ea] sticky top-0 z-20 border-b border-[#f0e6d2]">
+      <h2 className="text-lg font-bold text-[#290806]">{title}</h2>
+      <div className="text-xs text-[#8b5e3c]">{subtitle}</div>
+    </div>
+  );
+}

--- a/src/components/scoring/ScoreEntryCard.tsx
+++ b/src/components/scoring/ScoreEntryCard.tsx
@@ -48,7 +48,7 @@ export function ScoreEntryCard({
         </div>
       </div>
 
-      <div className="flex gap-2 flex-1">
+      <div className="flex gap-2 flex-1 max-w-[280px]">
         <div className="flex-1">
           <label className="block text-[9px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-1">
             Blitz left

--- a/src/components/scoring/ScoreEntryCard.tsx
+++ b/src/components/scoring/ScoreEntryCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { StatusIndicator } from "./StatusIndicator";
+import { type EntryStatus, type PlayerEntry } from "./types";
+
+interface ScoreEntryCardProps {
+  name: string;
+  color: string;
+  score: number;
+  entry: PlayerEntry;
+  status: EntryStatus;
+  onUpdate: (field: "blitzRemaining" | "cardsPlayed", value: number | null) => void;
+  deltaFlash?: number | null;
+}
+
+function handleNumericInput(
+  value: string,
+  max: number,
+  onChange: (v: number | null) => void
+) {
+  const raw = value.replace(/[^0-9]/g, "");
+  if (raw === "") {
+    onChange(null);
+    return;
+  }
+  const n = parseInt(raw, 10);
+  if (!isNaN(n)) onChange(Math.min(max, Math.max(0, n)));
+}
+
+export function ScoreEntryCard({
+  name,
+  color,
+  score,
+  entry,
+  status,
+  onUpdate,
+  deltaFlash,
+}: ScoreEntryCardProps) {
+  return (
+    <div
+      className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3 flex items-center gap-2.5 relative"
+      style={{ borderLeftWidth: "5px", borderLeftColor: color }}
+    >
+      {deltaFlash !== null && deltaFlash !== undefined && (
+        <div
+          className="absolute inset-0 flex items-center justify-center rounded-xl animate-[deltaFlash_1.2s_ease-out_forwards] pointer-events-none z-10"
+          style={{ backgroundColor: deltaFlash >= 0 ? "#dcfce7" : "#fef2f2" }}
+        >
+          <span
+            className={`text-2xl font-black ${deltaFlash >= 0 ? "text-[#2a6517]" : "text-[#b91c1c]"}`}
+          >
+            {deltaFlash > 0 ? `+${deltaFlash}` : deltaFlash}
+          </span>
+        </div>
+      )}
+
+      <div className="w-16 flex-shrink-0">
+        <div className="text-sm font-semibold text-[#290806]">{name}</div>
+        <div
+          className={`text-[11px] ${score < 0 ? "text-[#b91c1c]" : "text-[#8b5e3c]"}`}
+        >
+          {score} pts
+        </div>
+      </div>
+
+      <div className="flex gap-2 flex-1">
+        <div className="flex-1">
+          <label className="block text-[9px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-1">
+            Blitz left
+          </label>
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={entry.blitzRemaining !== null ? String(entry.blitzRemaining) : ""}
+            onChange={(e) =>
+              handleNumericInput(e.target.value, 10, (v) =>
+                onUpdate("blitzRemaining", v)
+              )
+            }
+            className="w-full h-11 bg-[#fff7ea] border-[1.5px] border-[#e6d7c3] rounded-lg text-[#290806] text-xl font-semibold text-center focus:border-[#8b5e3c] focus:outline-none transition-colors"
+            placeholder="—"
+          />
+        </div>
+        <div className="flex-1">
+          <label className="block text-[9px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-1">
+            Cards played
+          </label>
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={entry.cardsPlayed !== null ? String(entry.cardsPlayed) : ""}
+            onChange={(e) =>
+              handleNumericInput(e.target.value, 40, (v) =>
+                onUpdate("cardsPlayed", v)
+              )
+            }
+            className="w-full h-11 bg-[#fff7ea] border-[1.5px] border-[#e6d7c3] rounded-lg text-[#290806] text-xl font-semibold text-center focus:border-[#8b5e3c] focus:outline-none transition-colors"
+            placeholder="—"
+          />
+        </div>
+      </div>
+
+      <StatusIndicator status={status} />
+    </div>
+  );
+}

--- a/src/components/scoring/ScoreEntryCard.tsx
+++ b/src/components/scoring/ScoreEntryCard.tsx
@@ -10,7 +10,6 @@ interface ScoreEntryCardProps {
   entry: PlayerEntry;
   status: EntryStatus;
   onUpdate: (field: "blitzRemaining" | "cardsPlayed", value: number | null) => void;
-  deltaFlash?: number | null;
 }
 
 function handleNumericInput(
@@ -34,26 +33,12 @@ export function ScoreEntryCard({
   entry,
   status,
   onUpdate,
-  deltaFlash,
 }: ScoreEntryCardProps) {
   return (
     <div
-      className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3 flex items-center gap-2.5 relative"
+      className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3 flex items-center gap-2.5"
       style={{ borderLeftWidth: "5px", borderLeftColor: color }}
     >
-      {deltaFlash !== null && deltaFlash !== undefined && (
-        <div
-          className="absolute inset-0 flex items-center justify-center rounded-xl animate-[deltaFlash_1.2s_ease-out_forwards] pointer-events-none z-10"
-          style={{ backgroundColor: deltaFlash >= 0 ? "#dcfce7" : "#fef2f2" }}
-        >
-          <span
-            className={`text-2xl font-black ${deltaFlash >= 0 ? "text-[#2a6517]" : "text-[#b91c1c]"}`}
-          >
-            {deltaFlash > 0 ? `+${deltaFlash}` : deltaFlash}
-          </span>
-        </div>
-      )}
-
       <div className="w-16 flex-shrink-0">
         <div className="text-sm font-semibold text-[#290806]">{name}</div>
         <div

--- a/src/components/scoring/ScoreEntryView.tsx
+++ b/src/components/scoring/ScoreEntryView.tsx
@@ -1,0 +1,121 @@
+// src/components/scoring/ScoreEntryView.tsx
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { ScoreEntryCard } from "./ScoreEntryCard";
+import { FloatingCTA } from "./FloatingCTA";
+import { type PlayerEntry, type PlayerWithScore, getEntryStatus } from "./types";
+import { validateGameRules } from "@/lib/validation/gameRules";
+import { createRoundForGame } from "@/server/mutations";
+
+interface ScoreEntryViewProps {
+  gameId: string;
+  currentRoundNumber: number;
+  players: PlayerWithScore[];
+  winThreshold: number;
+}
+
+export function ScoreEntryView({
+  gameId,
+  currentRoundNumber,
+  players,
+  winThreshold,
+}: ScoreEntryViewProps) {
+  const router = useRouter();
+  const [entries, setEntries] = useState<Record<string, PlayerEntry>>(() =>
+    Object.fromEntries(
+      players.map((p) => [p.id, { blitzRemaining: null, cardsPlayed: null }])
+    )
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const allComplete = useMemo(
+    () => Object.values(entries).every((e) => getEntryStatus(e) === "complete"),
+    [entries]
+  );
+
+  const remainingCount = useMemo(
+    () =>
+      Object.values(entries).filter((e) => getEntryStatus(e) !== "complete")
+        .length,
+    [entries]
+  );
+
+  const handleUpdate = useCallback(
+    (playerId: string, field: "blitzRemaining" | "cardsPlayed", value: number | null) => {
+      setEntries((prev) => ({
+        ...prev,
+        [playerId]: { ...prev[playerId], [field]: value },
+      }));
+      setError(null);
+    },
+    []
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!allComplete || isSubmitting) return;
+    setIsSubmitting(true);
+    setError(null);
+
+    const scores = players.map((player) => {
+      const entry = entries[player.id];
+      return {
+        ...(player.isGuest
+          ? { guestId: player.guestId }
+          : { userId: player.userId }),
+        blitzPileRemaining: entry.blitzRemaining ?? 0,
+        totalCardsPlayed: entry.cardsPlayed ?? 0,
+      };
+    });
+
+    try {
+      validateGameRules(scores);
+      await createRoundForGame(gameId, currentRoundNumber, scores);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to submit round");
+      setIsSubmitting(false);
+    }
+  }, [allComplete, isSubmitting, players, entries, gameId, currentRoundNumber, router]);
+
+  return (
+    <>
+      {/* Error banner */}
+      {error && (
+        <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg text-sm text-[#b91c1c]">
+          {error}
+        </div>
+      )}
+
+      {/* Player cards */}
+      <div className="px-4 pt-2 pb-2 space-y-2.5">
+        {players.map((player) => (
+          <ScoreEntryCard
+            key={player.id}
+            name={player.name}
+            color={player.color}
+            score={player.score}
+            entry={entries[player.id]}
+            status={getEntryStatus(entries[player.id])}
+            onUpdate={(field, value) => handleUpdate(player.id, field, value)}
+          />
+        ))}
+      </div>
+
+      {/* Bottom spacer for floating CTA */}
+      <div className="h-24" />
+
+      {/* Floating CTA */}
+      <FloatingCTA
+        state={{
+          mode: "submit",
+          remainingCount,
+          allComplete: allComplete && !isSubmitting,
+        }}
+        onAction={handleSubmit}
+      />
+    </>
+  );
+}

--- a/src/components/scoring/ScoreEntryView.tsx
+++ b/src/components/scoring/ScoreEntryView.tsx
@@ -5,6 +5,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { ScoreEntryCard } from "./ScoreEntryCard";
 import { FloatingCTA } from "./FloatingCTA";
+import { RoundHeader } from "./RoundHeader";
 import { type PlayerEntry, type PlayerWithScore, getEntryStatus } from "./types";
 import { validateGameRules } from "@/lib/validation/gameRules";
 import { createRoundForGame } from "@/server/mutations";
@@ -82,6 +83,11 @@ export function ScoreEntryView({
 
   return (
     <>
+      <RoundHeader
+        title={`Round ${currentRoundNumber}`}
+        subtitle={`First to ${winThreshold} wins`}
+      />
+
       {/* Error banner */}
       {error && (
         <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg text-sm text-[#b91c1c]">

--- a/src/components/scoring/ScoreEntryView.tsx
+++ b/src/components/scoring/ScoreEntryView.tsx
@@ -74,6 +74,13 @@ export function ScoreEntryView({
     try {
       validateGameRules(scores);
       await createRoundForGame(gameId, currentRoundNumber, scores);
+      // Clear local state before refresh — App Router preserves client state across refresh
+      setEntries(
+        Object.fromEntries(
+          players.map((p) => [p.id, { blitzRemaining: null, cardsPlayed: null }])
+        )
+      );
+      setIsSubmitting(false);
       router.refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to submit round");

--- a/src/components/scoring/ScoreEntryView.tsx
+++ b/src/components/scoring/ScoreEntryView.tsx
@@ -89,7 +89,7 @@ export function ScoreEntryView({
   }, [allComplete, isSubmitting, players, entries, gameId, currentRoundNumber, router]);
 
   return (
-    <>
+    <div className="pb-4">
       <RoundHeader
         title={`Round ${currentRoundNumber}`}
         subtitle={`First to ${winThreshold} wins`}
@@ -103,7 +103,7 @@ export function ScoreEntryView({
       )}
 
       {/* Player cards */}
-      <div className="px-4 pt-2 pb-2 space-y-2.5">
+      <div className="px-4 pt-2 pb-2 space-y-2.5 max-w-[540px]">
         {players.map((player) => (
           <ScoreEntryCard
             key={player.id}
@@ -117,10 +117,7 @@ export function ScoreEntryView({
         ))}
       </div>
 
-      {/* Bottom spacer for floating CTA */}
-      <div className="h-24" />
-
-      {/* Floating CTA */}
+      {/* Sticky CTA — stays at bottom of viewport but won't overlap footer */}
       <FloatingCTA
         state={{
           mode: "submit",
@@ -129,6 +126,6 @@ export function ScoreEntryView({
         }}
         onAction={handleSubmit}
       />
-    </>
+    </div>
   );
 }

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { ScoreEntryView } from "./ScoreEntryView";
 import { type PlayerWithScore } from "./types";
 
@@ -30,10 +29,11 @@ export function ScoringShell({
   winThreshold,
   isFinished,
 }: ScoringShellProps) {
-  const [mode] = useState<ScoringMode>(isFinished ? "gameOver" : "entry");
-
-  // For Plan 1, only score entry mode is implemented.
+  // Derive mode from props — not useState — so it reacts to server state changes
+  // after router.refresh() (App Router preserves client state but updates props).
   // Plans 2-4 will add betweenRounds, editing, and gameOver rendering.
+  const mode: ScoringMode = isFinished ? "gameOver" : "entry";
+
   if (mode !== "entry") {
     return null;
   }

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ScoreEntryView } from "./ScoreEntryView";
+import { type PlayerWithScore } from "./types";
+
+interface ScoringShellProps {
+  gameId: string;
+  currentRoundNumber: number;
+  players: PlayerWithScore[];
+  winThreshold: number;
+  isFinished: boolean;
+  rounds: {
+    scores: {
+      userId?: string | null;
+      guestId?: string | null;
+      blitzPileRemaining: number;
+      totalCardsPlayed: number;
+    }[];
+  }[];
+}
+
+export function ScoringShell({
+  gameId,
+  currentRoundNumber,
+  players,
+  winThreshold,
+}: ScoringShellProps) {
+  // For Plan 1, only score entry mode.
+  // Plans 2-4 will add between-rounds, editing, and game-over modes.
+  return (
+    <ScoreEntryView
+      gameId={gameId}
+      currentRoundNumber={currentRoundNumber}
+      players={players}
+      winThreshold={winThreshold}
+    />
+  );
+}

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import { ScoreEntryView } from "./ScoreEntryView";
 import { type PlayerWithScore } from "./types";
+
+export type ScoringMode = "entry" | "betweenRounds" | "editing" | "gameOver";
 
 interface ScoringShellProps {
   gameId: string;
@@ -9,6 +12,7 @@ interface ScoringShellProps {
   players: PlayerWithScore[];
   winThreshold: number;
   isFinished: boolean;
+  winnerName?: string;
   rounds: {
     scores: {
       userId?: string | null;
@@ -24,9 +28,16 @@ export function ScoringShell({
   currentRoundNumber,
   players,
   winThreshold,
+  isFinished,
 }: ScoringShellProps) {
-  // For Plan 1, only score entry mode.
-  // Plans 2-4 will add between-rounds, editing, and game-over modes.
+  const [mode] = useState<ScoringMode>(isFinished ? "gameOver" : "entry");
+
+  // For Plan 1, only score entry mode is implemented.
+  // Plans 2-4 will add betweenRounds, editing, and gameOver rendering.
+  if (mode !== "entry") {
+    return null;
+  }
+
   return (
     <ScoreEntryView
       gameId={gameId}

--- a/src/components/scoring/StatusIndicator.tsx
+++ b/src/components/scoring/StatusIndicator.tsx
@@ -1,0 +1,18 @@
+import { type EntryStatus } from "./types";
+
+const STATUS_CONFIG = {
+  empty: { bg: "bg-[#f0e6d2]", text: "text-[#d1bfa8]", icon: "○" },
+  partial: { bg: "bg-[#fef3c7]", text: "text-[#b45309]", icon: "½" },
+  complete: { bg: "bg-[#dcfce7]", text: "text-[#2a6517]", icon: "✓" },
+} as const;
+
+export function StatusIndicator({ status }: { status: EntryStatus }) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <div
+      className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0 ${config.bg} ${config.text}`}
+    >
+      {config.icon}
+    </div>
+  );
+}

--- a/src/components/scoring/types.ts
+++ b/src/components/scoring/types.ts
@@ -1,0 +1,27 @@
+export type EntryStatus = "empty" | "partial" | "complete";
+
+export interface PlayerEntry {
+  blitzRemaining: number | null;
+  cardsPlayed: number | null;
+}
+
+export interface ScoringPlayer {
+  id: string;
+  name: string;
+  color: string;
+  isGuest: boolean;
+  userId?: string;
+  guestId?: string;
+}
+
+export interface PlayerWithScore extends ScoringPlayer {
+  score: number;
+}
+
+export function getEntryStatus(entry: PlayerEntry): EntryStatus {
+  const hasBlitz = entry.blitzRemaining !== null && !isNaN(entry.blitzRemaining);
+  const hasCards = entry.cardsPlayed !== null && !isNaN(entry.cardsPlayed);
+  if (hasBlitz && hasCards) return "complete";
+  if (hasBlitz || hasCards) return "partial";
+  return "empty";
+}

--- a/src/lib/__tests__/colors.test.ts
+++ b/src/lib/__tests__/colors.test.ts
@@ -1,0 +1,70 @@
+import {
+  ACCENT_COLORS,
+  resolvePlayerColor,
+  assignColorsToPlayers,
+} from "../scoring/colors";
+
+describe("ACCENT_COLORS", () => {
+  it("defines exactly 6 colors", () => {
+    expect(ACCENT_COLORS).toHaveLength(6);
+  });
+
+  it("each color has a value and label", () => {
+    for (const color of ACCENT_COLORS) {
+      expect(color.value).toMatch(/^#[0-9a-f]{6}$/);
+      expect(color.label).toBeTruthy();
+    }
+  });
+});
+
+describe("resolvePlayerColor", () => {
+  it("returns per-game override when present", () => {
+    const result = resolvePlayerColor({
+      gameColor: "#ef4444",
+      userDefault: "#3b82f6",
+    });
+    expect(result).toBe("#ef4444");
+  });
+
+  it("falls back to user default when no game override", () => {
+    const result = resolvePlayerColor({
+      gameColor: null,
+      userDefault: "#3b82f6",
+    });
+    expect(result).toBe("#3b82f6");
+  });
+
+  it("returns null when no color set anywhere", () => {
+    const result = resolvePlayerColor({
+      gameColor: null,
+      userDefault: null,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("assignColorsToPlayers", () => {
+  it("assigns first available color to players without one", () => {
+    const players = [
+      { id: "1", resolvedColor: "#3b82f6" },
+      { id: "2", resolvedColor: null },
+      { id: "3", resolvedColor: null },
+    ];
+    const result = assignColorsToPlayers(players);
+    expect(result["1"]).toBe("#3b82f6");
+    expect(result["2"]).toBeTruthy();
+    expect(result["3"]).toBeTruthy();
+    const values = Object.values(result);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("respects first-come priority for conflicts", () => {
+    const players = [
+      { id: "1", resolvedColor: "#3b82f6" },
+      { id: "2", resolvedColor: "#3b82f6" },
+    ];
+    const result = assignColorsToPlayers(players);
+    expect(result["1"]).toBe("#3b82f6");
+    expect(result["2"]).not.toBe("#3b82f6");
+  });
+});

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -8,6 +8,7 @@ export interface GameWithPlayersAndScores extends Game {
     gameId: string;
     userId?: string;
     guestId?: string;
+    accentColor?: string | null;
     user?: User;
     guestUser?: GuestUser;
   }[];
@@ -31,6 +32,7 @@ export interface DisplayScores {
   total: number;
   isInLead?: boolean;
   isWinner?: boolean;
+  accentColor?: string | null;
 }
 
 export interface ProcessedPlayerScore {
@@ -39,6 +41,7 @@ export interface ProcessedPlayerScore {
   isGuest: boolean;
   scoresByRound: number[];
   total: number;
+  accentColor?: string | null;
 }
 
 // Function to get player name - handles both regular users and guest users
@@ -77,6 +80,7 @@ function initializePlayerScoresMap(
       isGuest: isGuestPlayer(player),
       scoresByRound: [],
       total: 0,
+      accentColor: player.accentColor ?? null,
     };
   });
 
@@ -191,7 +195,7 @@ export default async function transformGameData(
 
   // Convert to final display scores
   return Object.entries(playerScoresMap).map(
-    ([id, { username, isGuest, scoresByRound, total }]) => ({
+    ([id, { username, isGuest, scoresByRound, total, accentColor }]) => ({
       id,
       userId: id, // Add userId for backward compatibility with tests
       username,
@@ -200,6 +204,7 @@ export default async function transformGameData(
       total,
       isInLead: leaders.includes(id),
       isWinner: id === winnerId,
+      accentColor,
     })
   );
 }

--- a/src/lib/scoring/colors.ts
+++ b/src/lib/scoring/colors.ts
@@ -37,12 +37,18 @@ export function assignColorsToPlayers(
   const availableColors = ACCENT_COLORS.map((c) => c.value).filter(
     (c) => !usedColors.has(c)
   );
+  const allColors = ACCENT_COLORS.map((c) => c.value);
   let colorIndex = 0;
 
   for (const player of players) {
     if (!assigned[player.id]) {
-      assigned[player.id] = availableColors[colorIndex];
-      usedColors.add(availableColors[colorIndex]);
+      if (colorIndex < availableColors.length) {
+        assigned[player.id] = availableColors[colorIndex];
+        usedColors.add(availableColors[colorIndex]);
+      } else {
+        // Palette exhausted (7+ players) — wrap around to reuse colors
+        assigned[player.id] = allColors[colorIndex % allColors.length];
+      }
       colorIndex++;
     }
   }

--- a/src/lib/scoring/colors.ts
+++ b/src/lib/scoring/colors.ts
@@ -1,0 +1,51 @@
+export const ACCENT_COLORS = [
+  { value: "#3b82f6", label: "Blue" },
+  { value: "#ef4444", label: "Red" },
+  { value: "#eab308", label: "Yellow" },
+  { value: "#22c55e", label: "Green" },
+  { value: "#8b5cf6", label: "Purple" },
+  { value: "#f97316", label: "Orange" },
+] as const;
+
+export type AccentColorValue = (typeof ACCENT_COLORS)[number]["value"];
+
+export function resolvePlayerColor({
+  gameColor,
+  userDefault,
+}: {
+  gameColor: string | null;
+  userDefault: string | null;
+}): string | null {
+  return gameColor ?? userDefault ?? null;
+}
+
+export function assignColorsToPlayers(
+  players: { id: string; resolvedColor: string | null }[]
+): Record<string, string> {
+  const assigned: Record<string, string> = {};
+  const usedColors = new Set<string>();
+
+  // First pass: assign players who already have a color (first-come priority)
+  for (const player of players) {
+    if (player.resolvedColor && !usedColors.has(player.resolvedColor)) {
+      assigned[player.id] = player.resolvedColor;
+      usedColors.add(player.resolvedColor);
+    }
+  }
+
+  // Second pass: assign remaining players the next available color
+  const availableColors = ACCENT_COLORS.map((c) => c.value).filter(
+    (c) => !usedColors.has(c)
+  );
+  let colorIndex = 0;
+
+  for (const player of players) {
+    if (!assigned[player.id]) {
+      assigned[player.id] = availableColors[colorIndex];
+      usedColors.add(availableColors[colorIndex]);
+      colorIndex++;
+    }
+  }
+
+  return assigned;
+}

--- a/src/lib/scoring/tokens.ts
+++ b/src/lib/scoring/tokens.ts
@@ -1,0 +1,21 @@
+// Reference for scoring design tokens — CSS custom properties are the source of truth.
+// Use these Tailwind classes in components:
+//
+// Backgrounds:   bg-[var(--scoring-bg)]  bg-[var(--scoring-bg-muted)]  bg-[var(--scoring-bg-subtle)]
+// Borders:       border-[var(--scoring-border)]  border-[var(--scoring-border-muted)]
+// Text:          text-[var(--scoring-text)]  text-[var(--scoring-text-muted)]  text-[var(--scoring-text-negative)]
+// Success:       bg-[var(--scoring-success)]
+//
+// Accent colors (player-specific) remain as inline styles since they're dynamic per-player.
+
+export const SCORING_TOKENS = {
+  bg: "var(--scoring-bg)",
+  bgMuted: "var(--scoring-bg-muted)",
+  bgSubtle: "var(--scoring-bg-subtle)",
+  border: "var(--scoring-border)",
+  borderMuted: "var(--scoring-border-muted)",
+  text: "var(--scoring-text)",
+  textMuted: "var(--scoring-text-muted)",
+  textNegative: "var(--scoring-text-negative)",
+  success: "var(--scoring-success)",
+} as const;

--- a/src/server/db/migrations/20260328155058_add_accent_colors/migration.sql
+++ b/src/server/db/migrations/20260328155058_add_accent_colors/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "GamePlayers" ADD COLUMN     "accent_color" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "accent_color" TEXT;

--- a/src/server/db/schema.prisma
+++ b/src/server/db/schema.prisma
@@ -15,6 +15,7 @@ model User {
   updatedAt              DateTime                 @default(now()) @map("updated_at")
   username               String                   @unique
   avatarUrl              String?
+  accentColor            String?                  @map("accent_color")
   games                  GamePlayers[]
   scores                 Score[]
   createdGuests          GuestUser[]              @relation("CreatedGuests")
@@ -85,10 +86,11 @@ model GamePlayers {
   id        String     @id @default(uuid())
   gameId    String
   userId    String?
-  guestId   String?
-  game      Game       @relation(fields: [gameId], references: [id])
-  user      User?      @relation(fields: [userId], references: [id])
-  guestUser GuestUser? @relation(fields: [guestId], references: [id])
+  guestId     String?
+  accentColor String?    @map("accent_color")
+  game        Game       @relation(fields: [gameId], references: [id])
+  user        User?      @relation(fields: [userId], references: [id])
+  guestUser   GuestUser? @relation(fields: [guestId], references: [id])
 
   @@unique([gameId, userId], name: "gamePlayer_userId", map: "game_players_game_id_user_id")
   @@unique([gameId, guestId], name: "gamePlayer_guestId", map: "game_players_game_id_guest_id")

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -346,9 +346,15 @@ export async function cloneGame(originalGameId: string) {
     // Create a new game with the same players
     const playerCreateInputs = originalGame.players.map((player) => {
       if (player.userId) {
-        return { userId: player.userId };
+        return {
+          userId: player.userId,
+          ...(player.accentColor ? { accentColor: player.accentColor } : {}),
+        };
       } else if (player.guestId) {
-        return { guestId: player.guestId };
+        return {
+          guestId: player.guestId,
+          ...(player.accentColor ? { accentColor: player.accentColor } : {}),
+        };
       }
       throw new Error("Player has neither userId nor guestId");
     });

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -4,6 +4,7 @@ import prisma from "@/server/db/db";
 import { clerkClient } from "@clerk/nextjs/server";
 import { getAuthenticatedUserWithOrg } from "./common";
 import { sendGameCompleteEmail, EMAIL_INTER_SEND_DELAY_MS } from "../email";
+import { resolvePlayerColor, assignColorsToPlayers } from "@/lib/scoring/colors";
 
 // Create a new game with support for guest players
 export async function createGame(
@@ -77,7 +78,27 @@ export async function createGame(
       }
     }
 
-    // Step 3: Add players to the game one by one
+    // Step 3: Resolve accent colors for all players
+    // Look up accent color defaults for regular players
+    const playerDefaults = await prisma.user.findMany({
+      where: { id: { in: regularPlayerIds } },
+      select: { id: true, accentColor: true },
+    });
+
+    // Resolve colors: game override (none at creation) > user default > auto-assign
+    const colorInputs = users.map((u) => {
+      const userDefault = playerDefaults.find((p) => p.id === u.id);
+      return {
+        id: u.id,
+        resolvedColor: resolvePlayerColor({
+          gameColor: null,
+          userDefault: userDefault?.accentColor ?? null,
+        }),
+      };
+    });
+    const playerColors = assignColorsToPlayers(colorInputs);
+
+    // Step 4: Add players to the game one by one
     for (const player of users) {
       if (player.isGuest) {
         const dbGuestId = guestUserIds.get(player.id);
@@ -87,6 +108,7 @@ export async function createGame(
             data: {
               gameId: newGame.id,
               guestId: dbGuestId,
+              accentColor: playerColors[player.id] ?? null,
             },
           });
         }
@@ -96,6 +118,7 @@ export async function createGame(
           data: {
             gameId: newGame.id,
             userId: player.id,
+            accentColor: playerColors[player.id] ?? null,
           },
         });
       }

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -298,6 +298,26 @@ export async function updateGameAsFinished(
   });
 }
 
+// Save user's default accent color preference
+export async function saveUserAccentColor(color: string) {
+  const { user, posthog } = await getAuthenticatedUserWithOrg();
+  const currentUser = await prisma.user.findUnique({
+    where: { clerk_user_id: user.userId },
+  });
+  if (!currentUser) throw new Error("User not found");
+
+  await prisma.user.update({
+    where: { id: currentUser.id },
+    data: { accentColor: color },
+  });
+
+  posthog.capture({
+    distinctId: user.userId,
+    event: "set_accent_color",
+    properties: { color },
+  });
+}
+
 // Clone an existing game
 export async function cloneGame(originalGameId: string) {
   const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();

--- a/src/server/mutations/index.ts
+++ b/src/server/mutations/index.ts
@@ -2,7 +2,7 @@
 // This maintains backward compatibility with existing imports
 
 // Import and re-export async functions directly
-import { createGame, updateGameAsFinished, cloneGame } from "./games";
+import { createGame, updateGameAsFinished, cloneGame, saveUserAccentColor } from "./games";
 import { createRoundForGame, updateRoundScores } from "./rounds";
 import { createGuestUser, getCircleGuestUsers, inviteGuestUser } from "./guests";
 import { inviteFriendToCircle } from "./circles";
@@ -12,6 +12,7 @@ export {
   createGame,
   updateGameAsFinished,
   cloneGame,
+  saveUserAccentColor,
   createRoundForGame,
   updateRoundScores,
   createGuestUser,


### PR DESCRIPTION
## Summary

- Add accent color system (constants, DB fields, assignment on game creation, color picker)
- New mobile-first score entry UI: vertical player cards with accent color borders, status indicators, floating CTA
- ScoringShell client wrapper for server/client boundary, behind `scoring-revamp` feature flag
- Design tokens extracted as CSS custom properties
- Sticky round header, first-game color prompt scaffolding
- Game over dialog works for flagged users, rematch preserves accent colors
- Desktop layout improvements (constrained input width, sticky CTA avoids footer overlap)

## Test plan

- [x] All 59 tests pass
- [x] Feature flag `scoring-revamp` shows new scoring UI on active games
- [x] Accent colors assigned on game creation, preserved on rematch
- [x] Game over dialog renders on finished games with flag enabled
- [x] Desktop: inputs constrained, CTA doesn't overlap footer
- [x] Mobile: layout remains compact and functional
- [ ] Verify on Vercel preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)