### PR TITLE
feat: graph carousel, round editing, and undo flow (Plan 3)

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -129,6 +129,7 @@ export default async function GameView(props: {
               winThreshold={game.winThreshold}
               isFinished={game.isFinished}
               rounds={game.rounds.map((r) => ({
+                id: r.id,
                 scores: r.scores.map((s) => ({
                   userId: s.userId,
                   guestId: s.guestId,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,3 +89,15 @@
     @apply bg-background text-foreground;
   }
 }
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
+@keyframes deltaFlash {
+  0% { opacity: 0; transform: scale(0.8); }
+  15% { opacity: 1; transform: scale(1.05); }
+  25% { transform: scale(1); }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/src/components/__tests__/scoring/ScoreEntryView.test.tsx
+++ b/src/components/__tests__/scoring/ScoreEntryView.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ScoreEntryView } from "../../scoring/ScoreEntryView";
+
+// Mock crypto.randomUUID for jsdom
+if (!globalThis.crypto?.randomUUID) {
+  Object.defineProperty(globalThis, "crypto", {
+    value: { randomUUID: () => "test-uuid-1234" },
+  });
+}
+
+// Mock server actions
+jest.mock("@/server/mutations", () => ({
+  createRoundForGame: jest.fn().mockResolvedValue({ id: "round-1" }),
+  deleteLatestRound: jest.fn().mockResolvedValue({ deletedRoundNumber: 1 }),
+}));
+
+// Mock posthog-js/react
+jest.mock("posthog-js/react", () => ({
+  usePostHog: () => ({
+    capture: jest.fn(),
+  }),
+}));
+
+// Mock game rules — keep real logic
+jest.mock("@/lib/validation/gameRules", () => ({
+  validateGameRules: jest.fn(),
+  calculateRoundScore: jest.fn(
+    (s: { blitzPileRemaining: number; totalCardsPlayed: number }) =>
+      s.totalCardsPlayed - 2 * s.blitzPileRemaining
+  ),
+}));
+
+const mockPlayers = [
+  {
+    id: "1",
+    name: "Mike",
+    color: "#3b82f6",
+    isGuest: false,
+    userId: "u1",
+    score: 0,
+  },
+  {
+    id: "2",
+    name: "Sarah",
+    color: "#ef4444",
+    isGuest: false,
+    userId: "u2",
+    score: 0,
+  },
+];
+
+describe("ScoreEntryView", () => {
+  it("renders player cards with names", () => {
+    render(
+      <ScoreEntryView
+        gameId="game-1"
+        currentRoundNumber={1}
+        players={mockPlayers}
+        winThreshold={75}
+      />
+    );
+    // Names appear in both RaceTrack pills and ScoreEntryCards, so use getAllByText
+    expect(screen.getAllByText("Mike").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Sarah").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows remaining count in submit button area", () => {
+    render(
+      <ScoreEntryView
+        gameId="game-1"
+        currentRoundNumber={1}
+        players={mockPlayers}
+        winThreshold={75}
+      />
+    );
+    expect(screen.getByText(/2 remaining/)).toBeInTheDocument();
+  });
+
+  it("updates remaining count when fields are filled", () => {
+    render(
+      <ScoreEntryView
+        gameId="game-1"
+        currentRoundNumber={1}
+        players={mockPlayers}
+        winThreshold={75}
+      />
+    );
+    const inputs = screen.getAllByPlaceholderText("—");
+    // Fill Mike's two fields
+    fireEvent.change(inputs[0], { target: { value: "3" } });
+    fireEvent.change(inputs[1], { target: { value: "18" } });
+    expect(screen.getByText(/1 remaining/)).toBeInTheDocument();
+  });
+
+  it("shows undo toast after submit", async () => {
+    render(
+      <ScoreEntryView
+        gameId="game-1"
+        currentRoundNumber={1}
+        players={mockPlayers}
+        winThreshold={75}
+      />
+    );
+
+    // Fill all inputs (2 per player = 4 total)
+    const inputs = screen.getAllByPlaceholderText("—");
+    fireEvent.change(inputs[0], { target: { value: "0" } });
+    fireEvent.change(inputs[1], { target: { value: "18" } });
+    fireEvent.change(inputs[2], { target: { value: "5" } });
+    fireEvent.change(inputs[3], { target: { value: "14" } });
+
+    // Submit
+    const submitBtn = screen.getByText("Submit Round");
+    fireEvent.click(submitBtn);
+
+    // Undo toast should appear
+    await waitFor(() => {
+      expect(screen.getByText("Round 1 submitted")).toBeInTheDocument();
+      expect(screen.getByText("Undo")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/scoring/BetweenRoundsView.tsx
+++ b/src/components/scoring/BetweenRoundsView.tsx
@@ -1,15 +1,26 @@
 "use client";
 
+import { useMemo, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { RaceTrack } from "./RaceTrack";
 import { Standings } from "./Standings";
 import { RoundHistoryTable } from "./RoundHistoryTable";
+import { RoundEditor } from "./RoundEditor";
 import { FloatingCTA } from "./FloatingCTA";
+import { GraphCarousel } from "./GraphCarousel";
+import { ScoreProgressionCard } from "./graphs/ScoreProgressionCard";
+import { HotColdCard } from "./graphs/HotColdCard";
+import { WinProbabilityCard } from "./graphs/WinProbabilityCard";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+import { updateRoundScores } from "@/server/mutations";
 import { type PlayerWithScore } from "./types";
 
 interface BetweenRoundsViewProps {
+  gameId: string;
   players: PlayerWithScore[];
   rounds: {
+    id: string;
     scores: {
       userId?: string | null;
       guestId?: string | null;
@@ -22,19 +33,93 @@ interface BetweenRoundsViewProps {
   onEnterScores: () => void;
 }
 
+function findPlayerScore(
+  player: PlayerWithScore,
+  roundScores: BetweenRoundsViewProps["rounds"][0]["scores"]
+) {
+  return roundScores.find(
+    (s) =>
+      (player.userId && s.userId === player.userId) ||
+      (player.guestId && s.guestId === player.guestId)
+  );
+}
+
 export function BetweenRoundsView({
+  gameId,
   players,
   rounds,
   winThreshold,
   nextRoundNumber,
   onEnterScores,
 }: BetweenRoundsViewProps) {
+  const router = useRouter();
   const posthog = usePostHog();
+  const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
 
   const handleEnterScores = () => {
     posthog.capture("scoring_enter_next_round", { round_number: nextRoundNumber });
     onEnterScores();
   };
+
+  const handleEditRound = useCallback((roundIndex: number) => {
+    posthog.capture("scoring_edit_round_tapped", { round_number: roundIndex + 1 });
+    setEditError(null);
+    setEditingRoundIndex(roundIndex);
+  }, [posthog]);
+
+  const handleSaveEdit = useCallback(async (
+    updated: Record<string, { blitzPileRemaining: number; totalCardsPlayed: number }>
+  ) => {
+    if (editingRoundIndex === null) return;
+    const round = rounds[editingRoundIndex];
+    setEditError(null);
+
+    const scores = players.map((player) => {
+      const data = updated[player.id];
+      return {
+        ...(player.isGuest
+          ? { guestId: player.guestId }
+          : { userId: player.userId }),
+        blitzPileRemaining: data.blitzPileRemaining,
+        totalCardsPlayed: data.totalCardsPlayed,
+      };
+    });
+
+    try {
+      await updateRoundScores(gameId, round.id, scores);
+      posthog.capture("scoring_round_edited", {
+        game_id: gameId,
+        round_number: editingRoundIndex + 1,
+      });
+      setEditingRoundIndex(null);
+      router.refresh();
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : "Failed to save changes");
+    }
+  }, [editingRoundIndex, rounds, players, gameId, posthog, router]);
+
+  // Compute derived graph data from rounds
+  const { scoresByRound, deltasByRound } = useMemo(() => {
+    const scores: Record<string, number[]> = {};
+    const deltas: Record<string, number[]> = {};
+
+    for (const player of players) {
+      scores[player.id] = [];
+      deltas[player.id] = [];
+      let cumulative = 0;
+
+      for (const round of rounds) {
+        const s = findPlayerScore(player, round.scores);
+        const delta = s ? calculateRoundScore(s) : 0;
+        cumulative += delta;
+        scores[player.id].push(cumulative);
+        deltas[player.id].push(delta);
+      }
+    }
+
+    return { scoresByRound: scores, deltasByRound: deltas };
+  }, [players, rounds]);
 
   return (
     <>
@@ -43,18 +128,61 @@ export function BetweenRoundsView({
         <RaceTrack players={players} winThreshold={winThreshold} />
       </div>
 
-      {/* Graph carousel placeholder — will be added in Plan 3 */}
+      {/* Graph carousel */}
+      <GraphCarousel>
+        <ScoreProgressionCard
+          players={players}
+          scoresByRound={scoresByRound}
+          winThreshold={winThreshold}
+        />
+        <HotColdCard players={players} deltasByRound={deltasByRound} />
+        <WinProbabilityCard
+          players={players}
+          roundsPlayed={rounds.length}
+          winThreshold={winThreshold}
+        />
+      </GraphCarousel>
 
       {/* Standings */}
       <div className="pt-2 pb-2">
         <Standings players={players} winThreshold={winThreshold} />
       </div>
 
+      {/* Edit error banner */}
+      {editError && (
+        <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg text-sm text-[#b91c1c]">
+          {editError}
+        </div>
+      )}
+
+      {/* Round editor (inline) */}
+      {editingRoundIndex !== null && (
+        <RoundEditor
+          roundIndex={editingRoundIndex}
+          players={players}
+          roundData={Object.fromEntries(
+            players.map((p) => {
+              const s = findPlayerScore(p, rounds[editingRoundIndex].scores);
+              return [
+                p.id,
+                {
+                  blitzPileRemaining: s?.blitzPileRemaining ?? 0,
+                  totalCardsPlayed: s?.totalCardsPlayed ?? 0,
+                },
+              ];
+            })
+          )}
+          onSave={handleSaveEdit}
+          onCancel={() => { setEditingRoundIndex(null); setEditError(null); }}
+        />
+      )}
+
       {/* Round history table */}
       <div className="pt-2 pb-2">
         <RoundHistoryTable
           players={players}
           rounds={rounds}
+          onEditRound={handleEditRound}
         />
       </div>
 

--- a/src/components/scoring/GraphCarousel.tsx
+++ b/src/components/scoring/GraphCarousel.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState, useEffect, type ReactNode } from "react";
+
+interface GraphCarouselProps {
+  children: ReactNode[];
+}
+
+export function GraphCarousel({ children }: GraphCarouselProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      const scrollLeft = el.scrollLeft;
+      const cardWidth = el.offsetWidth * 0.88; // ~88% card width + gap
+      const index = Math.round(scrollLeft / cardWidth);
+      setActiveIndex(Math.min(index, children.length - 1));
+    };
+
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [children.length]);
+
+  return (
+    <div className="px-4 py-2">
+      <div
+        ref={scrollRef}
+        className="flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+      >
+        {children.map((child, i) => (
+          <div
+            key={i}
+            className="min-w-[88%] snap-start"
+          >
+            {child}
+          </div>
+        ))}
+        {/* Peek spacer */}
+        <div className="min-w-[2%] flex-shrink-0" />
+      </div>
+
+      {/* Dot indicators */}
+      {children.length > 1 && (
+        <div className="flex justify-center gap-1.5 mt-2">
+          {children.map((_, i) => (
+            <div
+              key={i}
+              className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                i === activeIndex ? "bg-[#290806]" : "bg-[#d1bfa8]"
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scoring/RoundEditor.tsx
+++ b/src/components/scoring/RoundEditor.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+import { type ScoringPlayer } from "./types";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+
+interface RoundEditorProps {
+  roundIndex: number;
+  players: ScoringPlayer[];
+  roundData: Record<
+    string,
+    { blitzPileRemaining: number; totalCardsPlayed: number }
+  >;
+  onSave: (
+    updated: Record<
+      string,
+      { blitzPileRemaining: number; totalCardsPlayed: number }
+    >
+  ) => void;
+  onCancel: () => void;
+}
+
+export function RoundEditor({
+  roundIndex,
+  players,
+  roundData,
+  onSave,
+  onCancel,
+}: RoundEditorProps) {
+  const [editData, setEditData] = useState<
+    Record<string, { blitz: string; cards: string }>
+  >(() =>
+    Object.fromEntries(
+      players.map((p) => [
+        p.id,
+        {
+          blitz: String(roundData[p.id]?.blitzPileRemaining ?? 0),
+          cards: String(roundData[p.id]?.totalCardsPlayed ?? 0),
+        },
+      ])
+    )
+  );
+
+  const handleSave = () => {
+    const updated: Record<
+      string,
+      { blitzPileRemaining: number; totalCardsPlayed: number }
+    > = {};
+    for (const p of players) {
+      updated[p.id] = {
+        blitzPileRemaining: Math.max(
+          0,
+          Math.min(10, parseInt(editData[p.id].blitz) || 0)
+        ),
+        totalCardsPlayed: Math.max(
+          0,
+          Math.min(40, parseInt(editData[p.id].cards) || 0)
+        ),
+      };
+    }
+    onSave(updated);
+  };
+
+  return (
+    <div className="mx-4 my-3 bg-[#fffbeb] border-2 border-[#fbbf24] rounded-xl p-3">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[13px] font-bold text-[#290806]">
+          Edit Round {roundIndex + 1}
+        </div>
+        <div className="text-[9px] font-semibold bg-[#fbbf24] text-[#92400e] px-2 py-0.5 rounded-md">
+          Editing
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {players.map((p) => {
+          const orig = roundData[p.id];
+          const cur = editData[p.id];
+          const blitzChanged =
+            cur.blitz !== String(orig?.blitzPileRemaining ?? 0);
+          const cardsChanged =
+            cur.cards !== String(orig?.totalCardsPlayed ?? 0);
+          const blitz = parseInt(cur.blitz) || 0;
+          const cards = parseInt(cur.cards) || 0;
+          const delta = calculateRoundScore({
+            blitzPileRemaining: blitz,
+            totalCardsPlayed: cards,
+          });
+
+          return (
+            <div
+              key={p.id}
+              className="flex items-center gap-2 bg-white border-[1.5px] border-[#e6d7c3] rounded-lg p-2"
+              style={{ borderLeftWidth: "4px", borderLeftColor: p.color }}
+            >
+              <div className="w-12 text-[12px] font-semibold text-[#290806] flex-shrink-0">
+                {p.name}
+              </div>
+              <div className="flex gap-1.5 flex-1">
+                <div className="flex-1">
+                  <label className="block text-[8px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-0.5">
+                    Blitz left
+                  </label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    value={cur.blitz}
+                    onChange={(e) =>
+                      setEditData((prev) => ({
+                        ...prev,
+                        [p.id]: { ...prev[p.id], blitz: e.target.value },
+                      }))
+                    }
+                    className={`w-full h-9 border-[1.5px] rounded-md text-[16px] font-semibold text-center text-[#290806] focus:outline-none transition-colors ${
+                      blitzChanged
+                        ? "bg-[#fffbeb] border-[#fbbf24]"
+                        : "bg-[#fff7ea] border-[#e6d7c3]"
+                    }`}
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-[8px] text-[#8b5e3c] uppercase tracking-wider font-medium mb-0.5">
+                    Cards played
+                  </label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    value={cur.cards}
+                    onChange={(e) =>
+                      setEditData((prev) => ({
+                        ...prev,
+                        [p.id]: { ...prev[p.id], cards: e.target.value },
+                      }))
+                    }
+                    className={`w-full h-9 border-[1.5px] rounded-md text-[16px] font-semibold text-center text-[#290806] focus:outline-none transition-colors ${
+                      cardsChanged
+                        ? "bg-[#fffbeb] border-[#fbbf24]"
+                        : "bg-[#fff7ea] border-[#e6d7c3]"
+                    }`}
+                  />
+                </div>
+              </div>
+              <div
+                className={`w-9 text-right text-[11px] font-bold flex-shrink-0 ${
+                  delta < 0 ? "text-[#b91c1c]" : "text-[#2a6517]"
+                }`}
+              >
+                {delta > 0 ? `+${delta}` : delta}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex gap-2 mt-3">
+        <button
+          onClick={onCancel}
+          className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-[#f0e6d2] text-[#8b5e3c] cursor-pointer hover:bg-[#e6d7c3] transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSave}
+          className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-[#2a6517] text-white cursor-pointer hover:bg-[#1d4a10] transition-colors"
+        >
+          Save Changes
+        </button>
+      </div>
+      <div className="text-[9px] text-[#8b5e3c] text-center mt-2 italic">
+        Saving will recalculate all scores from round {roundIndex + 1} onward
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/RoundHistoryTable.tsx
+++ b/src/components/scoring/RoundHistoryTable.tsx
@@ -11,11 +11,13 @@ interface RoundHistoryTableProps {
       totalCardsPlayed: number;
     }[];
   }[];
+  onEditRound?: (roundIndex: number) => void;
 }
 
 export function RoundHistoryTable({
   players,
   rounds,
+  onEditRound,
 }: RoundHistoryTableProps) {
   if (rounds.length === 0) return null;
 
@@ -60,7 +62,8 @@ export function RoundHistoryTable({
       {rounds.map((round, ri) => (
         <div
           key={ri}
-          className="flex px-3 py-1.5 border-b border-[#f0e6d2] last:border-b-0"
+          className={`flex px-3 py-1.5 border-b border-[#f0e6d2] last:border-b-0${onEditRound ? " cursor-pointer hover:bg-[#faf5ed] active:bg-[#f0e6d2] transition-colors" : ""}`}
+          onClick={onEditRound ? () => onEditRound(ri) : undefined}
         >
           <div className="w-10 text-[11px] text-[#8b5e3c]">
             {ri + 1}

--- a/src/components/scoring/ScoreEntryCard.tsx
+++ b/src/components/scoring/ScoreEntryCard.tsx
@@ -10,6 +10,7 @@ interface ScoreEntryCardProps {
   entry: PlayerEntry;
   status: EntryStatus;
   onUpdate: (field: "blitzRemaining" | "cardsPlayed", value: number | null) => void;
+  deltaFlash?: number | null;
 }
 
 function handleNumericInput(
@@ -33,10 +34,11 @@ export function ScoreEntryCard({
   entry,
   status,
   onUpdate,
+  deltaFlash,
 }: ScoreEntryCardProps) {
   return (
     <div
-      className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3 flex items-center gap-2.5"
+      className="relative bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3 flex items-center gap-2.5"
       style={{ borderLeftWidth: "5px", borderLeftColor: color }}
     >
       <div className="w-16 flex-shrink-0">
@@ -88,6 +90,18 @@ export function ScoreEntryCard({
       </div>
 
       <StatusIndicator status={status} />
+
+      {/* Delta flash overlay */}
+      {deltaFlash !== null && deltaFlash !== undefined && (
+        <div
+          className="absolute inset-0 flex items-center justify-center rounded-xl animate-[deltaFlash_1.2s_ease-out_forwards] pointer-events-none"
+          style={{ backgroundColor: deltaFlash >= 0 ? "#dcfce7" : "#fef2f2" }}
+        >
+          <span className={`text-2xl font-black ${deltaFlash >= 0 ? "text-[#2a6517]" : "text-[#b91c1c]"}`}>
+            {deltaFlash > 0 ? `+${deltaFlash}` : deltaFlash}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/scoring/ScoreEntryView.tsx
+++ b/src/components/scoring/ScoreEntryView.tsx
@@ -1,15 +1,17 @@
 // src/components/scoring/ScoreEntryView.tsx
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { ScoreEntryCard } from "./ScoreEntryCard";
 import { FloatingCTA } from "./FloatingCTA";
 import { RoundHeader } from "./RoundHeader";
 import { RaceTrack } from "./RaceTrack";
+import { UndoToast } from "./UndoToast";
 import { type PlayerEntry, type PlayerWithScore, getEntryStatus } from "./types";
-import { validateGameRules } from "@/lib/validation/gameRules";
-import { createRoundForGame } from "@/server/mutations";
+import { usePostHog } from "posthog-js/react";
+import { validateGameRules, calculateRoundScore } from "@/lib/validation/gameRules";
+import { createRoundForGame, deleteLatestRound } from "@/server/mutations";
 
 interface ScoreEntryViewProps {
   gameId: string;
@@ -25,6 +27,7 @@ export function ScoreEntryView({
   winThreshold,
 }: ScoreEntryViewProps) {
   const router = useRouter();
+  const posthog = usePostHog();
   const [entries, setEntries] = useState<Record<string, PlayerEntry>>(() =>
     Object.fromEntries(
       players.map((p) => [p.id, { blitzRemaining: null, cardsPlayed: null }])
@@ -32,6 +35,13 @@ export function ScoreEntryView({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [undoData, setUndoData] = useState<{
+    roundNumber: number;
+    preSubmitEntries: Record<string, PlayerEntry>;
+    serverConfirmed: boolean;
+  } | null>(null);
+  const [optimisticDeltas, setOptimisticDeltas] = useState<Record<string, number> | null>(null);
+  const deltaTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const allComplete = useMemo(
     () => Object.values(entries).every((e) => getEntryStatus(e) === "complete"),
@@ -72,22 +82,78 @@ export function ScoreEntryView({
       };
     });
 
+    // Save pre-submit state for undo
+    const preSubmitEntries = { ...entries };
+
     try {
       validateGameRules(scores);
-      await createRoundForGame(gameId, currentRoundNumber, scores);
-      // Clear local state before refresh — App Router preserves client state across refresh
+      // Calculate deltas for flash animation
+      const deltas: Record<string, number> = {};
+      for (const player of players) {
+        const entry = entries[player.id];
+        deltas[player.id] = calculateRoundScore({
+          blitzPileRemaining: entry.blitzRemaining ?? 0,
+          totalCardsPlayed: entry.cardsPlayed ?? 0,
+        });
+      }
+      setOptimisticDeltas(deltas);
+      if (deltaTimerRef.current) clearTimeout(deltaTimerRef.current);
+      deltaTimerRef.current = setTimeout(() => setOptimisticDeltas(null), 1200);
+
+      // Show undo toast optimistically
+      setUndoData({ roundNumber: currentRoundNumber, preSubmitEntries, serverConfirmed: false });
       setEntries(
         Object.fromEntries(
           players.map((p) => [p.id, { blitzRemaining: null, cardsPlayed: null }])
         )
       );
+
+      await createRoundForGame(gameId, currentRoundNumber, scores);
+      // Mark server-confirmed so undo knows to call deleteLatestRound
+      // Don't router.refresh() here — that would unmount this component (ScoringShell
+      // flips to betweenRounds mode when round number changes), killing the undo toast.
+      // Refresh is deferred to onDismiss/onUndo.
+      setUndoData((prev) => prev ? { ...prev, serverConfirmed: true } : null);
+      posthog.capture("scoring_round_submitted", {
+        game_id: gameId,
+        round_number: currentRoundNumber,
+        player_count: players.length,
+      });
       setIsSubmitting(false);
-      router.refresh();
     } catch (e) {
+      // Revert optimistic update
+      setEntries(preSubmitEntries);
+      setUndoData(null);
+      setOptimisticDeltas(null);
       setError(e instanceof Error ? e.message : "Failed to submit round");
       setIsSubmitting(false);
     }
-  }, [allComplete, isSubmitting, players, entries, gameId, currentRoundNumber, router]);
+  }, [allComplete, isSubmitting, players, entries, gameId, currentRoundNumber, router, posthog]);
+
+  const handleUndo = useCallback(async () => {
+    if (!undoData) return;
+    const wasConfirmed = undoData.serverConfirmed;
+    const savedEntries = undoData.preSubmitEntries;
+
+    // Immediately revert local state
+    posthog.capture("scoring_round_undone", {
+      game_id: gameId,
+      round_number: undoData.roundNumber,
+    });
+    setUndoData(null);
+    setOptimisticDeltas(null);
+    setEntries(savedEntries);
+
+    if (wasConfirmed) {
+      try {
+        await deleteLatestRound(gameId);
+      } catch {
+        setError("Failed to undo. Please refresh the page.");
+      }
+    }
+
+    router.refresh();
+  }, [undoData, gameId, router, posthog]);
 
   return (
     <div className="pb-4">
@@ -103,8 +169,14 @@ export function ScoreEntryView({
 
       {/* Error banner */}
       {error && (
-        <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg text-sm text-[#b91c1c]">
-          {error}
+        <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg flex items-center justify-between">
+          <span className="text-sm text-[#b91c1c]">{error}</span>
+          <button
+            onClick={handleSubmit}
+            className="text-sm font-bold text-[#b91c1c] ml-2 underline cursor-pointer"
+          >
+            Retry
+          </button>
         </div>
       )}
 
@@ -119,6 +191,7 @@ export function ScoreEntryView({
             entry={entries[player.id]}
             status={getEntryStatus(entries[player.id])}
             onUpdate={(field, value) => handleUpdate(player.id, field, value)}
+            deltaFlash={optimisticDeltas?.[player.id] ?? null}
           />
         ))}
       </div>
@@ -132,6 +205,18 @@ export function ScoreEntryView({
         }}
         onAction={handleSubmit}
       />
+
+      {/* Undo toast */}
+      {undoData && (
+        <UndoToast
+          roundNumber={undoData.roundNumber}
+          onUndo={handleUndo}
+          onDismiss={() => {
+            setUndoData(null);
+            router.refresh();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -15,6 +15,7 @@ interface ScoringShellProps {
   isFinished: boolean;
   winnerName?: string;
   rounds: {
+    id: string;
     scores: {
       userId?: string | null;
       guestId?: string | null;
@@ -57,6 +58,7 @@ export function ScoringShell({
   if (mode === "betweenRounds") {
     return (
       <BetweenRoundsView
+        gameId={gameId}
         players={players}
         rounds={rounds}
         winThreshold={winThreshold}

--- a/src/components/scoring/UndoToast.tsx
+++ b/src/components/scoring/UndoToast.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+interface UndoToastProps {
+  roundNumber: number;
+  onUndo: () => void;
+  onDismiss: () => void;
+  durationMs?: number;
+}
+
+export function UndoToast({
+  roundNumber,
+  onUndo,
+  onDismiss,
+  durationMs = 5000,
+}: UndoToastProps) {
+  const [progress, setProgress] = useState(100);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalMs = 100;
+
+  useEffect(() => {
+    timerRef.current = setInterval(() => {
+      setProgress((prev) => {
+        const next = prev - (intervalMs / durationMs) * 100;
+        if (next <= 0) {
+          if (timerRef.current) clearInterval(timerRef.current);
+          onDismiss();
+          return 0;
+        }
+        return next;
+      });
+    }, intervalMs);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [durationMs, onDismiss]);
+
+  const handleUndo = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    onUndo();
+  };
+
+  return (
+    <div className="fixed bottom-20 left-1/2 -translate-x-1/2 w-[calc(100%-32px)] max-w-[408px] z-50">
+      <div className="bg-[#290806] text-white rounded-xl px-4 pt-3 pb-4 shadow-xl">
+        <div className="flex items-center justify-between">
+          <span className="text-[13px] font-medium">
+            Round {roundNumber} submitted
+          </span>
+          <button
+            onClick={handleUndo}
+            className="text-[13px] font-bold text-[#fbbf24] px-3 py-1 rounded-lg bg-[rgba(251,191,36,0.15)] hover:bg-[rgba(251,191,36,0.25)] transition-colors cursor-pointer"
+          >
+            Undo
+          </button>
+        </div>
+        <div className="mt-2 h-[3px] bg-[rgba(255,255,255,0.15)] rounded-full overflow-hidden">
+          <div
+            className="h-full bg-[#fbbf24] rounded-full transition-all"
+            style={{
+              width: `${progress}%`,
+              transitionDuration: `${intervalMs}ms`,
+              transitionTimingFunction: "linear",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/graphs/HotColdCard.tsx
+++ b/src/components/scoring/graphs/HotColdCard.tsx
@@ -1,0 +1,92 @@
+import { type PlayerWithScore } from "../types";
+
+interface HotColdCardProps {
+  players: PlayerWithScore[];
+  deltasByRound: Record<string, number[]>; // playerId -> delta per round
+}
+
+export function HotColdCard({ players, deltasByRound }: HotColdCardProps) {
+  const roundCount = Object.values(deltasByRound)[0]?.length ?? 0;
+
+  // Find the best round per player for fire emoji
+  const bestRoundByPlayer: Record<string, number> = {};
+  for (const player of players) {
+    const deltas = deltasByRound[player.id] ?? [];
+    let bestIdx = 0;
+    for (let i = 1; i < deltas.length; i++) {
+      if (deltas[i] > deltas[bestIdx]) bestIdx = i;
+    }
+    if (deltas[bestIdx] > 0) bestRoundByPlayer[player.id] = bestIdx;
+  }
+
+  return (
+    <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
+      <div className="text-[11px] font-bold text-[#290806] mb-0.5">
+        Hot & Cold
+      </div>
+      <div className="text-[9px] text-[#8b5e3c] mb-3">
+        Performance intensity per round
+      </div>
+
+      {/* Round headers */}
+      <div className="flex gap-1 mb-1.5" style={{ marginLeft: 44 }}>
+        {Array.from({ length: roundCount }, (_, i) => (
+          <div
+            key={i}
+            className="flex-1 text-center text-[8px] text-[#8b5e3c] font-medium"
+          >
+            R{i + 1}
+          </div>
+        ))}
+      </div>
+
+      {/* Player rows */}
+      <div className="space-y-1.5">
+        {players.map((player) => {
+          const deltas = deltasByRound[player.id] ?? [];
+          return (
+            <div key={player.id} className="flex items-center gap-1.5">
+              <div
+                className="w-10 text-[10px] font-semibold text-right flex-shrink-0 truncate"
+                style={{ color: player.color }}
+              >
+                {player.name}
+              </div>
+              <div className="flex gap-1 flex-1">
+                {deltas.map((d, ri) => {
+                  const isBest = bestRoundByPlayer[player.id] === ri;
+                  const isNeg = d < 0;
+                  const isHot = d >= 10;
+
+                  return (
+                    <div
+                      key={ri}
+                      className="flex-1 h-9 rounded-md flex items-center justify-center text-[10px] font-bold relative"
+                      style={{
+                        backgroundColor: isNeg
+                          ? "#b91c1c"
+                          : isHot
+                            ? player.color
+                            : "#f0e6d2",
+                        color:
+                          isNeg || isHot ? "#fff" : "#8b5e3c",
+                        opacity: isNeg ? 0.7 : isHot ? 1 : 0.8,
+                      }}
+                    >
+                      {d > 0 ? `+${d}` : d}
+                      {isBest && (
+                        <span className="absolute -top-1 -right-0.5 text-[7px]">
+                          🔥
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/graphs/ScoreProgressionCard.tsx
+++ b/src/components/scoring/graphs/ScoreProgressionCard.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { type PlayerWithScore } from "../types";
+
+interface ScoreProgressionCardProps {
+  players: PlayerWithScore[];
+  scoresByRound: Record<string, number[]>; // playerId -> cumulative scores per round
+  winThreshold: number;
+}
+
+export function ScoreProgressionCard({
+  players,
+  scoresByRound,
+  winThreshold,
+}: ScoreProgressionCardProps) {
+  const roundCount =
+    Object.values(scoresByRound)[0]?.length ?? 0;
+
+  const data = Array.from({ length: roundCount }, (_, i) => {
+    const point: Record<string, number | string> = { round: i + 1 };
+    for (const player of players) {
+      point[player.id] = scoresByRound[player.id]?.[i] ?? 0;
+    }
+    return point;
+  });
+
+  return (
+    <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
+      <div className="text-[11px] font-bold text-[#290806] mb-0.5">
+        Score Progression
+      </div>
+      <div className="text-[9px] text-[#8b5e3c] mb-3">
+        Cumulative scores across all rounds
+      </div>
+      <div className="h-[160px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0e6d2" />
+            <XAxis
+              dataKey="round"
+              tick={{ fontSize: 9, fill: "#8b5e3c" }}
+              tickLine={false}
+              axisLine={{ stroke: "#e6d7c3" }}
+            />
+            <YAxis
+              tick={{ fontSize: 9, fill: "#8b5e3c" }}
+              tickLine={false}
+              axisLine={{ stroke: "#e6d7c3" }}
+            />
+            <Tooltip
+              contentStyle={{
+                fontSize: 11,
+                borderRadius: 8,
+                border: "1px solid #e6d7c3",
+              }}
+            />
+            <ReferenceLine
+              y={winThreshold}
+              stroke="#290806"
+              strokeDasharray="4 3"
+              strokeWidth={1}
+              opacity={0.3}
+            />
+            <ReferenceLine y={0} stroke="#d1bfa8" strokeWidth={0.5} />
+            {players.map((player) => (
+              <Line
+                key={player.id}
+                dataKey={player.id}
+                name={player.name}
+                stroke={player.color}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -1,0 +1,112 @@
+import { type PlayerWithScore } from "../types";
+import {
+  calcWinProbabilities,
+  calcProjectedFinishRound,
+} from "@/lib/scoring/probability";
+
+interface WinProbabilityCardProps {
+  players: PlayerWithScore[];
+  roundsPlayed: number;
+  winThreshold: number;
+}
+
+export function WinProbabilityCard({
+  players,
+  roundsPlayed,
+  winThreshold,
+}: WinProbabilityCardProps) {
+  const probabilities = calcWinProbabilities(
+    players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
+    winThreshold
+  );
+
+  if (!probabilities) {
+    return (
+      <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
+        <div className="text-[11px] font-bold text-[#290806] mb-0.5">
+          Win Probability
+        </div>
+        <div className="text-[9px] text-[#8b5e3c]">
+          Available after 3 rounds
+        </div>
+      </div>
+    );
+  }
+
+  const sorted = [...players].sort(
+    (a, b) => (probabilities[b.id] ?? 0) - (probabilities[a.id] ?? 0)
+  );
+
+  return (
+    <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
+      <div className="text-[11px] font-bold text-[#290806] mb-0.5">
+        Win Probability
+      </div>
+      <div className="text-[9px] text-[#8b5e3c] mb-3">
+        Based on scoring pace through {roundsPlayed} rounds
+      </div>
+
+      <div className="space-y-2">
+        {sorted.map((player) => {
+          const pct = probabilities[player.id] ?? 0;
+          return (
+            <div key={player.id} className="flex items-center gap-2">
+              <div
+                className="w-10 text-[10px] font-semibold text-right flex-shrink-0"
+                style={{ color: player.color }}
+              >
+                {player.name}
+              </div>
+              <div className="flex-1 h-6 bg-[#f0e6d2] rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full flex items-center justify-end pr-2 text-[10px] font-bold text-white min-w-[28px]"
+                  style={{
+                    width: `${Math.max(pct, 8)}%`,
+                    backgroundColor: player.color,
+                  }}
+                >
+                  {pct}%
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Projected finish */}
+      <div className="mt-3 pt-3 border-t border-[#f0e6d2]">
+        <div className="text-[9px] font-semibold text-[#8b5e3c] mb-2">
+          Projected finish
+        </div>
+        <div className="flex gap-3">
+          {sorted
+            .filter((p) => (probabilities[p.id] ?? 0) > 0)
+            .map((player) => {
+              const round = calcProjectedFinishRound(
+                player.score,
+                roundsPlayed,
+                winThreshold
+              );
+              return (
+                <div key={player.id} className="text-center">
+                  <div
+                    className="text-lg font-extrabold"
+                    style={{ color: player.color }}
+                  >
+                    ~R{round === Infinity ? "∞" : round}
+                  </div>
+                  <div className="text-[8px] text-[#8b5e3c]">
+                    {player.name}
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      </div>
+
+      <div className="text-[8px] text-[#8b5e3c] text-center mt-2 italic">
+        Based on average scoring pace · updates each round
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -1,0 +1,57 @@
+import {
+  calcWinProbabilities,
+  calcProjectedFinishRound,
+} from "../scoring/probability";
+
+describe("calcProjectedFinishRound", () => {
+  it("projects finish round based on average pace", () => {
+    // 50 points in 5 rounds = 10/round, need 75, so ~7.5 → round 8
+    expect(calcProjectedFinishRound(50, 5, 75)).toBe(8);
+  });
+
+  it("returns Infinity for zero or negative pace", () => {
+    expect(calcProjectedFinishRound(-10, 5, 75)).toBe(Infinity);
+    expect(calcProjectedFinishRound(0, 5, 75)).toBe(Infinity);
+  });
+
+  it("returns current round if already past threshold", () => {
+    expect(calcProjectedFinishRound(80, 5, 75)).toBe(5);
+  });
+});
+
+describe("calcWinProbabilities", () => {
+  it("returns null when fewer than 3 rounds played", () => {
+    const result = calcWinProbabilities(
+      [{ id: "1", score: 10, roundsPlayed: 2 }],
+      75
+    );
+    expect(result).toBeNull();
+  });
+
+  it("distributes probability based on scoring pace", () => {
+    const result = calcWinProbabilities(
+      [
+        { id: "1", score: 50, roundsPlayed: 5 },
+        { id: "2", score: 20, roundsPlayed: 5 },
+      ],
+      75
+    );
+    expect(result).not.toBeNull();
+    expect(result!["1"]).toBeGreaterThan(result!["2"]);
+    // Probabilities should roughly sum to 100
+    const sum = Object.values(result!).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(100, 0);
+  });
+
+  it("gives 0% to players with negative pace", () => {
+    const result = calcWinProbabilities(
+      [
+        { id: "1", score: 50, roundsPlayed: 5 },
+        { id: "2", score: -10, roundsPlayed: 5 },
+      ],
+      75
+    );
+    expect(result).not.toBeNull();
+    expect(result!["2"]).toBe(0);
+  });
+});

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,0 +1,44 @@
+export function calcProjectedFinishRound(
+  currentScore: number,
+  roundsPlayed: number,
+  winThreshold: number
+): number {
+  if (currentScore >= winThreshold) return roundsPlayed;
+  const pace = roundsPlayed > 0 ? currentScore / roundsPlayed : 0;
+  if (pace <= 0) return Infinity;
+  return Math.ceil(winThreshold / pace);
+}
+
+export function calcWinProbabilities(
+  players: { id: string; score: number; roundsPlayed: number }[],
+  winThreshold: number
+): Record<string, number> | null {
+  if (players.length === 0) return null;
+  if (players[0].roundsPlayed < 3) return null;
+
+  const paces = players.map((p) => ({
+    id: p.id,
+    pace: p.roundsPlayed > 0 ? p.score / p.roundsPlayed : 0,
+  }));
+
+  // Only players with positive pace can win
+  const positivePaces = paces.filter((p) => p.pace > 0);
+  const totalPace = positivePaces.reduce((sum, p) => sum + p.pace, 0);
+
+  if (totalPace === 0) {
+    return Object.fromEntries(players.map((p) => [p.id, 0]));
+  }
+
+  const result: Record<string, number> = {};
+  for (const p of paces) {
+    result[p.id] = p.pace > 0 ? Math.round((p.pace / totalPace) * 100) : 0;
+  }
+
+  // Adjust rounding to sum to exactly 100
+  const sum = Object.values(result).reduce((a, b) => a + b, 0);
+  if (sum !== 100 && positivePaces.length > 0) {
+    result[positivePaces[0].id] += 100 - sum;
+  }
+
+  return result;
+}

--- a/src/server/mutations.ts
+++ b/src/server/mutations.ts
@@ -17,8 +17,8 @@ import { createGame, updateGameAsFinished, cloneGame } from "./mutations/games";
 export { createGame, updateGameAsFinished, cloneGame };
 
 // Re-export round-related mutations
-import { createRoundForGame, updateRoundScores } from "./mutations/rounds";
-export { createRoundForGame, updateRoundScores };
+import { createRoundForGame, updateRoundScores, deleteLatestRound } from "./mutations/rounds";
+export { createRoundForGame, updateRoundScores, deleteLatestRound };
 
 // Re-export guest-related mutations
 import {

--- a/src/server/mutations/index.ts
+++ b/src/server/mutations/index.ts
@@ -3,7 +3,7 @@
 
 // Import and re-export async functions directly
 import { createGame, updateGameAsFinished, cloneGame, saveUserAccentColor } from "./games";
-import { createRoundForGame, updateRoundScores } from "./rounds";
+import { createRoundForGame, updateRoundScores, deleteLatestRound } from "./rounds";
 import { createGuestUser, getCircleGuestUsers, inviteGuestUser } from "./guests";
 import { inviteFriendToCircle } from "./circles";
 
@@ -15,6 +15,7 @@ export {
   saveUserAccentColor,
   createRoundForGame,
   updateRoundScores,
+  deleteLatestRound,
   createGuestUser,
   getCircleGuestUsers,
   inviteGuestUser,

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -51,13 +51,26 @@ export async function createRoundForGame(
     throw new Error("Invalid score submission");
   }
 
-  // Modified to match test expectations - create round with scores in one operation
-  const round = await prisma.round.create({
-    data: {
-      gameId: game.id,
-      round: roundNumber,
-    },
-  });
+  // Create round — the @@unique([gameId, round]) constraint prevents duplicates.
+  // If a duplicate is attempted (e.g. double-tap), return the existing round.
+  let round;
+  try {
+    round = await prisma.round.create({
+      data: {
+        gameId: game.id,
+        round: roundNumber,
+      },
+    });
+  } catch (error) {
+    // Unique constraint violation — round already exists (double submit)
+    if (error && typeof error === "object" && "code" in error && error.code === "P2002") {
+      const existing = await prisma.round.findFirst({
+        where: { gameId: game.id, round: roundNumber },
+      });
+      if (existing) return existing;
+    }
+    throw error;
+  }
 
   // Add scores one by one after round is created
   for (const score of scores) {
@@ -99,6 +112,50 @@ export async function createRoundForGame(
   posthog.capture({ distinctId: user.userId, event: "create_scores" });
 
   return round;
+}
+
+// Delete the latest round (for undo support)
+export async function deleteLatestRound(gameId: string) {
+  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
+
+  const game = await prisma.game.findUnique({
+    where: { id: gameId },
+    include: {
+      rounds: {
+        orderBy: { round: "desc" },
+        take: 1,
+        include: { scores: true },
+      },
+    },
+  });
+
+  if (!game) throw new Error("Game not found");
+  if (game.organizationId !== orgId) {
+    throw new Error("Game does not belong to your active circle");
+  }
+
+  const latestRound = game.rounds[0];
+  if (!latestRound) throw new Error("No rounds to undo");
+
+  await prisma.$transaction(async (tx) => {
+    await tx.score.deleteMany({ where: { roundId: latestRound.id } });
+    await tx.round.delete({ where: { id: latestRound.id } });
+
+    if (game.isFinished) {
+      await tx.game.update({
+        where: { id: gameId },
+        data: { isFinished: false, winnerId: null, endedAt: null },
+      });
+    }
+  });
+
+  posthog.capture({
+    distinctId: user.userId,
+    event: "undo_round",
+    properties: { game_id: gameId, round_number: latestRound.round },
+  });
+
+  return { deletedRoundNumber: latestRound.round };
 }
 
 // Update scores for a round


### PR DESCRIPTION
## Summary

- **Graph carousel** with CSS scroll-snap: Score Progression (Recharts line chart), Hot & Cold (heatmap with fire emoji), Win Probability (pace-based bars + projected finish round)
- **Round editing**: tap any history row → inline editor with yellow change highlighting and live delta preview
- **Undo flow**: 5-second countdown toast after submit, deferred refresh so toast actually shows, deleteLatestRound server action
- **Optimistic submit**: delta flash animation on player cards, double-submit protection via DB unique constraint (P2002 catch)
- **PostHog tracking**: `scoring_round_submitted`, `scoring_round_undone`, `scoring_round_edited`, `scoring_edit_round_tapped`
- **Win probability logic**: linear extrapolation with 3-round minimum, 6 unit tests
- **Integration tests**: 4 tests for ScoreEntryView (render, remaining count, field updates, undo toast)

## New files

| File | Purpose |
|------|---------|
| `src/lib/scoring/probability.ts` | Win probability + projected finish calculations |
| `src/components/scoring/GraphCarousel.tsx` | Swipeable container with dot indicators |
| `src/components/scoring/graphs/ScoreProgressionCard.tsx` | Cumulative line chart |
| `src/components/scoring/graphs/HotColdCard.tsx` | Per-round delta heatmap |
| `src/components/scoring/graphs/WinProbabilityCard.tsx` | Probability bars + projected finish |
| `src/components/scoring/UndoToast.tsx` | Countdown toast with undo button |
| `src/components/scoring/RoundEditor.tsx` | Inline editor with change highlighting |

## Test plan

- [ ] Enter scores for all players → Submit → delta flash appears on cards → undo toast shows with countdown
- [ ] Tap Undo before countdown → scores revert, back to entry mode
- [ ] Let toast expire → between-rounds view appears with graph carousel
- [ ] Swipe through 3 graph cards → dots update, snap works
- [ ] Win Probability shows "Available after 3 rounds" for <3 rounds
- [ ] Tap a history row → inline editor opens with current values
- [ ] Change a value (yellow highlight) → Save → scores recalculate, editor closes
- [ ] Double-tap submit → only one round created (DB constraint)
- [ ] `npm test` passes (83/83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)