### PR TITLE
feat: game over experience (Plan 4)

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -126,7 +126,7 @@ export default async function GameView(props: {
       />
       {useScoringRevamp ? (
         <>
-          {(canEnterScores || (canViewScoringShell && game.isFinished)) && (
+          {canViewScoringShell && (
             <ScoringShell
               gameId={game.id}
               currentRoundNumber={currentRoundNumber}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,6 +1,5 @@
 import ScoreEntry from "./scoreEntry";
 import ScoreDisplay from "./scoreDisplay";
-import GameOver from "./GameOver";
 import { ScoringShell } from "@/components/scoring/ScoringShell";
 import { getGameById } from "@/server/queries";
 import { notFound } from "next/navigation";
@@ -106,6 +105,12 @@ export default async function GameView(props: {
     !!game.organizationId &&
     game.organizationId === orgId;
 
+  // Circle members can view the scoring shell (including game over state)
+  const canViewScoringShell =
+    isAuthenticated &&
+    !!game.organizationId &&
+    game.organizationId === orgId;
+
   return (
     <section className="py-6">
       {game.winThreshold !== 75 && (
@@ -121,7 +126,7 @@ export default async function GameView(props: {
       />
       {useScoringRevamp ? (
         <>
-          {canEnterScores && (
+          {(canEnterScores || (canViewScoringShell && game.isFinished)) && (
             <ScoringShell
               gameId={game.id}
               currentRoundNumber={currentRoundNumber}
@@ -137,12 +142,6 @@ export default async function GameView(props: {
                   totalCardsPlayed: s.totalCardsPlayed,
                 })),
               }))}
-            />
-          )}
-          {game.isFinished && displayScores.find((s) => s.isWinner) && (
-            <GameOver
-              gameId={game.id}
-              winner={displayScores.find((s) => s.isWinner)!.username}
             />
           )}
         </>

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -133,6 +133,8 @@ export default async function GameView(props: {
               players={scoringPlayers}
               winThreshold={game.winThreshold}
               isFinished={game.isFinished}
+              winnerId={displayScores.find((s) => s.isWinner)?.id}
+              endedAt={game.endedAt?.toISOString()}
               rounds={game.rounds.map((r) => ({
                 id: r.id,
                 scores: r.scores.map((s) => ({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,3 +101,40 @@
   70% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+@keyframes celebrationFade {
+  0% { opacity: 0; }
+  8% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; pointer-events: none; }
+}
+
+@keyframes bgFlash {
+  0% { opacity: 0; }
+  8% { opacity: 0.95; }
+  70% { opacity: 0.95; }
+  100% { opacity: 0; }
+}
+
+@keyframes contentPop {
+  0% { opacity: 0; transform: scale(0.5); }
+  12% { opacity: 1; transform: scale(1.1); }
+  18% { transform: scale(1); }
+  70% { opacity: 1; }
+  100% { opacity: 0; transform: scale(0.95); }
+}
+
+@keyframes trophyBounce {
+  0% { opacity: 0; transform: scale(0) rotate(-20deg); }
+  15% { opacity: 1; transform: scale(1.3) rotate(5deg); }
+  22% { transform: scale(1) rotate(0deg); }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@keyframes confettiFall {
+  0% { opacity: 0; transform: translateY(-20px) rotate(0deg); }
+  10% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(600px) rotate(720deg); }
+}

--- a/src/components/scoring/CelebrationOverlay.tsx
+++ b/src/components/scoring/CelebrationOverlay.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+
+interface CelebrationOverlayProps {
+  winnerName: string;
+  winnerScore: number;
+  winnerColor: string;
+  onComplete: () => void;
+}
+
+function generateConfetti(count: number, colors: string[]) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    color: colors[i % colors.length],
+    left: `${Math.random() * 100}%`,
+    top: `${-10 + Math.random() * 20}%`,
+    size: 4 + Math.random() * 8,
+    isCircle: Math.random() > 0.5,
+    delay: `${Math.random() * 0.5}s`,
+    duration: `${2 + Math.random() * 1.5}s`,
+  }));
+}
+
+const CONFETTI_COLORS = [
+  "#3b82f6", "#ef4444", "#eab308", "#22c55e",
+  "#8b5cf6", "#f97316", "#fff", "#fbbf24",
+];
+
+export function CelebrationOverlay({
+  winnerName,
+  winnerScore,
+  winnerColor,
+  onComplete,
+}: CelebrationOverlayProps) {
+  const [visible, setVisible] = useState(true);
+  const confetti = useRef(generateConfetti(50, CONFETTI_COLORS));
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      onComplete();
+    }, 2500);
+    return () => clearTimeout(timer);
+  }, [onComplete]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="absolute inset-0 z-50 flex flex-col items-center justify-center pointer-events-none animate-[celebrationFade_2.5s_ease-out_forwards]">
+      {/* Background flash */}
+      <div
+        className="absolute inset-0 animate-[bgFlash_2.5s_ease-out_forwards]"
+        style={{
+          background: `linear-gradient(135deg, ${winnerColor}, ${winnerColor}dd)`,
+        }}
+      />
+
+      {/* Confetti */}
+      <div className="absolute inset-0 overflow-hidden">
+        {confetti.current.map((c) => (
+          <div
+            key={c.id}
+            className="absolute animate-[confettiFall_3s_ease-out_forwards]"
+            style={{
+              left: c.left,
+              top: c.top,
+              width: c.size,
+              height: c.size,
+              backgroundColor: c.color,
+              borderRadius: c.isCircle ? "50%" : "2px",
+              animationDelay: c.delay,
+              animationDuration: c.duration,
+              opacity: 0,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 text-center animate-[contentPop_2.5s_ease-out_forwards]">
+        <div className="text-6xl mb-3 animate-[trophyBounce_2.5s_ease-out_forwards]">
+          🏆
+        </div>
+        <div className="text-3xl font-black text-white drop-shadow-lg">
+          {winnerName}
+        </div>
+        <div className="text-base font-semibold text-white/85">
+          wins the game!
+        </div>
+        <div className="text-5xl font-black text-white mt-2 drop-shadow-lg">
+          {winnerScore}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/CelebrationOverlay.tsx
+++ b/src/components/scoring/CelebrationOverlay.tsx
@@ -7,6 +7,8 @@ interface CelebrationOverlayProps {
   winnerScore: number;
   winnerColor: string;
   onComplete: () => void;
+  onCancel?: () => void;
+  cancelled?: boolean;
 }
 
 function generateConfetti(count: number, colors: string[]) {
@@ -32,6 +34,8 @@ export function CelebrationOverlay({
   winnerScore,
   winnerColor,
   onComplete,
+  onCancel,
+  cancelled,
 }: CelebrationOverlayProps) {
   const [visible, setVisible] = useState(true);
   const confetti = useRef(generateConfetti(50, CONFETTI_COLORS));
@@ -44,10 +48,17 @@ export function CelebrationOverlay({
     return () => clearTimeout(timer);
   }, [onComplete]);
 
+  useEffect(() => {
+    if (cancelled) {
+      setVisible(false);
+      onCancel?.();
+    }
+  }, [cancelled, onCancel]);
+
   if (!visible) return null;
 
   return (
-    <div className="absolute inset-0 z-50 flex flex-col items-center justify-center pointer-events-none animate-[celebrationFade_2.5s_ease-out_forwards]">
+    <div className="absolute inset-0 z-40 flex flex-col items-center justify-center pointer-events-none animate-[celebrationFade_2.5s_ease-out_forwards]">
       {/* Background flash */}
       <div
         className="absolute inset-0 animate-[bgFlash_2.5s_ease-out_forwards]"

--- a/src/components/scoring/CelebrationOverlay.tsx
+++ b/src/components/scoring/CelebrationOverlay.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 
 interface CelebrationOverlayProps {
   winnerName: string;
   winnerScore: number;
   winnerColor: string;
   onComplete: () => void;
-  onCancel?: () => void;
-  cancelled?: boolean;
 }
 
 function generateConfetti(count: number, colors: string[]) {
@@ -34,11 +32,9 @@ export function CelebrationOverlay({
   winnerScore,
   winnerColor,
   onComplete,
-  onCancel,
-  cancelled,
 }: CelebrationOverlayProps) {
   const [visible, setVisible] = useState(true);
-  const confetti = useRef(generateConfetti(50, CONFETTI_COLORS));
+  const [confetti] = useState(() => generateConfetti(50, CONFETTI_COLORS));
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -47,13 +43,6 @@ export function CelebrationOverlay({
     }, 2500);
     return () => clearTimeout(timer);
   }, [onComplete]);
-
-  useEffect(() => {
-    if (cancelled) {
-      setVisible(false);
-      onCancel?.();
-    }
-  }, [cancelled, onCancel]);
 
   if (!visible) return null;
 
@@ -69,7 +58,7 @@ export function CelebrationOverlay({
 
       {/* Confetti */}
       <div className="absolute inset-0 overflow-hidden">
-        {confetti.current.map((c) => (
+        {confetti.map((c) => (
           <div
             key={c.id}
             className="absolute animate-[confettiFall_3s_ease-out_forwards]"

--- a/src/components/scoring/GameOverView.tsx
+++ b/src/components/scoring/GameOverView.tsx
@@ -3,11 +3,22 @@
 import { type PlayerWithScore } from "./types";
 import { type GameStats } from "@/lib/scoring/gameStats";
 import { ACCENT_COLORS } from "@/lib/scoring/colors";
+import { RoundHistoryTable } from "./RoundHistoryTable";
+import { usePostHog } from "posthog-js/react";
 
 interface GameOverViewProps {
   winner: PlayerWithScore;
   players: PlayerWithScore[];
   stats: GameStats;
+  rounds: {
+    scores: {
+      userId?: string | null;
+      guestId?: string | null;
+      blitzPileRemaining: number;
+      totalCardsPlayed: number;
+    }[];
+  }[];
+  onEditRound?: (roundIndex: number) => void;
   onRematch: () => void;
   onBackToCircle: () => void;
 }
@@ -16,9 +27,12 @@ export function GameOverView({
   winner,
   players,
   stats,
+  rounds,
+  onEditRound,
   onRematch,
   onBackToCircle,
 }: GameOverViewProps) {
+  const posthog = usePostHog();
   const sorted = [...players].sort((a, b) => b.score - a.score);
   const colorLabel =
     ACCENT_COLORS.find((c) => c.value === winner.color)?.label ?? "";
@@ -144,16 +158,33 @@ export function GameOverView({
         </div>
       </div>
 
+      {/* Round history — tap to edit */}
+      <div className="pt-4 pb-2">
+        <RoundHistoryTable
+          players={players}
+          rounds={rounds}
+          onEditRound={onEditRound}
+        />
+      </div>
+
       {/* Actions */}
       <div className="px-4 pt-5 pb-6 space-y-2">
         <button
-          onClick={onRematch}
+          onClick={() => {
+            posthog.capture("game_over_rematch", {
+              player_count: players.length,
+            });
+            onRematch();
+          }}
           className="w-full py-3.5 rounded-xl text-[15px] font-bold bg-[#290806] text-white hover:bg-[#3d1a0a] transition-colors cursor-pointer"
         >
           New Game with Same Players
         </button>
         <button
-          onClick={onBackToCircle}
+          onClick={() => {
+            posthog.capture("game_over_back_to_circle");
+            onBackToCircle();
+          }}
           className="w-full py-3 rounded-xl text-[13px] font-semibold border-[1.5px] border-[#e6d7c3] bg-white text-[#8b5e3c] hover:bg-[#faf5ed] transition-colors cursor-pointer"
         >
           Back to Circle

--- a/src/components/scoring/GameOverView.tsx
+++ b/src/components/scoring/GameOverView.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { type PlayerWithScore } from "./types";
+import { type GameStats } from "@/lib/scoring/gameStats";
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
+
+interface GameOverViewProps {
+  winner: PlayerWithScore;
+  players: PlayerWithScore[];
+  stats: GameStats;
+  onRematch: () => void;
+  onBackToCircle: () => void;
+}
+
+export function GameOverView({
+  winner,
+  players,
+  stats,
+  onRematch,
+  onBackToCircle,
+}: GameOverViewProps) {
+  const sorted = [...players].sort((a, b) => b.score - a.score);
+  const colorLabel =
+    ACCENT_COLORS.find((c) => c.value === winner.color)?.label ?? "";
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="text-center py-4 border-b border-[#f0e6d2]">
+        <h2 className="text-xl font-extrabold text-[#290806]">
+          Game Complete
+        </h2>
+        <div className="text-xs text-[#8b5e3c] mt-1">
+          {stats.roundsPlayed} rounds · {players.length} players
+        </div>
+      </div>
+
+      {/* Winner card */}
+      <div
+        className="mx-4 mt-4 mb-3 p-5 rounded-2xl text-center relative overflow-hidden"
+        style={{ border: `2px solid ${winner.color}` }}
+      >
+        <div
+          className="absolute inset-0 opacity-10"
+          style={{ backgroundColor: winner.color }}
+        />
+        <div className="relative z-10">
+          <div className="text-4xl mb-2">🏆</div>
+          <div
+            className="text-[10px] font-bold uppercase tracking-widest mb-1"
+            style={{ color: winner.color }}
+          >
+            Winner
+          </div>
+          <div
+            className="text-[28px] font-black"
+            style={{ color: winner.color }}
+          >
+            {winner.name}
+          </div>
+          <div className="text-lg font-bold" style={{ color: winner.color }}>
+            {winner.score} points
+          </div>
+        </div>
+      </div>
+
+      {/* Final standings */}
+      <div className="px-4 space-y-1.5">
+        {sorted.map((player, i) => (
+          <div
+            key={player.id}
+            className={`flex items-center justify-between py-2.5 px-3 bg-white border-[1.5px] border-[#e6d7c3] rounded-lg ${
+              player.id === winner.id ? "bg-[#eff6ff]" : ""
+            }`}
+            style={{ borderLeftWidth: "5px", borderLeftColor: player.color }}
+          >
+            <div className="flex items-center gap-2.5">
+              <span className="text-sm font-extrabold text-[#8b5e3c] w-5">
+                {i + 1}
+              </span>
+              <span className="text-sm font-semibold text-[#290806]">
+                {player.name}
+              </span>
+            </div>
+            <div className="text-right">
+              <div
+                className="text-base font-extrabold"
+                style={{
+                  color: player.score < 0 ? "#b91c1c" : player.color,
+                }}
+              >
+                {player.score}
+              </div>
+              <div className="text-[9px] text-[#8b5e3c]">
+                {stats.roundWins[player.id] ?? 0} round win
+                {(stats.roundWins[player.id] ?? 0) !== 1 ? "s" : ""} ·{" "}
+                {stats.blitzCounts[player.id] ?? 0} blitz
+                {(stats.blitzCounts[player.id] ?? 0) !== 1 ? "es" : ""}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Game stats grid */}
+      <div className="mx-4 mt-4 grid grid-cols-2 gap-2">
+        <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-lg p-3 text-center">
+          <div className="text-xl font-extrabold text-[#290806]">
+            {stats.roundsPlayed}
+          </div>
+          <div className="text-[9px] text-[#8b5e3c] uppercase tracking-wider mt-0.5">
+            Rounds Played
+          </div>
+        </div>
+        <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-lg p-3 text-center">
+          <div className="text-xl font-extrabold text-[#2a6517]">
+            +{stats.biggestRound.delta}
+          </div>
+          <div className="text-[9px] text-[#8b5e3c] uppercase tracking-wider mt-0.5">
+            Biggest Round
+          </div>
+          <div className="text-[10px] text-[#8b5e3c]">
+            {stats.biggestRound.playerName} · R{stats.biggestRound.roundNumber}
+          </div>
+        </div>
+        <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-lg p-3 text-center">
+          <div className="text-xl font-extrabold text-[#b91c1c]">
+            {stats.worstRound.delta}
+          </div>
+          <div className="text-[9px] text-[#8b5e3c] uppercase tracking-wider mt-0.5">
+            Worst Round
+          </div>
+          <div className="text-[10px] text-[#8b5e3c]">
+            {stats.worstRound.playerName} · R{stats.worstRound.roundNumber}
+          </div>
+        </div>
+        <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-lg p-3 text-center">
+          <div className="text-xl font-extrabold text-[#290806]">
+            {stats.totalBlitzes}
+          </div>
+          <div className="text-[9px] text-[#8b5e3c] uppercase tracking-wider mt-0.5">
+            Total Blitzes
+          </div>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="px-4 pt-5 pb-6 space-y-2">
+        <button
+          onClick={onRematch}
+          className="w-full py-3.5 rounded-xl text-[15px] font-bold bg-[#290806] text-white hover:bg-[#3d1a0a] transition-colors cursor-pointer"
+        >
+          New Game with Same Players
+        </button>
+        <button
+          onClick={onBackToCircle}
+          className="w-full py-3 rounded-xl text-[13px] font-semibold border-[1.5px] border-[#e6d7c3] bg-white text-[#8b5e3c] hover:bg-[#faf5ed] transition-colors cursor-pointer"
+        >
+          Back to Circle
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/GameOverView.tsx
+++ b/src/components/scoring/GameOverView.tsx
@@ -2,7 +2,6 @@
 
 import { type PlayerWithScore } from "./types";
 import { type GameStats } from "@/lib/scoring/gameStats";
-import { ACCENT_COLORS } from "@/lib/scoring/colors";
 import { RoundHistoryTable } from "./RoundHistoryTable";
 import { usePostHog } from "posthog-js/react";
 
@@ -34,8 +33,6 @@ export function GameOverView({
 }: GameOverViewProps) {
   const posthog = usePostHog();
   const sorted = [...players].sort((a, b) => b.score - a.score);
-  const colorLabel =
-    ACCENT_COLORS.find((c) => c.value === winner.color)?.label ?? "";
 
   return (
     <div>

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { ScoreEntryView } from "./ScoreEntryView";
 import { BetweenRoundsView } from "./BetweenRoundsView";
+import { CelebrationOverlay } from "./CelebrationOverlay";
+import { GameOverView } from "./GameOverView";
 import { type PlayerWithScore } from "./types";
+import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+import { cloneGame } from "@/server/mutations/games";
 
 export type ScoringMode = "entry" | "betweenRounds" | "gameOver";
 
@@ -32,11 +38,15 @@ export function ScoringShell({
   isFinished,
   rounds,
 }: ScoringShellProps) {
+  const router = useRouter();
+
   // showEntry is a client override — when user taps "Enter Next Round" we flip to entry.
   // Reset when currentRoundNumber changes (i.e. after a round is submitted + refresh).
   // Uses React's "adjust state during render" pattern to avoid useEffect lint issues.
   const [showEntry, setShowEntry] = useState(false);
   const [prevRound, setPrevRound] = useState(currentRoundNumber);
+  const [hasSeenCelebration, setHasSeenCelebration] = useState(false);
+  const [celebrationCancelled, setCelebrationCancelled] = useState(false);
 
   if (currentRoundNumber !== prevRound) {
     setPrevRound(currentRoundNumber);
@@ -50,8 +60,60 @@ export function ScoringShell({
       ? "entry"
       : "betweenRounds";
 
+  // Compute game stats from rounds data (client-side from serialized props)
+  const roundResults: RoundResult[] = rounds.map((round) => {
+    const deltas: Record<string, number> = {};
+    const blitzCounts: Record<string, number> = {};
+    for (const score of round.scores) {
+      const pid = score.userId ?? score.guestId ?? "";
+      deltas[pid] = calculateRoundScore(score);
+      blitzCounts[pid] = score.blitzPileRemaining === 0 ? 1 : 0;
+    }
+    return { deltas, blitzCounts };
+  });
+  const playerNameMap = Object.fromEntries(
+    players.map((p) => [p.id, p.name])
+  );
+  const gameStats = calcGameStats(roundResults, playerNameMap);
+
+  // Determine winner (highest score among players)
+  const sorted = [...players].sort((a, b) => b.score - a.score);
+  const winner = sorted[0];
+
+  const showCelebration =
+    isFinished && !hasSeenCelebration && !celebrationCancelled;
+
+  const handleRematch = async () => {
+    const newGameId = await cloneGame(gameId);
+    router.push(`/games/${newGameId}`);
+  };
+
+  const handleBackToCircle = () => {
+    router.push("/games");
+  };
+
   if (mode === "gameOver") {
-    return null;
+    return (
+      <>
+        {showCelebration && winner && (
+          <CelebrationOverlay
+            winnerName={winner.name}
+            winnerScore={winner.score}
+            winnerColor={winner.color}
+            onComplete={() => setHasSeenCelebration(true)}
+          />
+        )}
+        {winner && (
+          <GameOverView
+            winner={winner}
+            players={players}
+            stats={gameStats}
+            onRematch={handleRematch}
+            onBackToCircle={handleBackToCircle}
+          />
+        )}
+      </>
+    );
   }
 
   if (mode === "betweenRounds") {

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
 import { ScoreEntryView } from "./ScoreEntryView";
 import { BetweenRoundsView } from "./BetweenRoundsView";
 import { CelebrationOverlay } from "./CelebrationOverlay";
 import { GameOverView } from "./GameOverView";
+import { RoundEditor } from "./RoundEditor";
 import { type PlayerWithScore } from "./types";
 import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { cloneGame } from "@/server/mutations/games";
+import { updateRoundScores } from "@/server/mutations/rounds";
 
 export type ScoringMode = "entry" | "betweenRounds" | "gameOver";
 
@@ -19,6 +22,8 @@ interface ScoringShellProps {
   players: PlayerWithScore[];
   winThreshold: number;
   isFinished: boolean;
+  winnerId?: string;
+  endedAt?: string;
   rounds: {
     id: string;
     scores: {
@@ -36,17 +41,31 @@ export function ScoringShell({
   players,
   winThreshold,
   isFinished,
+  winnerId,
+  endedAt,
   rounds,
 }: ScoringShellProps) {
   const router = useRouter();
+  const posthog = usePostHog();
 
   // showEntry is a client override — when user taps "Enter Next Round" we flip to entry.
   // Reset when currentRoundNumber changes (i.e. after a round is submitted + refresh).
   // Uses React's "adjust state during render" pattern to avoid useEffect lint issues.
   const [showEntry, setShowEntry] = useState(false);
   const [prevRound, setPrevRound] = useState(currentRoundNumber);
-  const [hasSeenCelebration, setHasSeenCelebration] = useState(false);
-  const [celebrationCancelled, setCelebrationCancelled] = useState(false);
+
+  // Celebration: only show for recently-finished games (within 30s of endedAt).
+  // useState initializer runs once on mount — safe to call Date.now() there.
+  const [hasSeenCelebration, setHasSeenCelebration] = useState(() => {
+    if (!endedAt) return true;
+    return Date.now() - new Date(endedAt).getTime() >= 30_000;
+  });
+
+  // Editing state for game over view
+  const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(
+    null
+  );
+  const [editError, setEditError] = useState<string | null>(null);
 
   if (currentRoundNumber !== prevRound) {
     setPrevRound(currentRoundNumber);
@@ -76,12 +95,10 @@ export function ScoringShell({
   );
   const gameStats = calcGameStats(roundResults, playerNameMap);
 
-  // Determine winner (highest score among players)
-  const sorted = [...players].sort((a, b) => b.score - a.score);
-  const winner = sorted[0];
+  // Use server-resolved winnerId (includes tie-breaking) instead of client sort
+  const winner = winnerId ? players.find((p) => p.id === winnerId) : undefined;
 
-  const showCelebration =
-    isFinished && !hasSeenCelebration && !celebrationCancelled;
+  const showCelebration = isFinished && !hasSeenCelebration;
 
   const handleRematch = async () => {
     const newGameId = await cloneGame(gameId);
@@ -92,7 +109,67 @@ export function ScoringShell({
     router.push("/games");
   };
 
+  const handleEditRound = useCallback(
+    (roundIndex: number) => {
+      posthog.capture("scoring_edit_round_tapped", {
+        round_number: roundIndex + 1,
+      });
+      setEditError(null);
+      setEditingRoundIndex(roundIndex);
+    },
+    [posthog]
+  );
+
+  const handleSaveEdit = useCallback(
+    async (
+      updated: Record<
+        string,
+        { blitzPileRemaining: number; totalCardsPlayed: number }
+      >
+    ) => {
+      if (editingRoundIndex === null) return;
+      const round = rounds[editingRoundIndex];
+      setEditError(null);
+
+      const scores = players.map((player) => {
+        const data = updated[player.id];
+        return {
+          ...(player.isGuest
+            ? { guestId: player.guestId }
+            : { userId: player.userId }),
+          blitzPileRemaining: data.blitzPileRemaining,
+          totalCardsPlayed: data.totalCardsPlayed,
+        };
+      });
+
+      try {
+        await updateRoundScores(gameId, round.id, scores);
+        posthog.capture("scoring_round_edited", {
+          game_id: gameId,
+          round_number: editingRoundIndex + 1,
+        });
+        setEditingRoundIndex(null);
+        router.refresh();
+      } catch (e) {
+        setEditError(
+          e instanceof Error ? e.message : "Failed to save changes"
+        );
+      }
+    },
+    [editingRoundIndex, rounds, players, gameId, posthog, router]
+  );
+
   if (mode === "gameOver") {
+    const findPlayerScore = (
+      player: PlayerWithScore,
+      roundScores: ScoringShellProps["rounds"][0]["scores"]
+    ) =>
+      roundScores.find(
+        (s) =>
+          (player.userId && s.userId === player.userId) ||
+          (player.guestId && s.guestId === player.guestId)
+      );
+
     return (
       <>
         {showCelebration && winner && (
@@ -101,16 +178,41 @@ export function ScoringShell({
             winnerScore={winner.score}
             winnerColor={winner.color}
             onComplete={() => setHasSeenCelebration(true)}
-            cancelled={celebrationCancelled}
-            onCancel={() => setCelebrationCancelled(true)}
           />
         )}
+
+        {/* Inline round editor for finished games */}
+        {editingRoundIndex !== null && (
+          <RoundEditor
+            roundIndex={editingRoundIndex}
+            players={players}
+            roundData={Object.fromEntries(
+              players.map((p) => {
+                const s = findPlayerScore(
+                  p,
+                  rounds[editingRoundIndex].scores
+                );
+                return [
+                  p.id,
+                  {
+                    blitzPileRemaining: s?.blitzPileRemaining ?? 0,
+                    totalCardsPlayed: s?.totalCardsPlayed ?? 0,
+                  },
+                ];
+              })
+            )}
+            onSave={handleSaveEdit}
+            onCancel={() => setEditingRoundIndex(null)}
+          />
+        )}
+
         {winner && (
           <GameOverView
             winner={winner}
             players={players}
             stats={gameStats}
             rounds={rounds}
+            onEditRound={handleEditRound}
             onRematch={handleRematch}
             onBackToCircle={handleBackToCircle}
           />

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -110,6 +110,7 @@ export function ScoringShell({
             winner={winner}
             players={players}
             stats={gameStats}
+            rounds={rounds}
             onRematch={handleRematch}
             onBackToCircle={handleBackToCircle}
           />

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { ScoreEntryView } from "./ScoreEntryView";
@@ -65,7 +65,6 @@ export function ScoringShell({
   const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(
     null
   );
-  const [editError, setEditError] = useState<string | null>(null);
 
   if (currentRoundNumber !== prevRound) {
     setPrevRound(currentRoundNumber);
@@ -79,26 +78,32 @@ export function ScoringShell({
       ? "entry"
       : "betweenRounds";
 
-  // Compute game stats from rounds data (client-side from serialized props)
-  const roundResults: RoundResult[] = rounds.map((round) => {
-    const deltas: Record<string, number> = {};
-    const blitzCounts: Record<string, number> = {};
-    for (const score of round.scores) {
-      const pid = score.userId ?? score.guestId ?? "";
-      deltas[pid] = calculateRoundScore(score);
-      blitzCounts[pid] = score.blitzPileRemaining === 0 ? 1 : 0;
-    }
-    return { deltas, blitzCounts };
-  });
-  const playerNameMap = Object.fromEntries(
-    players.map((p) => [p.id, p.name])
-  );
-  const gameStats = calcGameStats(roundResults, playerNameMap);
+  // Compute game stats only when rounds/players change (not on every render)
+  const gameStats = useMemo(() => {
+    const roundResults: RoundResult[] = rounds.map((round) => {
+      const deltas: Record<string, number> = {};
+      const blitzCounts: Record<string, number> = {};
+      for (const score of round.scores) {
+        const pid = score.userId ?? score.guestId ?? "";
+        deltas[pid] = calculateRoundScore(score);
+        blitzCounts[pid] = score.blitzPileRemaining === 0 ? 1 : 0;
+      }
+      return { deltas, blitzCounts };
+    });
+    const playerNameMap = Object.fromEntries(
+      players.map((p) => [p.id, p.name])
+    );
+    return calcGameStats(roundResults, playerNameMap);
+  }, [rounds, players]);
 
   // Use server-resolved winnerId (includes tie-breaking) instead of client sort
   const winner = winnerId ? players.find((p) => p.id === winnerId) : undefined;
 
   const showCelebration = isFinished && !hasSeenCelebration;
+
+  const handleCelebrationComplete = useCallback(() => {
+    setHasSeenCelebration(true);
+  }, []);
 
   const handleRematch = async () => {
     const newGameId = await cloneGame(gameId);
@@ -114,7 +119,6 @@ export function ScoringShell({
       posthog.capture("scoring_edit_round_tapped", {
         round_number: roundIndex + 1,
       });
-      setEditError(null);
       setEditingRoundIndex(roundIndex);
     },
     [posthog]
@@ -129,7 +133,6 @@ export function ScoringShell({
     ) => {
       if (editingRoundIndex === null) return;
       const round = rounds[editingRoundIndex];
-      setEditError(null);
 
       const scores = players.map((player) => {
         const data = updated[player.id];
@@ -142,19 +145,13 @@ export function ScoringShell({
         };
       });
 
-      try {
-        await updateRoundScores(gameId, round.id, scores);
-        posthog.capture("scoring_round_edited", {
-          game_id: gameId,
-          round_number: editingRoundIndex + 1,
-        });
-        setEditingRoundIndex(null);
-        router.refresh();
-      } catch (e) {
-        setEditError(
-          e instanceof Error ? e.message : "Failed to save changes"
-        );
-      }
+      await updateRoundScores(gameId, round.id, scores);
+      posthog.capture("scoring_round_edited", {
+        game_id: gameId,
+        round_number: editingRoundIndex + 1,
+      });
+      setEditingRoundIndex(null);
+      router.refresh();
     },
     [editingRoundIndex, rounds, players, gameId, posthog, router]
   );
@@ -177,7 +174,7 @@ export function ScoringShell({
             winnerName={winner.name}
             winnerScore={winner.score}
             winnerColor={winner.color}
-            onComplete={() => setHasSeenCelebration(true)}
+            onComplete={handleCelebrationComplete}
           />
         )}
 

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -101,6 +101,8 @@ export function ScoringShell({
             winnerScore={winner.score}
             winnerColor={winner.color}
             onComplete={() => setHasSeenCelebration(true)}
+            cancelled={celebrationCancelled}
+            onCancel={() => setCelebrationCancelled(true)}
           />
         )}
         {winner && (

--- a/src/lib/__tests__/gameLogic.test.ts
+++ b/src/lib/__tests__/gameLogic.test.ts
@@ -203,6 +203,58 @@ describe("transformGameData", () => {
     expect(leadPlayers[0].total).toBe(leadPlayers[1].total);
   });
 
+  describe("tie-breaking", () => {
+    it("should break ties by fewest blitz cards remaining in the final round", async () => {
+      // user1 has MORE blitz cards remaining in the final round (worse)
+      // user2 has FEWER blitz cards remaining in the final round (better)
+      // Without tie-breaking, user1 would win because it appears first in the array.
+      // With proper tie-breaking, user2 should win.
+      const mockGame = createMockGame(
+        [
+          { userId: "user1", username: "Player 1" },
+          { userId: "user2", username: "Player 2" },
+        ],
+        [
+          {
+            roundNumber: 1,
+            scores: [
+              { userId: "user1", blitzPileRemaining: 0, totalCardsPlayed: 25 },
+              { userId: "user2", blitzPileRemaining: 0, totalCardsPlayed: 25 },
+            ],
+          },
+          {
+            roundNumber: 2,
+            scores: [
+              { userId: "user1", blitzPileRemaining: 0, totalCardsPlayed: 25 },
+              { userId: "user2", blitzPileRemaining: 0, totalCardsPlayed: 25 },
+            ],
+          },
+          {
+            roundNumber: 3,
+            scores: [
+              // Player 1: 28 points (blitzPile=2, cards=32 -> 32-4=28). Total = 78
+              { userId: "user1", blitzPileRemaining: 2, totalCardsPlayed: 32 },
+              // Player 2: 28 points (blitzPile=0, cards=28). Total = 78
+              { userId: "user2", blitzPileRemaining: 0, totalCardsPlayed: 28 },
+            ],
+          },
+        ]
+      );
+
+      const result = await transformGameData(mockGame);
+
+      // Both players should be at 78
+      const player1 = result.find((p) => p.userId === "user1");
+      const player2 = result.find((p) => p.userId === "user2");
+      expect(player1?.total).toBe(78);
+      expect(player2?.total).toBe(78);
+
+      // Player 2 should win because they had fewer blitz cards remaining (0 vs 2) in the final round
+      expect(player2?.isWinner).toBe(true);
+      expect(player1?.isWinner).toBe(false);
+    });
+  });
+
   it("marks guest winners correctly when finishing a game", async () => {
     const mockGame: GameWithPlayersAndScores = {
       id: "guest-game-id",

--- a/src/lib/__tests__/gameStats.test.ts
+++ b/src/lib/__tests__/gameStats.test.ts
@@ -1,0 +1,57 @@
+import { calcGameStats, type RoundResult } from "../scoring/gameStats";
+
+const sampleRounds: RoundResult[] = [
+  {
+    deltas: { p1: 18, p2: 12, p3: 8, p4: -4 },
+    blitzCounts: { p1: 0, p2: 0, p3: 0, p4: 0 },
+  },
+  {
+    deltas: { p1: 6, p2: 14, p3: 2, p4: -6 },
+    blitzCounts: { p1: 0, p2: 1, p3: 0, p4: 0 },
+  },
+  {
+    deltas: { p1: 14, p2: 8, p3: 10, p4: 6 },
+    blitzCounts: { p1: 1, p2: 0, p3: 0, p4: 0 },
+  },
+];
+
+const playerNames: Record<string, string> = {
+  p1: "Mike",
+  p2: "Sarah",
+  p3: "Dan",
+  p4: "Jo",
+};
+
+describe("calcGameStats", () => {
+  it("finds the biggest single round", () => {
+    const stats = calcGameStats(sampleRounds, playerNames);
+    expect(stats.biggestRound.delta).toBe(18);
+    expect(stats.biggestRound.playerName).toBe("Mike");
+    expect(stats.biggestRound.roundNumber).toBe(1);
+  });
+
+  it("finds the worst single round", () => {
+    const stats = calcGameStats(sampleRounds, playerNames);
+    expect(stats.worstRound.delta).toBe(-6);
+    expect(stats.worstRound.playerName).toBe("Jo");
+    expect(stats.worstRound.roundNumber).toBe(2);
+  });
+
+  it("counts total blitzes per player", () => {
+    const stats = calcGameStats(sampleRounds, playerNames);
+    expect(stats.blitzCounts["p1"]).toBe(1);
+    expect(stats.blitzCounts["p2"]).toBe(1);
+    expect(stats.totalBlitzes).toBe(2);
+  });
+
+  it("counts round wins per player", () => {
+    const stats = calcGameStats(sampleRounds, playerNames);
+    expect(stats.roundWins["p1"]).toBe(2);
+    expect(stats.roundWins["p2"]).toBe(1);
+  });
+
+  it("returns total rounds played", () => {
+    const stats = calcGameStats(sampleRounds, playerNames);
+    expect(stats.roundsPlayed).toBe(3);
+  });
+});

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -157,6 +157,24 @@ async function determineWinner(
       (player) => player.total === highestScore
     );
 
+    // Tie-breaking: when multiple players have the same highest score,
+    // the player with fewer blitz cards remaining in the final round wins.
+    if (potentialWinners.length > 1) {
+      const finalRound = game.rounds[game.rounds.length - 1];
+      potentialWinners.sort((a, b) => {
+        const aScore = finalRound.scores.find(
+          (s) => s.userId === a.id || s.guestId === a.id
+        );
+        const bScore = finalRound.scores.find(
+          (s) => s.userId === b.id || s.guestId === b.id
+        );
+        return (
+          (aScore?.blitzPileRemaining ?? 10) -
+          (bScore?.blitzPileRemaining ?? 10)
+        );
+      });
+    }
+
     const winnerId = potentialWinners[0].id;
     if (!game.isFinished) {
       const winnerPlayer = game.players.find(

--- a/src/lib/scoring/gameStats.ts
+++ b/src/lib/scoring/gameStats.ts
@@ -1,0 +1,70 @@
+export interface RoundResult {
+  deltas: Record<string, number>;
+  blitzCounts: Record<string, number>;
+}
+
+export interface GameStats {
+  roundsPlayed: number;
+  biggestRound: { delta: number; playerName: string; roundNumber: number };
+  worstRound: { delta: number; playerName: string; roundNumber: number };
+  blitzCounts: Record<string, number>;
+  totalBlitzes: number;
+  roundWins: Record<string, number>;
+}
+
+export function calcGameStats(
+  rounds: RoundResult[],
+  playerNames: Record<string, string>
+): GameStats {
+  let biggestRound = { delta: -Infinity, playerName: "", roundNumber: 0 };
+  let worstRound = { delta: Infinity, playerName: "", roundNumber: 0 };
+  const blitzCounts: Record<string, number> = {};
+  const roundWins: Record<string, number> = {};
+
+  for (const pid of Object.keys(playerNames)) {
+    blitzCounts[pid] = 0;
+    roundWins[pid] = 0;
+  }
+
+  for (let ri = 0; ri < rounds.length; ri++) {
+    const round = rounds[ri];
+    let bestDelta = -Infinity;
+    let bestPlayer = "";
+
+    for (const [pid, delta] of Object.entries(round.deltas)) {
+      if (delta > biggestRound.delta) {
+        biggestRound = {
+          delta,
+          playerName: playerNames[pid] ?? pid,
+          roundNumber: ri + 1,
+        };
+      }
+      if (delta < worstRound.delta) {
+        worstRound = {
+          delta,
+          playerName: playerNames[pid] ?? pid,
+          roundNumber: ri + 1,
+        };
+      }
+      if (delta > bestDelta) {
+        bestDelta = delta;
+        bestPlayer = pid;
+      }
+    }
+
+    if (bestPlayer) roundWins[bestPlayer]++;
+
+    for (const [pid, count] of Object.entries(round.blitzCounts)) {
+      blitzCounts[pid] += count;
+    }
+  }
+
+  return {
+    roundsPlayed: rounds.length,
+    biggestRound,
+    worstRound,
+    blitzCounts,
+    totalBlitzes: Object.values(blitzCounts).reduce((a, b) => a + b, 0),
+    roundWins,
+  };
+}

--- a/src/server/__tests__/mutations.test.ts
+++ b/src/server/__tests__/mutations.test.ts
@@ -202,7 +202,10 @@ describe("Game Mutations", () => {
 
     it("should update scores for a round", async () => {
       const mockGame = { id: mockGameId, isFinished: false, organizationId: mockOrgId };
-      (prisma.game.findUnique as jest.Mock).mockResolvedValue(mockGame);
+      // First call: initial game fetch; second call: re-fetch for reopen check
+      (prisma.game.findUnique as jest.Mock)
+        .mockResolvedValueOnce(mockGame)
+        .mockResolvedValueOnce({ ...mockGame, rounds: [], winThreshold: 75 });
       (prisma.$transaction as jest.Mock).mockResolvedValue([{ count: 1 }]);
 
       const result = await updateRoundScores(
@@ -245,13 +248,22 @@ describe("Game Mutations", () => {
       });
     });
 
-    it("should throw error if game is finished", async () => {
+    it("should allow editing finished games", async () => {
       const mockGame = { id: mockGameId, isFinished: true, organizationId: mockOrgId };
-      (prisma.game.findUnique as jest.Mock).mockResolvedValue(mockGame);
+      // First call: initial game fetch; second call: re-fetch for reopen check
+      (prisma.game.findUnique as jest.Mock)
+        .mockResolvedValueOnce(mockGame)
+        .mockResolvedValueOnce({ ...mockGame, rounds: [], winThreshold: 75 });
+      (prisma.$transaction as jest.Mock).mockResolvedValue([{ count: 1 }]);
 
-      await expect(
-        updateRoundScores(mockGameId, mockRoundId, validScores)
-      ).rejects.toThrow("Cannot update scores for a finished game");
+      const result = await updateRoundScores(
+        mockGameId,
+        mockRoundId,
+        validScores
+      );
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toEqual([{ count: 1 }]);
     });
 
     it("should throw error if game is not found", async () => {

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -2,7 +2,11 @@
 
 import prisma from "@/server/db/db";
 import { getAuthenticatedUserWithOrg } from "./common";
-import { validateGameRules, ValidationError } from "@/lib/validation/gameRules";
+import {
+  validateGameRules,
+  ValidationError,
+  calculateRoundScore,
+} from "@/lib/validation/gameRules";
 
 // Create new round with scores
 export async function createRoundForGame(
@@ -184,9 +188,8 @@ export async function updateRoundScores(
     throw new Error("Game does not belong to your active circle");
   }
 
-  if (game.isFinished) {
-    throw new Error("Cannot update scores for a finished game");
-  }
+  // Finished games are still editable — if an edit drops all players
+  // below the threshold, the game will be reopened (see below).
 
   // Validate scores using centralized validation
   try {
@@ -256,6 +259,41 @@ export async function updateRoundScores(
       roundId: roundId,
     },
   });
+
+  // Check if editing a finished game should reopen it
+  const updatedGame = await prisma.game.findUnique({
+    where: { id: gameId },
+    include: {
+      rounds: { include: { scores: true } },
+    },
+  });
+
+  if (updatedGame?.isFinished) {
+    const totals: Record<string, number> = {};
+    for (const round of updatedGame.rounds) {
+      for (const score of round.scores) {
+        const pid = score.userId ?? score.guestId ?? "";
+        totals[pid] = (totals[pid] ?? 0) + calculateRoundScore(score);
+      }
+    }
+
+    const anyoneAboveThreshold = Object.values(totals).some(
+      (total) => total >= updatedGame.winThreshold
+    );
+
+    if (!anyoneAboveThreshold) {
+      await prisma.game.update({
+        where: { id: gameId },
+        data: { isFinished: false, winnerId: null, endedAt: null },
+      });
+
+      posthog.capture({
+        distinctId: user.userId,
+        event: "game_reopened_after_edit",
+        properties: { game_id: gameId },
+      });
+    }
+  }
 
   return updatedScores;
 }

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -260,75 +260,76 @@ export async function updateRoundScores(
     },
   });
 
-  // Check if editing a finished game should reopen it
-  const updatedGame = await prisma.game.findUnique({
-    where: { id: gameId },
-    include: {
-      rounds: { include: { scores: true } },
-    },
-  });
+  // Only re-fetch and check thresholds for finished games
+  if (game.isFinished) {
+    const updatedGame = await prisma.game.findUnique({
+      where: { id: gameId },
+      include: {
+        rounds: { include: { scores: true } },
+      },
+    });
 
-  if (updatedGame?.isFinished) {
-    const totals: Record<string, number> = {};
-    for (const round of updatedGame.rounds) {
-      for (const score of round.scores) {
-        const pid = score.userId ?? score.guestId ?? "";
-        totals[pid] = (totals[pid] ?? 0) + calculateRoundScore(score);
-      }
-    }
-
-    const anyoneAboveThreshold = Object.values(totals).some(
-      (total) => total >= updatedGame.winThreshold
-    );
-
-    if (!anyoneAboveThreshold) {
-      // No one above threshold — reopen the game
-      await prisma.game.update({
-        where: { id: gameId },
-        data: { isFinished: false, winnerId: null, endedAt: null },
-      });
-
-      posthog.capture({
-        distinctId: user.userId,
-        event: "game_reopened_after_edit",
-        properties: { game_id: gameId },
-      });
-    } else {
-      // Game still finished — check if the winner changed
-      const highestScore = Math.max(...Object.values(totals));
-      const topPlayers = Object.entries(totals)
-        .filter(([, total]) => total === highestScore)
-        .map(([pid]) => pid);
-
-      // Tie-break by fewest blitz cards remaining in final round
-      let newWinnerId = topPlayers[0];
-      if (topPlayers.length > 1) {
-        const finalRound =
-          updatedGame.rounds[updatedGame.rounds.length - 1];
-        let bestRemaining = Infinity;
-        for (const pid of topPlayers) {
-          const s = finalRound.scores.find(
-            (sc) => (sc.userId ?? sc.guestId ?? "") === pid
-          );
-          const remaining = s?.blitzPileRemaining ?? 10;
-          if (remaining < bestRemaining) {
-            bestRemaining = remaining;
-            newWinnerId = pid;
-          }
+    if (updatedGame) {
+      const totals: Record<string, number> = {};
+      for (const round of updatedGame.rounds) {
+        for (const score of round.scores) {
+          const pid = score.userId ?? score.guestId ?? "";
+          totals[pid] = (totals[pid] ?? 0) + calculateRoundScore(score);
         }
       }
 
-      if (newWinnerId && newWinnerId !== updatedGame.winnerId) {
+      const anyoneAboveThreshold = Object.values(totals).some(
+        (total) => total >= updatedGame.winThreshold
+      );
+
+      if (!anyoneAboveThreshold) {
         await prisma.game.update({
           where: { id: gameId },
-          data: { winnerId: newWinnerId },
+          data: { isFinished: false, winnerId: null, endedAt: null },
         });
 
         posthog.capture({
           distinctId: user.userId,
-          event: "game_winner_updated_after_edit",
-          properties: { game_id: gameId, new_winner_id: newWinnerId },
+          event: "game_reopened_after_edit",
+          properties: { game_id: gameId },
         });
+      } else {
+        // Game still finished — check if the winner changed
+        const highestScore = Math.max(...Object.values(totals));
+        const topPlayers = Object.entries(totals)
+          .filter(([, total]) => total === highestScore)
+          .map(([pid]) => pid);
+
+        // Tie-break by fewest blitz cards remaining in final round
+        let newWinnerId = topPlayers[0];
+        if (topPlayers.length > 1) {
+          const finalRound =
+            updatedGame.rounds[updatedGame.rounds.length - 1];
+          let bestRemaining = Infinity;
+          for (const pid of topPlayers) {
+            const s = finalRound.scores.find(
+              (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+            );
+            const remaining = s?.blitzPileRemaining ?? 10;
+            if (remaining < bestRemaining) {
+              bestRemaining = remaining;
+              newWinnerId = pid;
+            }
+          }
+        }
+
+        if (newWinnerId && newWinnerId !== updatedGame.winnerId) {
+          await prisma.game.update({
+            where: { id: gameId },
+            data: { winnerId: newWinnerId },
+          });
+
+          posthog.capture({
+            distinctId: user.userId,
+            event: "game_winner_updated_after_edit",
+            properties: { game_id: gameId, new_winner_id: newWinnerId },
+          });
+        }
       }
     }
   }

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -282,6 +282,7 @@ export async function updateRoundScores(
     );
 
     if (!anyoneAboveThreshold) {
+      // No one above threshold — reopen the game
       await prisma.game.update({
         where: { id: gameId },
         data: { isFinished: false, winnerId: null, endedAt: null },
@@ -292,6 +293,43 @@ export async function updateRoundScores(
         event: "game_reopened_after_edit",
         properties: { game_id: gameId },
       });
+    } else {
+      // Game still finished — check if the winner changed
+      const highestScore = Math.max(...Object.values(totals));
+      const topPlayers = Object.entries(totals)
+        .filter(([, total]) => total === highestScore)
+        .map(([pid]) => pid);
+
+      // Tie-break by fewest blitz cards remaining in final round
+      let newWinnerId = topPlayers[0];
+      if (topPlayers.length > 1) {
+        const finalRound =
+          updatedGame.rounds[updatedGame.rounds.length - 1];
+        let bestRemaining = Infinity;
+        for (const pid of topPlayers) {
+          const s = finalRound.scores.find(
+            (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+          );
+          const remaining = s?.blitzPileRemaining ?? 10;
+          if (remaining < bestRemaining) {
+            bestRemaining = remaining;
+            newWinnerId = pid;
+          }
+        }
+      }
+
+      if (newWinnerId && newWinnerId !== updatedGame.winnerId) {
+        await prisma.game.update({
+          where: { id: gameId },
+          data: { winnerId: newWinnerId },
+        });
+
+        posthog.capture({
+          distinctId: user.userId,
+          event: "game_winner_updated_after_edit",
+          properties: { game_id: gameId, new_winner_id: newWinnerId },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- **CelebrationOverlay**: animated color flash with confetti and trophy, auto-fades after 2.5s
- **GameOverView**: winner card, final standings with per-player stats, game summary grid, editable round history, rematch/back actions
- **Game stats**: pure `calcGameStats` function (biggest/worst round, blitz counts, round wins)
- **Tie-breaking**: when players cross threshold with same score, fewer blitz cards remaining wins
- **Edit-reopens-game**: relaxed `isFinished` guard — editing scores can reopen a finished game or update the winner
- **Server-resolved winner**: `winnerId` passed from server (includes tie-breaking), not derived client-side
- **Celebration guard**: only plays within 30s of `endedAt`, no replay on revisit
- **PostHog tracking**: `game_over_rematch`, `game_over_back_to_circle`, `game_reopened_after_edit`, `game_winner_updated_after_edit`

## Test plan
- [x] 89 tests passing (gameStats, gameLogic tie-breaking, mutations)
- [x] ESLint clean on all changed files
- [ ] Play a game to threshold — celebration fires, results show
- [ ] Revisit finished game — no celebration, results show directly
- [ ] Edit winning round to drop below threshold — game reopens
- [ ] Edit that changes winner but stays finished — winner updates
- [ ] "New Game with Same Players" — cloned game with colors preserved
- [ ] "Back to Circle" — navigates to /games

🤖 Generated with [Claude Code](https://claude.com/claude-code)