### PR TITLE
Plan 5: Cleanup, deduplication & color prompt

### DIFF
--- a/docs/solutions/ui-bugs/nextjs-router-replace-history-cross-route.md
+++ b/docs/solutions/ui-bugs/nextjs-router-replace-history-cross-route.md
@@ -1,0 +1,81 @@
+---
+title: "Next.js router.replace() fails to replace history entry across route boundaries"
+date: 2026-03-30
+category: ui-bugs
+tags:
+  - nextjs
+  - app-router
+  - router
+  - history
+  - navigation
+  - query-params
+  - turbopack
+module: src/app/games/new/newGameChooser.tsx
+symptoms:
+  - "Browser back navigates to ?step=colors instead of clean URL after game creation"
+  - "Ghost URL persists in history stack despite router.replace() call"
+  - "Submitting a round navigates back to the color selection step"
+severity: medium
+resolved: true
+---
+
+# Next.js `router.replace()` Ghost History Entry Across Route Boundaries
+
+## Symptom
+
+In a multi-step game creation flow (`/games/new` → `/games/new?step=colors` → `/games/[id]`), calling `router.replace("/games/[id]")` from the color step did not replace the `?step=colors` entry in the browser history. Users pressing back or triggering any navigation ended up on `/games/new?step=colors` instead of `/games/new`.
+
+## Root Cause
+
+Next.js App Router's `router.replace()` does not reliably call `window.history.replaceState()` when navigating across different route segments (e.g., `/games/new` → `/games/[id]`). Its internal soft navigation adds a new browser history entry despite "replace" semantics.
+
+This was verified by testing raw browser APIs via Playwright:
+
+```javascript
+// Raw browser API works correctly:
+window.history.pushState(null, "", "/games/new?step=colors");
+window.history.replaceState(null, "", "/games/test-123");
+// Back goes to /games/new — ?step=colors is gone. Correct.
+
+// Next.js router.replace() does NOT achieve the same result.
+```
+
+## Investigation Steps
+
+1. Tried `window.history.pushState` with a hash (`#colors`) — same ghost entry, plus conflicted with Next.js's own history management.
+2. Switched to `useSearchParams` with `router.replace()` for game creation — `?step=colors` still persisted.
+3. Added `window.history.replaceState()` before `router.replace()` — Next.js overrode it internally.
+4. Used Playwright to test raw `replaceState` + `pushState` — confirmed browser-level replace works. The bug is in Next.js's router layer, not the browser.
+
+## Working Solution
+
+Bypass Next.js router for the history replacement, then use `router.push()` for navigation:
+
+```typescript
+if (result && result.gameId) {
+  // Use replaceState to remove ?step=colors from history, then
+  // push the game URL. Next.js router.replace() doesn't reliably
+  // replace the history entry when crossing route boundaries.
+  window.history.replaceState(null, "", `/games/${result.gameId}`);
+  router.push(`/games/${result.gameId}`);
+}
+```
+
+Also required: wrap the component using `useSearchParams` in `<Suspense>`:
+
+```tsx
+<Suspense>
+  <NewGameChooser users={users} />
+</Suspense>
+```
+
+## Key Insight
+
+When you need true history replacement across route segment boundaries in Next.js App Router, call `window.history.replaceState()` directly before `router.push()`. The `replaceState` call is synchronous and sticks; Next.js then builds on that state when `router.push()` fires.
+
+## Prevention
+
+- **Multi-step forms:** Use a single route with search params (`?step=X`) for all steps. Navigate to a new route only at the terminal action.
+- **`router.replace` vs `replaceState`:** Use `window.history.replaceState` when you need to silently update the URL without re-triggering route resolution. Use `router.replace` only when you want Next.js to re-evaluate the route.
+- **Rule of thumb:** If steps share a layout and no new server data is needed, stay on one URL with search params.
+- **Testing:** Write Playwright tests that assert `window.history.length` before and after transitions, and verify the back button lands on the expected URL.

--- a/docs/superpowers/plans/2026-03-28-scoring-revamp-plan-5-cleanup-notes.md
+++ b/docs/superpowers/plans/2026-03-28-scoring-revamp-plan-5-cleanup-notes.md
@@ -1,0 +1,24 @@
+# Scoring Revamp Plan 5: Cleanup & Gaps — Identified Items
+
+> These items were collected during Plan 4 implementation and code review. This is a starting point for brainstorming/planning, not a final plan.
+
+## Legacy UI Removal (when flag is on)
+
+- **Remove ScoreDisplay + ScoreLineGraph from game page** — still rendered alongside ScoringShell when `scoring-revamp` flag is enabled. The old score table and graph double up with the new UI.
+- **Remove old GameOver component** — `src/app/games/[id]/GameOver.tsx` is dead code (import removed in Plan 4).
+- **Remove old ScoreEntry/ScoreEditor** — `src/app/games/[id]/scoreEntry.tsx` and `ScoreEditor.tsx` are only used in the non-revamp path. When flag is on, they're unused.
+
+## Code Duplication (from Plan 4 review)
+
+- **Extract shared `findPlayerScore` utility** — identical function in `BetweenRoundsView.tsx:36` and `ScoringShell.tsx` (gameOver branch). Move to `src/components/scoring/utils.ts` or similar.
+- **Extract shared round editing hook** — `handleEditRound`, `handleSaveEdit`, editing state management duplicated between `BetweenRoundsView` and `ScoringShell`. Extract `useRoundEditing(gameId, rounds, players)` hook.
+- **Extract shared tie-breaking function** — logic duplicated in `src/lib/gameLogic.ts:determineWinner` and `src/server/mutations/rounds.ts` (winner-update-after-edit). Create a pure `breakTie(playerIds, finalRoundScores)` function.
+- **Extract shared `RoundData` type** — the `rounds` prop shape (`{ id: string; scores: { userId?, guestId?, blitzPileRemaining, totalCardsPlayed }[] }[]`) is repeated in `ScoringShellProps`, `BetweenRoundsViewProps`, and `GameOverViewProps`.
+
+## Missing Features
+
+- **ColorPrompt/ColorPicker not wired** — components built in Plan 1 but never integrated into game creation flow. Players with no `accentColor` should see the prompt before game starts.
+
+## Feature Flag Cleanup
+
+- **Remove `scoring-revamp` flag gating** — once confident the new UI is solid, remove the flag checks and delete all legacy code paths entirely.

--- a/docs/superpowers/plans/2026-03-29-scoring-revamp-plan-5-cleanup.md
+++ b/docs/superpowers/plans/2026-03-29-scoring-revamp-plan-5-cleanup.md
@@ -1,0 +1,1323 @@
+# Scoring Revamp Plan 5: Cleanup, Deduplication & Color Prompt
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract duplicated scoring code into shared utilities, fix feature flag gating so old/new UI don't render simultaneously, and wire the ColorPrompt into game creation so players choose deck colors before starting.
+
+**Architecture:** Bottom-up — extractions first (safe refactors), then flag fix (one structural change), then ColorPrompt integration (net-new feature on clean foundations). Legacy code is kept; the feature flag stays.
+
+**Tech Stack:** Next.js App Router, React hooks, TypeScript, Prisma, PostHog, Jest + Testing Library
+
+---
+
+## File Structure
+
+**New files:**
+- `src/components/scoring/utils.ts` — `findPlayerScore` pure function
+- `src/components/__tests__/scoring/utils.test.ts` — tests for above
+- `src/lib/scoring/tiebreak.ts` — `breakTie` pure function
+- `src/lib/__tests__/tiebreak.test.ts` — tests for above
+- `src/components/scoring/useRoundEditing.ts` — extracted editing hook
+- `src/components/scoring/GameColorStep.tsx` — color selection step for game creation
+- `src/lib/scoring/colorCascade.ts` — `resolveColorCascade` pure function
+- `src/lib/__tests__/colorCascade.test.ts` — tests for above
+- `src/components/scoring/useGameColors.ts` — hook wrapping color cascade logic
+
+**Modified files:**
+- `src/components/scoring/types.ts` — add `RoundScoreData` and `RoundData` types
+- `src/components/scoring/BetweenRoundsView.tsx` — use extracted utils/hook/types
+- `src/components/scoring/ScoringShell.tsx` — use extracted utils/hook/types
+- `src/components/scoring/GameOverView.tsx` — use shared `RoundData` type
+- `src/lib/gameLogic.ts` — use shared `breakTie`
+- `src/server/mutations/rounds.ts` — use shared `breakTie`
+- `src/app/games/[id]/page.tsx` — fix flag gating conditional
+- `src/app/games/new/page.tsx` — include `accentColor` in user query
+- `src/app/games/new/newGameChooser.tsx` — add color step before game creation
+- `src/server/mutations/games.ts` — accept `accentColor` per player in `createGame`
+
+---
+
+### Task 1: Extract `findPlayerScore` utility
+
+**Files:**
+- Create: `src/components/__tests__/scoring/utils.test.ts`
+- Create: `src/components/scoring/utils.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/components/__tests__/scoring/utils.test.ts
+import { findPlayerScore } from "../../scoring/utils";
+
+const scores = [
+  { userId: "u1", guestId: null, blitzPileRemaining: 3, totalCardsPlayed: 20 },
+  { userId: null, guestId: "g1", blitzPileRemaining: 0, totalCardsPlayed: 15 },
+];
+
+describe("findPlayerScore", () => {
+  it("matches a registered user by userId", () => {
+    const player = { id: "u1", name: "Alice", color: "#3b82f6", isGuest: false, userId: "u1", score: 0 };
+    const result = findPlayerScore(player, scores);
+    expect(result).toBe(scores[0]);
+  });
+
+  it("matches a guest user by guestId", () => {
+    const player = { id: "g1", name: "Bob", color: "#ef4444", isGuest: true, guestId: "g1", score: 0 };
+    const result = findPlayerScore(player, scores);
+    expect(result).toBe(scores[1]);
+  });
+
+  it("returns undefined when no match", () => {
+    const player = { id: "u99", name: "Nobody", color: "#eab308", isGuest: false, userId: "u99", score: 0 };
+    const result = findPlayerScore(player, scores);
+    expect(result).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern="components/__tests__/scoring/utils" --verbose`
+Expected: FAIL — `Cannot find module '../../scoring/utils'`
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/components/scoring/utils.ts
+import { type PlayerWithScore } from "./types";
+
+type RoundScore = {
+  userId?: string | null;
+  guestId?: string | null;
+  blitzPileRemaining: number;
+  totalCardsPlayed: number;
+};
+
+export function findPlayerScore(
+  player: Pick<PlayerWithScore, "userId" | "guestId">,
+  roundScores: RoundScore[]
+) {
+  return roundScores.find(
+    (s) =>
+      (player.userId && s.userId === player.userId) ||
+      (player.guestId && s.guestId === player.guestId)
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --testPathPattern="components/__tests__/scoring/utils" --verbose`
+Expected: PASS — 3 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/scoring/utils.ts src/components/__tests__/scoring/utils.test.ts
+git commit -m "feat: extract findPlayerScore utility"
+```
+
+---
+
+### Task 2: Extract `breakTie` function
+
+**Files:**
+- Create: `src/lib/__tests__/tiebreak.test.ts`
+- Create: `src/lib/scoring/tiebreak.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/__tests__/tiebreak.test.ts
+import { breakTie } from "../scoring/tiebreak";
+
+describe("breakTie", () => {
+  it("returns the player with fewest blitz cards remaining", () => {
+    const candidates = [
+      { playerId: "a", blitzPileRemaining: 5 },
+      { playerId: "b", blitzPileRemaining: 2 },
+      { playerId: "c", blitzPileRemaining: 7 },
+    ];
+    expect(breakTie(candidates)).toBe("b");
+  });
+
+  it("returns the first player when all have equal remaining", () => {
+    const candidates = [
+      { playerId: "a", blitzPileRemaining: 3 },
+      { playerId: "b", blitzPileRemaining: 3 },
+    ];
+    expect(breakTie(candidates)).toBe("a");
+  });
+
+  it("returns the single candidate when only one", () => {
+    const candidates = [{ playerId: "a", blitzPileRemaining: 10 }];
+    expect(breakTie(candidates)).toBe("a");
+  });
+
+  it("uses default of 10 when blitzPileRemaining is null", () => {
+    const candidates = [
+      { playerId: "a", blitzPileRemaining: null },
+      { playerId: "b", blitzPileRemaining: 5 },
+    ];
+    expect(breakTie(candidates as any)).toBe("b");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern="__tests__/tiebreak" --verbose`
+Expected: FAIL — `Cannot find module '../scoring/tiebreak'`
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/lib/scoring/tiebreak.ts
+
+interface TieBreakCandidate {
+  playerId: string;
+  blitzPileRemaining: number;
+}
+
+/**
+ * Break a tie among players with equal scores.
+ * The player with the fewest blitz cards remaining wins.
+ * If still tied, first in the array wins (stable).
+ */
+export function breakTie(candidates: TieBreakCandidate[]): string {
+  let bestId = candidates[0].playerId;
+  let bestRemaining = candidates[0].blitzPileRemaining ?? 10;
+
+  for (let i = 1; i < candidates.length; i++) {
+    const remaining = candidates[i].blitzPileRemaining ?? 10;
+    if (remaining < bestRemaining) {
+      bestRemaining = remaining;
+      bestId = candidates[i].playerId;
+    }
+  }
+
+  return bestId;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --testPathPattern="__tests__/tiebreak" --verbose`
+Expected: PASS — 4 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/scoring/tiebreak.ts src/lib/__tests__/tiebreak.test.ts
+git commit -m "feat: extract breakTie utility"
+```
+
+---
+
+### Task 3: Add shared `RoundData` type
+
+**Files:**
+- Modify: `src/components/scoring/types.ts`
+
+- [ ] **Step 1: Add the shared types to `types.ts`**
+
+Add to the end of `src/components/scoring/types.ts`:
+
+```typescript
+export interface RoundScoreData {
+  userId?: string | null;
+  guestId?: string | null;
+  blitzPileRemaining: number;
+  totalCardsPlayed: number;
+}
+
+export interface RoundData {
+  id: string;
+  scores: RoundScoreData[];
+}
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing breaks**
+
+Run: `npm test --verbose`
+Expected: All existing tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/scoring/types.ts
+git commit -m "feat: add shared RoundData and RoundScoreData types"
+```
+
+---
+
+### Task 4: Extract `useRoundEditing` hook
+
+**Files:**
+- Create: `src/components/scoring/useRoundEditing.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// src/components/scoring/useRoundEditing.ts
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import { updateRoundScores } from "@/server/mutations/rounds";
+import { type PlayerWithScore, type RoundData } from "./types";
+
+interface UseRoundEditingParams {
+  gameId: string;
+  rounds: RoundData[];
+  players: PlayerWithScore[];
+}
+
+export function useRoundEditing({ gameId, rounds, players }: UseRoundEditingParams) {
+  const router = useRouter();
+  const posthog = usePostHog();
+  const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const handleEditRound = useCallback((roundIndex: number) => {
+    posthog.capture("scoring_edit_round_tapped", { round_number: roundIndex + 1 });
+    setEditError(null);
+    setEditingRoundIndex(roundIndex);
+  }, [posthog]);
+
+  const handleSaveEdit = useCallback(async (
+    updated: Record<string, { blitzPileRemaining: number; totalCardsPlayed: number }>
+  ) => {
+    if (editingRoundIndex === null || editingRoundIndex >= rounds.length) return;
+    const round = rounds[editingRoundIndex];
+    setEditError(null);
+
+    const scores = players.map((player) => {
+      const data = updated[player.id];
+      return {
+        ...(player.isGuest
+          ? { guestId: player.guestId }
+          : { userId: player.userId }),
+        blitzPileRemaining: data.blitzPileRemaining,
+        totalCardsPlayed: data.totalCardsPlayed,
+      };
+    });
+
+    try {
+      await updateRoundScores(gameId, round.id, scores);
+      posthog.capture("scoring_round_edited", {
+        game_id: gameId,
+        round_number: editingRoundIndex + 1,
+      });
+      setEditingRoundIndex(null);
+      router.refresh();
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : "Failed to save changes");
+    }
+  }, [editingRoundIndex, rounds, players, gameId, posthog, router]);
+
+  const cancelEdit = useCallback(() => {
+    setEditingRoundIndex(null);
+    setEditError(null);
+  }, []);
+
+  return { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit };
+}
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing breaks**
+
+Run: `npm test --verbose`
+Expected: All existing tests PASS (new file, no consumers yet)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/scoring/useRoundEditing.ts
+git commit -m "feat: extract useRoundEditing hook"
+```
+
+---
+
+### Task 5: Wire extractions into BetweenRoundsView
+
+**Files:**
+- Modify: `src/components/scoring/BetweenRoundsView.tsx`
+
+- [ ] **Step 1: Update imports**
+
+Replace the import block and interface at the top of `BetweenRoundsView.tsx`:
+
+```typescript
+"use client";
+
+import { useMemo } from "react";
+import { usePostHog } from "posthog-js/react";
+import { RaceTrack } from "./RaceTrack";
+import { Standings } from "./Standings";
+import { RoundHistoryTable } from "./RoundHistoryTable";
+import { RoundEditor } from "./RoundEditor";
+import { FloatingCTA } from "./FloatingCTA";
+import { GraphCarousel } from "./GraphCarousel";
+import { ScoreProgressionCard } from "./graphs/ScoreProgressionCard";
+import { HotColdCard } from "./graphs/HotColdCard";
+import { WinProbabilityCard } from "./graphs/WinProbabilityCard";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+import { useRoundEditing } from "./useRoundEditing";
+import { findPlayerScore } from "./utils";
+import { type PlayerWithScore, type RoundData } from "./types";
+
+interface BetweenRoundsViewProps {
+  gameId: string;
+  players: PlayerWithScore[];
+  rounds: RoundData[];
+  winThreshold: number;
+  nextRoundNumber: number;
+  onEnterScores: () => void;
+}
+```
+
+- [ ] **Step 2: Replace editing state and handlers with hook**
+
+Remove the `useState` imports for `useState, useCallback` (keep `useMemo`). Remove `useRouter` import. Remove the `useState<number | null>(null)` and `useState<string | null>(null)` lines, the `handleEditRound`, `handleSaveEdit` callbacks, and the standalone `findPlayerScore` function (lines 36-45).
+
+Replace with the hook call at the top of the component:
+
+```typescript
+export function BetweenRoundsView({
+  gameId,
+  players,
+  rounds,
+  winThreshold,
+  nextRoundNumber,
+  onEnterScores,
+}: BetweenRoundsViewProps) {
+  const posthog = usePostHog();
+  const { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit } =
+    useRoundEditing({ gameId, rounds, players });
+```
+
+- [ ] **Step 3: Update RoundEditor's onCancel**
+
+Change the `onCancel` prop on `RoundEditor` from:
+```tsx
+onCancel={() => { setEditingRoundIndex(null); setEditError(null); }}
+```
+to:
+```tsx
+onCancel={cancelEdit}
+```
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/scoring/BetweenRoundsView.tsx
+git commit -m "refactor: wire BetweenRoundsView to shared utils and hook"
+```
+
+---
+
+### Task 6: Wire extractions into ScoringShell
+
+**Files:**
+- Modify: `src/components/scoring/ScoringShell.tsx`
+- Modify: `src/components/scoring/GameOverView.tsx`
+
+- [ ] **Step 1: Update ScoringShell imports**
+
+Replace the import block and interface in `ScoringShell.tsx`:
+
+```typescript
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import { ScoreEntryView } from "./ScoreEntryView";
+import { BetweenRoundsView } from "./BetweenRoundsView";
+import { CelebrationOverlay } from "./CelebrationOverlay";
+import { GameOverView } from "./GameOverView";
+import { RoundEditor } from "./RoundEditor";
+import { findPlayerScore } from "./utils";
+import { useRoundEditing } from "./useRoundEditing";
+import { type PlayerWithScore, type RoundData } from "./types";
+import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+import { cloneGame } from "@/server/mutations/games";
+
+export type ScoringMode = "entry" | "betweenRounds" | "gameOver";
+
+interface ScoringShellProps {
+  gameId: string;
+  currentRoundNumber: number;
+  players: PlayerWithScore[];
+  winThreshold: number;
+  isFinished: boolean;
+  winnerId?: string;
+  endedAt?: string;
+  rounds: RoundData[];
+}
+```
+
+- [ ] **Step 2: Replace editing state with hook**
+
+Remove the `updateRoundScores` import (line 15 of current file). Remove the `editingRoundIndex` useState (line 65-67), the `handleEditRound` callback (lines 117-125), and the `handleSaveEdit` callback (lines 127-157).
+
+Add the hook call after the celebration state:
+
+```typescript
+  // Editing state — shared hook for game-over round editing
+  const { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit } =
+    useRoundEditing({ gameId, rounds, players });
+```
+
+- [ ] **Step 3: Remove inline `findPlayerScore` from game-over block**
+
+Delete the `findPlayerScore` function definition inside the `if (mode === "gameOver")` block (lines 160-168). It's now imported from `./utils`.
+
+- [ ] **Step 4: Update RoundEditor onCancel in game-over block**
+
+Change:
+```tsx
+onCancel={() => setEditingRoundIndex(null)}
+```
+to:
+```tsx
+onCancel={cancelEdit}
+```
+
+- [ ] **Step 5: Add error banner to game-over block**
+
+Add an error banner right before the RoundEditor in the game-over `return` block:
+
+```tsx
+{editError && (
+  <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg text-sm text-[#b91c1c]">
+    {editError}
+  </div>
+)}
+```
+
+- [ ] **Step 6: Update GameOverView props to use shared type**
+
+In `src/components/scoring/GameOverView.tsx`, update the `rounds` prop type:
+
+Change:
+```typescript
+import { type PlayerWithScore } from "./types";
+```
+to:
+```typescript
+import { type PlayerWithScore, type RoundData } from "./types";
+```
+
+And change the `rounds` type in `GameOverViewProps` from:
+```typescript
+  rounds: {
+    scores: {
+      userId?: string | null;
+      guestId?: string | null;
+      blitzPileRemaining: number;
+      totalCardsPlayed: number;
+    }[];
+  }[];
+```
+to:
+```typescript
+  rounds: RoundData[];
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/scoring/ScoringShell.tsx src/components/scoring/GameOverView.tsx
+git commit -m "refactor: wire ScoringShell and GameOverView to shared utils, hook, and types"
+```
+
+---
+
+### Task 7: Wire `breakTie` into gameLogic.ts and rounds.ts
+
+**Files:**
+- Modify: `src/lib/gameLogic.ts:148-176`
+- Modify: `src/server/mutations/rounds.ts:304-319`
+
+- [ ] **Step 1: Update gameLogic.ts**
+
+Add import at top of `src/lib/gameLogic.ts`:
+```typescript
+import { breakTie } from "./scoring/tiebreak";
+```
+
+Replace the tie-breaking block inside `determineWinner` (lines 162-176). Change from:
+
+```typescript
+    // Tie-breaking: when multiple players have the same highest score,
+    // the player with fewer blitz cards remaining in the final round wins.
+    if (potentialWinners.length > 1) {
+      const finalRound = game.rounds[game.rounds.length - 1];
+      potentialWinners.sort((a, b) => {
+        const aScore = finalRound.scores.find(
+          (s) => s.userId === a.id || s.guestId === a.id
+        );
+        const bScore = finalRound.scores.find(
+          (s) => s.userId === b.id || s.guestId === b.id
+        );
+        return (
+          (aScore?.blitzPileRemaining ?? 10) -
+          (bScore?.blitzPileRemaining ?? 10)
+        );
+      });
+    }
+
+    const winnerId = potentialWinners[0].id;
+```
+
+to:
+
+```typescript
+    let winnerId: string;
+    if (potentialWinners.length > 1) {
+      const finalRound = game.rounds[game.rounds.length - 1];
+      const candidates = potentialWinners.map((pw) => {
+        const score = finalRound.scores.find(
+          (s) => s.userId === pw.id || s.guestId === pw.id
+        );
+        return { playerId: pw.id, blitzPileRemaining: score?.blitzPileRemaining ?? 10 };
+      });
+      winnerId = breakTie(candidates);
+    } else {
+      winnerId = potentialWinners[0].id;
+    }
+```
+
+- [ ] **Step 2: Update rounds.ts**
+
+Add import at top of `src/server/mutations/rounds.ts`:
+```typescript
+import { breakTie } from "@/lib/scoring/tiebreak";
+```
+
+Replace the tie-breaking block inside `updateRoundScores` (lines 304-319). Change from:
+
+```typescript
+        // Tie-break by fewest blitz cards remaining in final round
+        let newWinnerId = topPlayers[0];
+        if (topPlayers.length > 1) {
+          const finalRound =
+            updatedGame.rounds[updatedGame.rounds.length - 1];
+          let bestRemaining = Infinity;
+          for (const pid of topPlayers) {
+            const s = finalRound.scores.find(
+              (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+            );
+            const remaining = s?.blitzPileRemaining ?? 10;
+            if (remaining < bestRemaining) {
+              bestRemaining = remaining;
+              newWinnerId = pid;
+            }
+          }
+        }
+```
+
+to:
+
+```typescript
+        const finalRound = updatedGame.rounds[updatedGame.rounds.length - 1];
+        const candidates = topPlayers.map((pid) => {
+          const s = finalRound.scores.find(
+            (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+          );
+          return { playerId: pid, blitzPileRemaining: s?.blitzPileRemaining ?? 10 };
+        });
+        const newWinnerId = breakTie(candidates);
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS (gameLogic.test.ts should still pass since behavior is identical)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/gameLogic.ts src/server/mutations/rounds.ts
+git commit -m "refactor: wire breakTie into gameLogic and rounds mutation"
+```
+
+---
+
+### Task 8: Fix feature flag gating in page.tsx
+
+**Files:**
+- Modify: `src/app/games/[id]/page.tsx:121-126`
+
+- [ ] **Step 1: Update the ScoreDisplay conditional**
+
+In `src/app/games/[id]/page.tsx`, change the render block from:
+
+```tsx
+      <ScoreDisplay
+        displayScores={displayScores}
+        numRounds={game.rounds.length}
+        gameId={game.id}
+        isFinished={game.isFinished}
+      />
+      {useScoringRevamp ? (
+```
+
+to:
+
+```tsx
+      {!(useScoringRevamp && canViewScoringShell) && (
+        <ScoreDisplay
+          displayScores={displayScores}
+          numRounds={game.rounds.length}
+          gameId={game.id}
+          isFinished={game.isFinished}
+        />
+      )}
+      {useScoringRevamp ? (
+```
+
+This ensures:
+- Flag on + circle member: ScoringShell only (ScoreDisplay hidden)
+- Flag on + non-member/logged-out: ScoreDisplay (read-only fallback)
+- Flag off: ScoreDisplay + ScoreEntry (existing behavior)
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/games/[id]/page.tsx
+git commit -m "fix: gate ScoreDisplay so it doesn't double-render with ScoringShell"
+```
+
+---
+
+### Task 9: Build `resolveColorCascade` utility + test
+
+**Files:**
+- Create: `src/lib/__tests__/colorCascade.test.ts`
+- Create: `src/lib/scoring/colorCascade.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/__tests__/colorCascade.test.ts
+import { resolveColorCascade } from "../scoring/colorCascade";
+
+describe("resolveColorCascade", () => {
+  it("sets the chosen color for the target player", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444" };
+    const result = resolveColorCascade(colors, "a", "#22c55e");
+    expect(result.a).toBe("#22c55e");
+    expect(result.b).toBe("#ef4444");
+  });
+
+  it("bumps displaced player to next available color", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444" };
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    expect(result.a).toBe("#ef4444");
+    expect(result.b).not.toBe("#ef4444");
+    expect(result.b).not.toBe("#3b82f6"); // old color of a is not "available" — it's freed
+    // Actually, #3b82f6 IS freed since a no longer holds it
+    // b should get the first available from ACCENT_COLORS not used by anyone
+  });
+
+  it("never produces duplicate colors", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444", c: "#eab308" };
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    const values = Object.values(result);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("handles no displacement when color is unoccupied", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444" };
+    const result = resolveColorCascade(colors, "a", "#eab308");
+    expect(result).toEqual({ a: "#eab308", b: "#ef4444" });
+  });
+
+  it("handles displaced player getting first unused ACCENT_COLOR", () => {
+    // All 6 accent colors: blue, red, yellow, green, purple, orange
+    const colors = {
+      a: "#3b82f6", // blue
+      b: "#ef4444", // red
+      c: "#eab308", // yellow
+    };
+    // a takes red from b — b should get the first unused: green (#22c55e)
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    expect(result.a).toBe("#ef4444");
+    expect(result.b).toBe("#22c55e"); // green — first unused
+    expect(result.c).toBe("#eab308"); // unchanged
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern="__tests__/colorCascade" --verbose`
+Expected: FAIL — `Cannot find module '../scoring/colorCascade'`
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/lib/scoring/colorCascade.ts
+import { ACCENT_COLORS } from "./colors";
+
+/**
+ * Update a player's color and cascade-bump any displaced player.
+ * Returns a new color map (does not mutate the input).
+ *
+ * Invariant: the returned map never contains duplicate values.
+ */
+export function resolveColorCascade(
+  currentColors: Record<string, string>,
+  playerId: string,
+  newColor: string
+): Record<string, string> {
+  const next = { ...currentColors };
+
+  // Find who (if anyone) currently holds the new color
+  const displacedEntry = Object.entries(next).find(
+    ([id, c]) => id !== playerId && c === newColor
+  );
+
+  // Assign the new color
+  next[playerId] = newColor;
+
+  // Bump the displaced player to the first available accent color
+  if (displacedEntry) {
+    const usedColors = new Set(Object.values(next));
+    const available = ACCENT_COLORS.find((c) => !usedColors.has(c.value));
+    if (available) {
+      next[displacedEntry[0]] = available.value;
+    }
+  }
+
+  return next;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --testPathPattern="__tests__/colorCascade" --verbose`
+Expected: PASS — 5 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/scoring/colorCascade.ts src/lib/__tests__/colorCascade.test.ts
+git commit -m "feat: add resolveColorCascade for color step cascade logic"
+```
+
+---
+
+### Task 10: Build `useGameColors` hook
+
+**Files:**
+- Create: `src/components/scoring/useGameColors.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// src/components/scoring/useGameColors.ts
+"use client";
+
+import { useState, useCallback } from "react";
+import { assignColorsToPlayers } from "@/lib/scoring/colors";
+import { resolveColorCascade } from "@/lib/scoring/colorCascade";
+
+export interface ColorStepPlayer {
+  id: string;
+  name: string;
+  isGuest: boolean;
+  isCurrentUser: boolean;
+  defaultColor: string | null;
+  avatarUrl?: string | null;
+}
+
+export function useGameColors(players: ColorStepPlayer[]) {
+  const [colors, setColors] = useState<Record<string, string>>(() => {
+    const inputs = players.map((p) => ({
+      id: p.id,
+      resolvedColor: p.defaultColor,
+    }));
+    return assignColorsToPlayers(inputs);
+  });
+
+  const updateColor = useCallback((playerId: string, newColor: string) => {
+    setColors((prev) => resolveColorCascade(prev, playerId, newColor));
+  }, []);
+
+  return { colors, updateColor };
+}
+```
+
+- [ ] **Step 2: Run existing tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/scoring/useGameColors.ts
+git commit -m "feat: add useGameColors hook for color step state"
+```
+
+---
+
+### Task 11: Build `GameColorStep` component
+
+**Files:**
+- Create: `src/components/scoring/GameColorStep.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```typescript
+// src/components/scoring/GameColorStep.tsx
+"use client";
+
+import { useState } from "react";
+import { ColorPicker } from "./ColorPicker";
+import { useGameColors, type ColorStepPlayer } from "./useGameColors";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { PlayCircle, ArrowLeft } from "lucide-react";
+
+interface GameColorStepProps {
+  players: ColorStepPlayer[];
+  onConfirm: (colors: Record<string, string>, saveCreatorDefault: boolean) => void;
+  onBack: () => void;
+}
+
+export function GameColorStep({ players, onConfirm, onBack }: GameColorStepProps) {
+  const { colors, updateColor } = useGameColors(players);
+  const [saveAsDefault, setSaveAsDefault] = useState(true);
+
+  const getInitials = (name: string) => name.substring(0, 2).toUpperCase();
+
+  return (
+    <div className="space-y-4">
+      <div className="text-sm font-semibold text-[#5a341f] mb-1">
+        Pick a color for each player
+      </div>
+
+      {players.map((player) => {
+        const usedByOthers = Object.entries(colors)
+          .filter(([id]) => id !== player.id)
+          .map(([, c]) => c);
+
+        return (
+          <div
+            key={player.id}
+            className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3"
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <Avatar className="h-7 w-7">
+                {player.avatarUrl ? (
+                  <AvatarImage src={player.avatarUrl} alt={player.name} />
+                ) : (
+                  <AvatarFallback className="bg-[#f0e6d2] text-[#2a0e02] text-xs">
+                    {getInitials(player.name)}
+                  </AvatarFallback>
+                )}
+              </Avatar>
+              <span className="text-sm font-semibold text-[#290806]">
+                {player.name}
+              </span>
+              {player.isCurrentUser && (
+                <span className="text-xs bg-[#f0e6d2] text-[#5a341f] px-2 py-0.5 rounded-full">
+                  You
+                </span>
+              )}
+              {player.isGuest && (
+                <span className="text-xs bg-[#e6d7c3] text-[#5a341f] px-2 py-0.5 rounded-full">
+                  Guest
+                </span>
+              )}
+            </div>
+
+            <ColorPicker
+              value={colors[player.id] ?? null}
+              onChange={(color) => updateColor(player.id, color)}
+              usedColors={usedByOthers}
+            />
+
+            {player.isCurrentUser && (
+              <label className="flex items-center gap-2 mt-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={saveAsDefault}
+                  onChange={(e) => setSaveAsDefault(e.target.checked)}
+                  className="w-4 h-4 rounded border-[#e6d7c3] accent-[#290806]"
+                />
+                <span className="text-xs text-[#8b5e3c]">
+                  Save as my default color
+                </span>
+              </label>
+            )}
+
+            {player.isGuest && (
+              <p className="text-xs text-[#b8a08c] italic mt-2">
+                Color saved to this game only
+              </p>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="flex justify-between items-center pt-2 border-t border-[#e6d7c3]">
+        <Button variant="ghost" size="sm" className="text-[#5a341f]" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back
+        </Button>
+        <Button
+          className="bg-[#2a6517] hover:bg-[#1d4a10] text-white font-medium px-6"
+          onClick={() => onConfirm(colors, saveAsDefault)}
+        >
+          <PlayCircle className="mr-2 h-4 w-4" />
+          Start Game
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run existing tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/scoring/GameColorStep.tsx
+git commit -m "feat: add GameColorStep component for color selection in game creation"
+```
+
+---
+
+### Task 12: Update `createGame` mutation to accept player colors
+
+**Files:**
+- Modify: `src/server/mutations/games.ts:10-16`
+
+- [ ] **Step 1: Extend the input type**
+
+In `src/server/mutations/games.ts`, change the `createGame` parameter type from:
+
+```typescript
+export async function createGame(
+  users: {
+    id: string;
+    username?: string;
+    isGuest?: boolean;
+  }[],
+  winThreshold?: number
+) {
+```
+
+to:
+
+```typescript
+export async function createGame(
+  users: {
+    id: string;
+    username?: string;
+    isGuest?: boolean;
+    accentColor?: string;
+  }[],
+  winThreshold?: number
+) {
+```
+
+- [ ] **Step 2: Use client-provided colors in resolution**
+
+Change the color resolution block (lines 89-98) from:
+
+```typescript
+    const colorInputs = users.map((u) => {
+      const userDefault = playerDefaults.find((p) => p.id === u.id);
+      return {
+        id: u.id,
+        resolvedColor: resolvePlayerColor({
+          gameColor: null,
+          userDefault: userDefault?.accentColor ?? null,
+        }),
+      };
+    });
+```
+
+to:
+
+```typescript
+    const colorInputs = users.map((u) => {
+      const userDefault = playerDefaults.find((p) => p.id === u.id);
+      return {
+        id: u.id,
+        resolvedColor: u.accentColor ?? resolvePlayerColor({
+          gameColor: null,
+          userDefault: userDefault?.accentColor ?? null,
+        }),
+      };
+    });
+```
+
+If the client sends a color (from the color step), it takes priority. Otherwise the existing resolution (user default → auto-assign) applies.
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/mutations/games.ts
+git commit -m "feat: accept accentColor per player in createGame mutation"
+```
+
+---
+
+### Task 13: Wire GameColorStep into newGameChooser
+
+**Files:**
+- Modify: `src/app/games/new/page.tsx:30-40`
+- Modify: `src/app/games/new/newGameChooser.tsx`
+
+- [ ] **Step 1: Add `accentColor` to user query**
+
+In `src/app/games/new/page.tsx`, change the prisma select from:
+
+```typescript
+    select: {
+      id: true,
+      username: true,
+      clerk_user_id: true,
+      avatarUrl: true,
+    },
+```
+
+to:
+
+```typescript
+    select: {
+      id: true,
+      username: true,
+      clerk_user_id: true,
+      avatarUrl: true,
+      accentColor: true,
+    },
+```
+
+- [ ] **Step 2: Update `UserSubset` type in newGameChooser**
+
+In `src/app/games/new/newGameChooser.tsx`, change:
+
+```typescript
+type UserSubset = Pick<User, "id" | "username" | "clerk_user_id" | "avatarUrl">;
+```
+
+to:
+
+```typescript
+type UserSubset = Pick<User, "id" | "username" | "clerk_user_id" | "avatarUrl" | "accentColor">;
+```
+
+- [ ] **Step 3: Add step state and imports**
+
+Add imports at the top of `newGameChooser.tsx`:
+
+```typescript
+import { GameColorStep } from "@/components/scoring/GameColorStep";
+import { type ColorStepPlayer } from "@/components/scoring/useGameColors";
+import { saveUserAccentColor } from "@/server/mutations/games";
+```
+
+Add step state inside the component:
+
+```typescript
+  const [step, setStep] = useState<"players" | "colors">("players");
+```
+
+- [ ] **Step 4: Create the color step player mapper**
+
+Add a helper inside the component (after `isGuestPlayer`):
+
+```typescript
+  const buildColorStepPlayers = (): ColorStepPlayer[] => {
+    return inGamePlayers.map((player) => {
+      const isGuest = isGuestPlayer(player);
+      const isCurrent = isCurrentUser(player);
+      const defaultColor = !isGuest && "accentColor" in player
+        ? player.accentColor ?? null
+        : null;
+
+      return {
+        id: player.id,
+        name: player.username,
+        isGuest,
+        isCurrentUser: isCurrent,
+        defaultColor,
+        avatarUrl: "avatarUrl" in player ? player.avatarUrl : null,
+      };
+    });
+  };
+```
+
+- [ ] **Step 5: Update handleCreateGame to accept colors**
+
+Change `handleCreateGame` from:
+
+```typescript
+  const handleCreateGame = async () => {
+    try {
+      const result = await createGame(inGamePlayers, winThreshold);
+      if (result && result.gameId) {
+        router.push(`/games/${result.gameId}`);
+      }
+    } catch (error) {
+      console.error("Error creating game:", error);
+    }
+  };
+```
+
+to:
+
+```typescript
+  const handleCreateGame = async (
+    playerColors: Record<string, string>,
+    saveCreatorDefault: boolean
+  ) => {
+    try {
+      const playersWithColors = inGamePlayers.map((p) => ({
+        ...p,
+        accentColor: playerColors[p.id],
+      }));
+      const result = await createGame(playersWithColors, winThreshold);
+
+      if (saveCreatorDefault) {
+        const currentPlayer = inGamePlayers.find((p) => isCurrentUser(p));
+        if (currentPlayer && playerColors[currentPlayer.id]) {
+          await saveUserAccentColor(playerColors[currentPlayer.id]);
+        }
+      }
+
+      if (result && result.gameId) {
+        router.push(`/games/${result.gameId}`);
+      }
+    } catch (error) {
+      console.error("Error creating game:", error);
+    }
+  };
+```
+
+- [ ] **Step 6: Change "Start Game" button to "Next" and add color step render**
+
+Change the `CardFooter` button from:
+
+```tsx
+      <CardFooter className="bg-[#f7f2e9] border-t border-[#e6d7c3] p-4 flex justify-end">
+        <Button
+          className="bg-[#2a6517] hover:bg-[#1d4a10] text-white font-medium px-6 h-10"
+          onClick={handleCreateGame}
+          disabled={inGamePlayers.length < 2}
+        >
+          <PlayCircle className="mr-2 h-4 w-4" />
+          Start Game
+        </Button>
+      </CardFooter>
+```
+
+to:
+
+```tsx
+      <CardFooter className="bg-[#f7f2e9] border-t border-[#e6d7c3] p-4 flex justify-end">
+        <Button
+          className="bg-[#2a6517] hover:bg-[#1d4a10] text-white font-medium px-6 h-10"
+          onClick={() => setStep("colors")}
+          disabled={inGamePlayers.length < 2}
+        >
+          <PlayCircle className="mr-2 h-4 w-4" />
+          Next
+        </Button>
+      </CardFooter>
+```
+
+- [ ] **Step 7: Wrap the component return in step conditional**
+
+Wrap the existing Card return in a step check. Change the return to:
+
+```tsx
+  if (step === "colors") {
+    return (
+      <Card className="mx-auto shadow-md border-[#e6d7c3] max-w-md my-6">
+        <CardHeader className="bg-gradient-to-r from-[#5a341f] to-[#8b5e3c] text-white rounded-t-lg">
+          <CardTitle className="text-xl flex items-center gap-2">
+            <PlayCircle className="h-5 w-5" />
+            Choose Colors
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4">
+          <GameColorStep
+            players={buildColorStepPlayers()}
+            onConfirm={handleCreateGame}
+            onBack={() => setStep("players")}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mx-auto shadow-md border-[#e6d7c3] max-w-md my-6">
+      {/* ... existing Card content unchanged ... */}
+    </Card>
+  );
+```
+
+The existing `Card` return stays exactly as-is (minus the button text change from Step 6).
+
+- [ ] **Step 8: Run all tests**
+
+Run: `npm test --verbose`
+Expected: All tests PASS
+
+- [ ] **Step 9: Manual smoke test**
+
+Run: `npm run dev`
+
+Verify:
+1. Navigate to `/games/new`
+2. Add 2+ players, click "Next"
+3. Color step appears with pre-filled colors
+4. Changing a color displaces the other player correctly
+5. "Save as my default" checkbox only appears for the current user
+6. "Back" returns to player selection
+7. "Start Game" creates the game with chosen colors
+8. Visit the game page — colors match what was chosen
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/app/games/new/page.tsx src/app/games/new/newGameChooser.tsx
+git commit -m "feat: wire GameColorStep into game creation flow"
+```

--- a/docs/superpowers/plans/2026-03-29-scoring-revamp-plan-5-cleanup.md
+++ b/docs/superpowers/plans/2026-03-29-scoring-revamp-plan-5-cleanup.md
@@ -18,7 +18,7 @@
 - `src/lib/scoring/tiebreak.ts` — `breakTie` pure function
 - `src/lib/__tests__/tiebreak.test.ts` — tests for above
 - `src/components/scoring/useRoundEditing.ts` — extracted editing hook
-- `src/components/scoring/GameColorStep.tsx` — color selection step for game creation
+- `src/components/scoring/GameColorStep.tsx` — color selection step for game creation (new component; the existing `ColorPrompt.tsx` is a single-player prompt with its own confirm button — `GameColorStep` composes `ColorPicker` directly to show all players at once with a shared confirm, so `ColorPrompt` is intentionally not reused here)
 - `src/lib/scoring/colorCascade.ts` — `resolveColorCascade` pure function
 - `src/lib/__tests__/colorCascade.test.ts` — tests for above
 - `src/components/scoring/useGameColors.ts` — hook wrapping color cascade logic
@@ -644,16 +644,50 @@ to:
         const newWinnerId = breakTie(candidates);
 ```
 
-- [ ] **Step 3: Run tests**
+- [ ] **Step 3: Run existing tests**
 
 Run: `npm test --verbose`
 Expected: All tests PASS (gameLogic.test.ts should still pass since behavior is identical)
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Add regression test for breakTie via updateRoundScores**
+
+The existing `gameLogic.test.ts` covers tie-breaking through `transformGameData`, but `updateRoundScores` in `rounds.ts` has its own tie-break path (winner recomputation after editing a finished game) that has no direct test coverage. Add a targeted unit test for the `breakTie` function that matches the mutation's usage pattern — playerIds as strings mapped to blitz counts:
+
+```typescript
+// Add to src/lib/__tests__/tiebreak.test.ts
+
+describe("breakTie — rounds mutation usage pattern", () => {
+  it("selects winner from string playerIds mapped via scores", () => {
+    // Simulates the updateRoundScores path: topPlayers are string IDs,
+    // mapped to candidates via final-round score lookup
+    const topPlayers = ["user-1", "user-2"];
+    const finalRoundScores = [
+      { id: "s1", userId: "user-1", guestId: null, blitzPileRemaining: 4, totalCardsPlayed: 22 },
+      { id: "s2", userId: "user-2", guestId: null, blitzPileRemaining: 1, totalCardsPlayed: 25 },
+    ];
+
+    const candidates = topPlayers.map((pid) => {
+      const s = finalRoundScores.find(
+        (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+      );
+      return { playerId: pid, blitzPileRemaining: s?.blitzPileRemaining ?? 10 };
+    });
+
+    expect(breakTie(candidates)).toBe("user-2"); // fewer blitz cards
+  });
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test -- --testPathPattern="__tests__/tiebreak" --verbose`
+Expected: PASS — 5 tests (4 original + 1 new)
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/lib/gameLogic.ts src/server/mutations/rounds.ts
-git commit -m "refactor: wire breakTie into gameLogic and rounds mutation"
+git add src/lib/gameLogic.ts src/server/mutations/rounds.ts src/lib/__tests__/tiebreak.test.ts
+git commit -m "refactor: wire breakTie into gameLogic and rounds mutation, add regression test"
 ```
 
 ---
@@ -730,14 +764,13 @@ describe("resolveColorCascade", () => {
     expect(result.b).toBe("#ef4444");
   });
 
-  it("bumps displaced player to next available color", () => {
+  it("bumps displaced player to first unused ACCENT_COLOR", () => {
     const colors = { a: "#3b82f6", b: "#ef4444" };
+    // a takes red from b. After assignment: a=#ef4444, b=?
+    // Used colors: #ef4444. Free from palette: #3b82f6 (blue, index 0).
     const result = resolveColorCascade(colors, "a", "#ef4444");
     expect(result.a).toBe("#ef4444");
-    expect(result.b).not.toBe("#ef4444");
-    expect(result.b).not.toBe("#3b82f6"); // old color of a is not "available" — it's freed
-    // Actually, #3b82f6 IS freed since a no longer holds it
-    // b should get the first available from ACCENT_COLORS not used by anyone
+    expect(result.b).toBe("#3b82f6"); // blue — first unused in ACCENT_COLORS order
   });
 
   it("never produces duplicate colors", () => {
@@ -766,6 +799,23 @@ describe("resolveColorCascade", () => {
     expect(result.b).toBe("#22c55e"); // green — first unused
     expect(result.c).toBe("#eab308"); // unchanged
   });
+
+  it("falls back to freed color when palette is exhausted (7+ players)", () => {
+    // All 6 palette colors are in use, plus a 7th player wrapping
+    const colors = {
+      a: "#3b82f6", // blue
+      b: "#ef4444", // red
+      c: "#eab308", // yellow
+      d: "#22c55e", // green
+      e: "#8b5cf6", // purple
+      f: "#f97316", // orange
+      g: "#3b82f6", // blue (wrapped — already a duplicate)
+    };
+    // a takes red from b — no free palette slot, b gets a's old color (blue)
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    expect(result.a).toBe("#ef4444");
+    expect(result.b).toBe("#3b82f6"); // gets a's freed blue
+  });
 });
 ```
 
@@ -784,7 +834,10 @@ import { ACCENT_COLORS } from "./colors";
  * Update a player's color and cascade-bump any displaced player.
  * Returns a new color map (does not mutate the input).
  *
- * Invariant: the returned map never contains duplicate values.
+ * When fewer players than palette colors (≤6), duplicates are impossible.
+ * When palette is exhausted (7+ players), the displaced player keeps
+ * their current color — duplicates are tolerated, matching the base
+ * allocator behavior in assignColorsToPlayers (colors.ts:49).
  */
 export function resolveColorCascade(
   currentColors: Record<string, string>,
@@ -798,16 +851,19 @@ export function resolveColorCascade(
     ([id, c]) => id !== playerId && c === newColor
   );
 
+  // Remember the outgoing color before overwriting
+  const oldColor = next[playerId];
+
   // Assign the new color
   next[playerId] = newColor;
 
-  // Bump the displaced player to the first available accent color
+  // Bump the displaced player to the first available accent color.
+  // If the palette is exhausted (7+ players), fall back to the
+  // color that was just freed by the current player.
   if (displacedEntry) {
     const usedColors = new Set(Object.values(next));
     const available = ACCENT_COLORS.find((c) => !usedColors.has(c.value));
-    if (available) {
-      next[displacedEntry[0]] = available.value;
-    }
+    next[displacedEntry[0]] = available ? available.value : oldColor;
   }
 
   return next;
@@ -1214,10 +1270,14 @@ to:
       }));
       const result = await createGame(playersWithColors, winThreshold);
 
+      // Fire-and-forget: saving the creator's default must not block
+      // navigation or cause a retry that duplicates the game.
       if (saveCreatorDefault) {
         const currentPlayer = inGamePlayers.find((p) => isCurrentUser(p));
         if (currentPlayer && playerColors[currentPlayer.id]) {
-          await saveUserAccentColor(playerColors[currentPlayer.id]);
+          saveUserAccentColor(playerColors[currentPlayer.id]).catch((e) =>
+            console.error("Failed to save default color:", e)
+          );
         }
       }
 

--- a/docs/superpowers/plans/2026-03-29-scoring-revamp-plan-6-notes.md
+++ b/docs/superpowers/plans/2026-03-29-scoring-revamp-plan-6-notes.md
@@ -1,0 +1,21 @@
+# Scoring Revamp Plan 6: Mobile Polish — Identified Items
+
+> Collected from real-device mobile testing (iPhone, Safari) on 2026-03-29. Starting point for brainstorming/planning.
+
+## Mobile Readability
+
+- **Racetrack text too small** — The score labels, player names, and "-10 / 0 / 75 to win" axis labels on the race track are hard to read on a phone screen. Need to increase font sizes for mobile viewports.
+- **Graph card text too small** — The Score Progression chart axis labels (0, 8, 16, 24, 32) and player legend text are not comfortably readable on mobile. Same applies to the Hot/Cold and Win Probability cards in the carousel.
+
+## Layout / Spacing
+
+- **Container width misalignment** — The overall viewport isn't fully edge-to-edge or consistently inset. Visible in the screenshot where the racetrack, graph carousel, and standings cards have slightly different horizontal alignment. Needs a consistent container/padding strategy across the between-rounds view.
+
+## UX: Undo Flow
+
+- **Undo toast blocks the standings view** — After submitting a round, the undo countdown toast takes ~5 seconds before the standings appear. But the standings (who's ahead, how far to win) are exactly what players want to see immediately after a round. The undo feature is valuable and worth keeping, but it needs a different mechanism that doesn't delay showing results.
+- **Possible approaches to explore in brainstorm:**
+  - Show standings immediately with an undo button overlaid (floating or inline) rather than blocking
+  - Undo as a persistent option in the round history (tap the round to undo/edit)
+  - Snackbar-style undo that doesn't block the main content
+  - Brief undo window that shows alongside the results, not instead of them

--- a/docs/superpowers/specs/2026-03-28-scoring-revamp-plan-5-cleanup-design.md
+++ b/docs/superpowers/specs/2026-03-28-scoring-revamp-plan-5-cleanup-design.md
@@ -22,10 +22,12 @@ Extract the duplicated round editing logic from `BetweenRoundsView` and `Scoring
 
 Duplicated state and handlers:
 - `editingRoundIndex` state (`useState<number | null>`)
-- `handleEditRound` callback (sets index, tracks PostHog event)
-- `handleSaveEdit` callback (calls `editRoundScores` mutation, resets state, refreshes router)
+- `editError` state (`useState<string | null>`) — present in BetweenRoundsView but missing from ScoringShell. The hook must include this so both consumers surface inline errors on failed edits.
+- `handleEditRound` callback (sets index, clears error, tracks PostHog event)
+- `handleSaveEdit` callback (calls `editRoundScores` mutation, resets state, refreshes router; catches errors and sets `editError`)
+- Cancel/reset behavior (clears `editingRoundIndex` and `editError` together)
 
-The hook takes `gameId`, `rounds`, and `players` as inputs. Returns `{ editingRoundIndex, handleEditRound, handleSaveEdit }`.
+The hook takes `gameId`, `rounds`, and `players` as inputs. Returns `{ editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit }`.
 
 ### 1c. `breakTie` function
 
@@ -47,11 +49,14 @@ Define this once in `src/components/scoring/types.ts` (which already exists) and
 
 The game page (`src/app/games/[id]/page.tsx`) currently renders `ScoreDisplay` unconditionally (line 121-126), outside the feature flag conditional. When the `scoring-revamp` flag is on, both the old score table and the new `ScoringShell` render simultaneously.
 
-**Fix:** Move `ScoreDisplay` inside the flag-off branch so it only renders when the old UI is active.
+**Fix:** ScoreDisplay currently serves as the read-only view for non-circle-members and logged-out users. It cannot simply move into the flag-off branch — that would leave flagged games blank for public viewers.
 
 Result:
-- Flag on: `ScoringShell` only (gated by `canViewScoringShell`)
+- Flag on + circle member: `ScoringShell` only (no `ScoreDisplay` above it)
+- Flag on + non-member / logged-out: `ScoreDisplay` (read-only fallback, same as today)
 - Flag off: `ScoreDisplay` + `ScoreEntry` (existing behavior)
+
+The conditional becomes: render `ScoreDisplay` unless (flag is on AND user is a circle member who sees `ScoringShell`).
 
 No files are deleted. All legacy components remain in place.
 
@@ -67,8 +72,9 @@ The game creation page (`src/app/games/new/newGameChooser.tsx`) currently has tw
 
 ### Per-player behavior
 
-- **Registered users with a saved `accentColor`:** Pre-filled with their default. "Save as my default color" checkbox shown (checked by default). Override allowed.
-- **Registered users without a saved color:** Auto-picks the first available unselected color. "Save as my default color" checkbox shown (checked by default).
+- **Current user (game creator) with a saved `accentColor`:** Pre-filled with their default. "Save as my default color" checkbox shown (checked by default). Override allowed.
+- **Current user (game creator) without a saved color:** Auto-picks the first available unselected color. "Save as my default color" checkbox shown (checked by default).
+- **Other registered users:** Pre-filled with their saved default if they have one, otherwise auto-picks next available. No "Save as default" checkbox — the creator cannot update another user's profile preferences. Color saved to the game record only.
 - **Guest users:** Auto-picks the first available unselected color. No "Save as default" checkbox — color saved to game record only. Shows italic note: "Color saved to this game only."
 
 ### Conflict resolution
@@ -77,13 +83,13 @@ Players are processed top-to-bottom in list order. First player with a given sav
 
 ### Taken color handling
 
-Each player's picker dims and disables colors already selected by players above them in the list. A player can always see and select any color not taken by another player.
+Each player's picker dims and disables colors already selected by other players. When an earlier player switches to a color currently held by a later player, the later player is auto-bumped to the next available color (cascade reassignment). This prevents duplicate colors despite the interactive UI — the invariant is that no two players can hold the same color at any point.
 
 ### Data flow
 
 On confirm:
 - Each player's chosen color is passed to the `createGame` mutation as `accentColor` on the game-player record.
-- For registered users with "Save as default" checked, also update their user profile's `accentColor`.
+- If the current user (game creator) checked "Save as default," update their own user profile's `accentColor`. This uses the existing `updateAccentColor` mutation which only updates the authenticated user's own profile — no new permission model needed.
 - The existing `resolvePlayerColor` / `assignColorsToPlayers` pipeline on the game page finds colors already set (instead of auto-assigning).
 
 ### Mockup
@@ -96,7 +102,7 @@ A visual mockup of this flow is saved at `.superpowers/brainstorm/` in the proje
 - **No feature flag removal:** The `scoring-revamp` flag remains active. Full removal deferred to a future plan.
 - **Bottom-up ordering:** Extract shared code first, fix gating second, build ColorPrompt third.
 - **Conflict resolution by list order:** Consistent with how `assignColorsToPlayers` already works on the game page.
-- **"Save as default" only for registered users:** Guests have no profile to persist to.
+- **"Save as default" only for the game creator:** Only the authenticated user can update their own profile. Other registered users' colors are saved to the game record only — no delegated profile edits.
 
 ## Open Questions
 

--- a/docs/superpowers/specs/2026-03-28-scoring-revamp-plan-5-cleanup-design.md
+++ b/docs/superpowers/specs/2026-03-28-scoring-revamp-plan-5-cleanup-design.md
@@ -1,0 +1,107 @@
+# Scoring Revamp Plan 5: Cleanup, Deduplication & Color Prompt
+
+## What We're Building
+
+Plan 5 completes the scoring revamp with three workstreams: extract duplicated code into shared utilities, fix the feature flag gating so old and new UI don't render simultaneously, and wire the ColorPrompt into the game creation flow so players choose their deck colors before a game starts.
+
+## Why This Approach
+
+Bottom-up ordering (extract, then fix gating, then build feature) ensures each step lands on clean foundations. Extractions are safe refactors with test coverage. The flag gating fix is a one-line structural change. The ColorPrompt is the only net-new feature — built last on top of deduplicated code.
+
+Legacy code is **not** deleted in this plan. The feature flag stays in place so the old UI remains available for testing. Full removal will happen in a future plan once the new UI has been validated in production.
+
+## Section 1: Code Extractions
+
+### 1a. `findPlayerScore` utility
+
+Extract the identical `findPlayerScore` function from `BetweenRoundsView.tsx:36` and `ScoringShell.tsx:160` into `src/components/scoring/utils.ts`. Pure function — takes a player and a round's scores array, returns the matching score entry by matching `userId` or `guestId`.
+
+### 1b. `useRoundEditing` hook
+
+Extract the duplicated round editing logic from `BetweenRoundsView` and `ScoringShell` into `src/components/scoring/useRoundEditing.ts`.
+
+Duplicated state and handlers:
+- `editingRoundIndex` state (`useState<number | null>`)
+- `handleEditRound` callback (sets index, tracks PostHog event)
+- `handleSaveEdit` callback (calls `editRoundScores` mutation, resets state, refreshes router)
+
+The hook takes `gameId`, `rounds`, and `players` as inputs. Returns `{ editingRoundIndex, handleEditRound, handleSaveEdit }`.
+
+### 1c. `breakTie` function
+
+Extract the tie-breaking logic duplicated in `src/lib/gameLogic.ts:determineWinner` and `src/server/mutations/rounds.ts` (winner-update-after-edit) into a shared pure function in `src/lib/scoring/tiebreak.ts`.
+
+Both callers invoke the extracted function instead of implementing tie-breaking inline.
+
+### 1d. Shared `RoundData` type
+
+The rounds prop shape is repeated across `ScoringShellProps`, `BetweenRoundsViewProps`, and `GameOverViewProps`:
+
+```typescript
+{ id: string; scores: { userId?: string; guestId?: string; blitzPileRemaining: number; totalCardsPlayed: number }[] }[]
+```
+
+Define this once in `src/components/scoring/types.ts` (which already exists) and reference it from all three component prop interfaces.
+
+## Section 2: Fix Feature Flag Gating
+
+The game page (`src/app/games/[id]/page.tsx`) currently renders `ScoreDisplay` unconditionally (line 121-126), outside the feature flag conditional. When the `scoring-revamp` flag is on, both the old score table and the new `ScoringShell` render simultaneously.
+
+**Fix:** Move `ScoreDisplay` inside the flag-off branch so it only renders when the old UI is active.
+
+Result:
+- Flag on: `ScoringShell` only (gated by `canViewScoringShell`)
+- Flag off: `ScoreDisplay` + `ScoreEntry` (existing behavior)
+
+No files are deleted. All legacy components remain in place.
+
+## Section 3: ColorPrompt Integration
+
+Wire the existing `ColorPrompt` and `ColorPicker` components (built in Plan 1, currently only used in dev workbench) into the game creation flow.
+
+### Flow
+
+The game creation page (`src/app/games/new/newGameChooser.tsx`) currently has two sections: player selection and win threshold. After clicking "Start Game," the game is created immediately.
+
+**New behavior:** "Start Game" becomes "Next" and reveals a color selection step. The color step shows all players with a color picker for each. "Back" returns to the player/threshold step. "Start Game" on the color step creates the game with the chosen colors.
+
+### Per-player behavior
+
+- **Registered users with a saved `accentColor`:** Pre-filled with their default. "Save as my default color" checkbox shown (checked by default). Override allowed.
+- **Registered users without a saved color:** Auto-picks the first available unselected color. "Save as my default color" checkbox shown (checked by default).
+- **Guest users:** Auto-picks the first available unselected color. No "Save as default" checkbox — color saved to game record only. Shows italic note: "Color saved to this game only."
+
+### Conflict resolution
+
+Players are processed top-to-bottom in list order. First player with a given saved default wins it. Later players whose default conflicts are auto-bumped to the next available color. No error message — the picker just shows the fallback pre-selected. The creator can manually adjust any player's color.
+
+### Taken color handling
+
+Each player's picker dims and disables colors already selected by players above them in the list. A player can always see and select any color not taken by another player.
+
+### Data flow
+
+On confirm:
+- Each player's chosen color is passed to the `createGame` mutation as `accentColor` on the game-player record.
+- For registered users with "Save as default" checked, also update their user profile's `accentColor`.
+- The existing `resolvePlayerColor` / `assignColorsToPlayers` pipeline on the game page finds colors already set (instead of auto-assigning).
+
+### Mockup
+
+A visual mockup of this flow is saved at `.superpowers/brainstorm/` in the project directory (served via the brainstorming visual companion during design).
+
+## Key Decisions
+
+- **No legacy deletion:** Old components stay for rollback safety while testing the new UI behind the flag.
+- **No feature flag removal:** The `scoring-revamp` flag remains active. Full removal deferred to a future plan.
+- **Bottom-up ordering:** Extract shared code first, fix gating second, build ColorPrompt third.
+- **Conflict resolution by list order:** Consistent with how `assignColorsToPlayers` already works on the game page.
+- **"Save as default" only for registered users:** Guests have no profile to persist to.
+
+## Open Questions
+
+- None — all decisions resolved during brainstorming.
+
+## Next Steps
+
+Proceed to implementation planning via writing-plans skill.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 import {withSentryConfig} from "@sentry/nextjs";
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  allowedDevOrigins: ["192.168.7.249"],
   async rewrites() {
     return [
       {

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -118,12 +118,14 @@ export default async function GameView(props: {
           Playing to {game.winThreshold} points
         </p>
       )}
-      <ScoreDisplay
-        displayScores={displayScores}
-        numRounds={game.rounds.length}
-        gameId={game.id}
-        isFinished={game.isFinished}
-      />
+      {!(useScoringRevamp && canViewScoringShell) && (
+        <ScoreDisplay
+          displayScores={displayScores}
+          numRounds={game.rounds.length}
+          gameId={game.id}
+          isFinished={game.isFinished}
+        />
+      )}
       {useScoringRevamp ? (
         <>
           {canViewScoringShell && (

--- a/src/app/games/new/newGameChooser.tsx
+++ b/src/app/games/new/newGameChooser.tsx
@@ -9,7 +9,7 @@ import { type ColorStepPlayer } from "@/components/scoring/useGameColors";
 import { saveUserAccentColor } from "@/server/mutations/games";
 import { GAME_RULES } from "@/lib/validation/gameRules";
 import { cn } from "@/lib/utils";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 // UI Components
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
@@ -59,7 +59,8 @@ export default function NewGameChooser({
 }: NewGameChooserProps) {
   const [inGamePlayers, setInGamePlayers] = useState<GamePlayer[]>([]);
   const [open, setOpen] = useState(false);
-  const [step, setStep] = useState<"players" | "colors">("players");
+  const searchParams = useSearchParams();
+  const step = searchParams.get("step") === "colors" ? "colors" : "players";
   const [addingPlayer, setAddingPlayer] = useState(false);
   const [activeTab, setActiveTab] = useState("existing");
   const [guestName, setGuestName] = useState("");
@@ -199,6 +200,10 @@ export default function NewGameChooser({
       }
 
       if (result && result.gameId) {
+        // Use replaceState to remove ?step=colors from history, then
+        // push the game URL. Next.js router.replace() doesn't reliably
+        // replace the history entry when crossing route boundaries.
+        window.history.replaceState(null, "", `/games/${result.gameId}`);
         router.push(`/games/${result.gameId}`);
       }
     } catch (error) {
@@ -219,7 +224,7 @@ export default function NewGameChooser({
           <GameColorStep
             players={buildColorStepPlayers()}
             onConfirm={handleCreateGame}
-            onBack={() => setStep("players")}
+            onBack={() => router.back()}
           />
         </CardContent>
       </Card>
@@ -486,7 +491,7 @@ export default function NewGameChooser({
       <CardFooter className="bg-[#f7f2e9] border-t border-[#e6d7c3] p-4 flex justify-end">
         <Button
           className="bg-[#2a6517] hover:bg-[#1d4a10] text-white font-medium px-6 h-10"
-          onClick={() => setStep("colors")}
+          onClick={() => router.push("/games/new?step=colors")}
           disabled={inGamePlayers.length < 2}
         >
           <PlayCircle className="mr-2 h-4 w-4" />

--- a/src/app/games/new/newGameChooser.tsx
+++ b/src/app/games/new/newGameChooser.tsx
@@ -4,6 +4,9 @@ import { useState, useEffect } from "react";
 import { User } from "@/generated/prisma/client";
 import { useUser } from "@clerk/nextjs";
 import { createGame } from "@/server/mutations";
+import { GameColorStep } from "@/components/scoring/GameColorStep";
+import { type ColorStepPlayer } from "@/components/scoring/useGameColors";
+import { saveUserAccentColor } from "@/server/mutations/games";
 import { GAME_RULES } from "@/lib/validation/gameRules";
 import { cn } from "@/lib/utils";
 import { useRouter } from "next/navigation";
@@ -43,7 +46,7 @@ import {
   User as UserIcon,
 } from "lucide-react";
 
-type UserSubset = Pick<User, "id" | "username" | "clerk_user_id" | "avatarUrl">;
+type UserSubset = Pick<User, "id" | "username" | "clerk_user_id" | "avatarUrl" | "accentColor">;
 
 type GamePlayer = UserSubset | { id: string; username: string; isGuest: true };
 
@@ -56,6 +59,7 @@ export default function NewGameChooser({
 }: NewGameChooserProps) {
   const [inGamePlayers, setInGamePlayers] = useState<GamePlayer[]>([]);
   const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<"players" | "colors">("players");
   const [addingPlayer, setAddingPlayer] = useState(false);
   const [activeTab, setActiveTab] = useState("existing");
   const [guestName, setGuestName] = useState("");
@@ -152,10 +156,48 @@ export default function NewGameChooser({
     return "isGuest" in player && player.isGuest === true;
   };
 
+  const buildColorStepPlayers = (): ColorStepPlayer[] => {
+    return inGamePlayers.map((player) => {
+      const isGuest = isGuestPlayer(player);
+      const isCurrent = isCurrentUser(player);
+      const defaultColor = !isGuest && "accentColor" in player
+        ? player.accentColor ?? null
+        : null;
+
+      return {
+        id: player.id,
+        name: player.username,
+        isGuest,
+        isCurrentUser: isCurrent,
+        defaultColor,
+        avatarUrl: "avatarUrl" in player ? player.avatarUrl : null,
+      };
+    });
+  };
+
   // Handle game creation and redirect
-  const handleCreateGame = async () => {
+  const handleCreateGame = async (
+    playerColors: Record<string, string>,
+    saveCreatorDefault: boolean
+  ) => {
     try {
-      const result = await createGame(inGamePlayers, winThreshold);
+      const playersWithColors = inGamePlayers.map((p) => ({
+        ...p,
+        accentColor: playerColors[p.id],
+      }));
+      const result = await createGame(playersWithColors, winThreshold);
+
+      // Fire-and-forget: saving the creator's default must not block
+      // navigation or cause a retry that duplicates the game.
+      if (saveCreatorDefault) {
+        const currentPlayer = inGamePlayers.find((p) => isCurrentUser(p));
+        if (currentPlayer && playerColors[currentPlayer.id]) {
+          saveUserAccentColor(playerColors[currentPlayer.id]).catch((e) =>
+            console.error("Failed to save default color:", e)
+          );
+        }
+      }
+
       if (result && result.gameId) {
         router.push(`/games/${result.gameId}`);
       }
@@ -163,6 +205,26 @@ export default function NewGameChooser({
       console.error("Error creating game:", error);
     }
   };
+
+  if (step === "colors") {
+    return (
+      <Card className="mx-auto shadow-md border-[#e6d7c3] max-w-md my-6">
+        <CardHeader className="bg-gradient-to-r from-[#5a341f] to-[#8b5e3c] text-white rounded-t-lg">
+          <CardTitle className="text-xl flex items-center gap-2">
+            <PlayCircle className="h-5 w-5" />
+            Choose Colors
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4">
+          <GameColorStep
+            players={buildColorStepPlayers()}
+            onConfirm={handleCreateGame}
+            onBack={() => setStep("players")}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="mx-auto shadow-md border-[#e6d7c3] max-w-md my-6">
@@ -424,11 +486,11 @@ export default function NewGameChooser({
       <CardFooter className="bg-[#f7f2e9] border-t border-[#e6d7c3] p-4 flex justify-end">
         <Button
           className="bg-[#2a6517] hover:bg-[#1d4a10] text-white font-medium px-6 h-10"
-          onClick={handleCreateGame}
+          onClick={() => setStep("colors")}
           disabled={inGamePlayers.length < 2}
         >
           <PlayCircle className="mr-2 h-4 w-4" />
-          Start Game
+          Next
         </Button>
       </CardFooter>
     </Card>

--- a/src/app/games/new/page.tsx
+++ b/src/app/games/new/page.tsx
@@ -36,6 +36,7 @@ export default async function NewGamePage() {
       username: true,
       clerk_user_id: true,
       avatarUrl: true,
+      accentColor: true,
     },
   });
 

--- a/src/app/games/new/page.tsx
+++ b/src/app/games/new/page.tsx
@@ -1,5 +1,6 @@
 "use server";
 
+import { Suspense } from "react";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import prisma from "@/server/db/db";
 import NewGameChooser from "./newGameChooser";
@@ -42,7 +43,9 @@ export default async function NewGamePage() {
 
   return (
     <main className="container mx-auto p-4">
-      <NewGameChooser users={users} />
+      <Suspense>
+        <NewGameChooser users={users} />
+      </Suspense>
     </main>
   );
 }

--- a/src/components/__tests__/scoring/utils.test.ts
+++ b/src/components/__tests__/scoring/utils.test.ts
@@ -1,0 +1,26 @@
+import { findPlayerScore } from "../../scoring/utils";
+
+const scores = [
+  { userId: "u1", guestId: null, blitzPileRemaining: 3, totalCardsPlayed: 20 },
+  { userId: null, guestId: "g1", blitzPileRemaining: 0, totalCardsPlayed: 15 },
+];
+
+describe("findPlayerScore", () => {
+  it("matches a registered user by userId", () => {
+    const player = { id: "u1", name: "Alice", color: "#3b82f6", isGuest: false, userId: "u1", score: 0 };
+    const result = findPlayerScore(player, scores);
+    expect(result).toBe(scores[0]);
+  });
+
+  it("matches a guest user by guestId", () => {
+    const player = { id: "g1", name: "Bob", color: "#ef4444", isGuest: true, guestId: "g1", score: 0 };
+    const result = findPlayerScore(player, scores);
+    expect(result).toBe(scores[1]);
+  });
+
+  it("returns undefined when no match", () => {
+    const player = { id: "u99", name: "Nobody", color: "#eab308", isGuest: false, userId: "u99", score: 0 };
+    const result = findPlayerScore(player, scores);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/components/scoring/BetweenRoundsView.tsx
+++ b/src/components/scoring/BetweenRoundsView.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useMemo, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { usePostHog } from "posthog-js/react";
 import { RaceTrack } from "./RaceTrack";
 import { Standings } from "./Standings";
@@ -13,35 +12,17 @@ import { ScoreProgressionCard } from "./graphs/ScoreProgressionCard";
 import { HotColdCard } from "./graphs/HotColdCard";
 import { WinProbabilityCard } from "./graphs/WinProbabilityCard";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
-import { updateRoundScores } from "@/server/mutations";
-import { type PlayerWithScore } from "./types";
+import { useRoundEditing } from "./useRoundEditing";
+import { findPlayerScore } from "./utils";
+import { type PlayerWithScore, type RoundData } from "./types";
 
 interface BetweenRoundsViewProps {
   gameId: string;
   players: PlayerWithScore[];
-  rounds: {
-    id: string;
-    scores: {
-      userId?: string | null;
-      guestId?: string | null;
-      blitzPileRemaining: number;
-      totalCardsPlayed: number;
-    }[];
-  }[];
+  rounds: RoundData[];
   winThreshold: number;
   nextRoundNumber: number;
   onEnterScores: () => void;
-}
-
-function findPlayerScore(
-  player: PlayerWithScore,
-  roundScores: BetweenRoundsViewProps["rounds"][0]["scores"]
-) {
-  return roundScores.find(
-    (s) =>
-      (player.userId && s.userId === player.userId) ||
-      (player.guestId && s.guestId === player.guestId)
-  );
 }
 
 export function BetweenRoundsView({
@@ -52,52 +33,14 @@ export function BetweenRoundsView({
   nextRoundNumber,
   onEnterScores,
 }: BetweenRoundsViewProps) {
-  const router = useRouter();
   const posthog = usePostHog();
-  const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(null);
-  const [editError, setEditError] = useState<string | null>(null);
+  const { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit } =
+    useRoundEditing({ gameId, rounds, players });
 
   const handleEnterScores = () => {
     posthog.capture("scoring_enter_next_round", { round_number: nextRoundNumber });
     onEnterScores();
   };
-
-  const handleEditRound = useCallback((roundIndex: number) => {
-    posthog.capture("scoring_edit_round_tapped", { round_number: roundIndex + 1 });
-    setEditError(null);
-    setEditingRoundIndex(roundIndex);
-  }, [posthog]);
-
-  const handleSaveEdit = useCallback(async (
-    updated: Record<string, { blitzPileRemaining: number; totalCardsPlayed: number }>
-  ) => {
-    if (editingRoundIndex === null || editingRoundIndex >= rounds.length) return;
-    const round = rounds[editingRoundIndex];
-    setEditError(null);
-
-    const scores = players.map((player) => {
-      const data = updated[player.id];
-      return {
-        ...(player.isGuest
-          ? { guestId: player.guestId }
-          : { userId: player.userId }),
-        blitzPileRemaining: data.blitzPileRemaining,
-        totalCardsPlayed: data.totalCardsPlayed,
-      };
-    });
-
-    try {
-      await updateRoundScores(gameId, round.id, scores);
-      posthog.capture("scoring_round_edited", {
-        game_id: gameId,
-        round_number: editingRoundIndex + 1,
-      });
-      setEditingRoundIndex(null);
-      router.refresh();
-    } catch (e) {
-      setEditError(e instanceof Error ? e.message : "Failed to save changes");
-    }
-  }, [editingRoundIndex, rounds, players, gameId, posthog, router]);
 
   // Compute derived graph data from rounds
   const { scoresByRound, deltasByRound } = useMemo(() => {
@@ -173,7 +116,7 @@ export function BetweenRoundsView({
             })
           )}
           onSave={handleSaveEdit}
-          onCancel={() => { setEditingRoundIndex(null); setEditError(null); }}
+          onCancel={cancelEdit}
         />
       )}
 

--- a/src/components/scoring/GameColorStep.tsx
+++ b/src/components/scoring/GameColorStep.tsx
@@ -1,0 +1,108 @@
+// src/components/scoring/GameColorStep.tsx
+"use client";
+
+import { useState } from "react";
+import { ColorPicker } from "./ColorPicker";
+import { useGameColors, type ColorStepPlayer } from "./useGameColors";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { PlayCircle, ArrowLeft } from "lucide-react";
+
+interface GameColorStepProps {
+  players: ColorStepPlayer[];
+  onConfirm: (colors: Record<string, string>, saveCreatorDefault: boolean) => void;
+  onBack: () => void;
+}
+
+export function GameColorStep({ players, onConfirm, onBack }: GameColorStepProps) {
+  const { colors, updateColor } = useGameColors(players);
+  const [saveAsDefault, setSaveAsDefault] = useState(true);
+
+  const getInitials = (name: string) => name.substring(0, 2).toUpperCase();
+
+  return (
+    <div className="space-y-4">
+      <div className="text-sm font-semibold text-[#5a341f] mb-1">
+        Pick a color for each player
+      </div>
+
+      {players.map((player) => {
+        const usedByOthers = Object.entries(colors)
+          .filter(([id]) => id !== player.id)
+          .map(([, c]) => c);
+
+        return (
+          <div
+            key={player.id}
+            className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-3"
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <Avatar className="h-7 w-7">
+                {player.avatarUrl ? (
+                  <AvatarImage src={player.avatarUrl} alt={player.name} />
+                ) : (
+                  <AvatarFallback className="bg-[#f0e6d2] text-[#2a0e02] text-xs">
+                    {getInitials(player.name)}
+                  </AvatarFallback>
+                )}
+              </Avatar>
+              <span className="text-sm font-semibold text-[#290806]">
+                {player.name}
+              </span>
+              {player.isCurrentUser && (
+                <span className="text-xs bg-[#f0e6d2] text-[#5a341f] px-2 py-0.5 rounded-full">
+                  You
+                </span>
+              )}
+              {player.isGuest && (
+                <span className="text-xs bg-[#e6d7c3] text-[#5a341f] px-2 py-0.5 rounded-full">
+                  Guest
+                </span>
+              )}
+            </div>
+
+            <ColorPicker
+              value={colors[player.id] ?? null}
+              onChange={(color) => updateColor(player.id, color)}
+              usedColors={usedByOthers}
+            />
+
+            {player.isCurrentUser && (
+              <label className="flex items-center gap-2 mt-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={saveAsDefault}
+                  onChange={(e) => setSaveAsDefault(e.target.checked)}
+                  className="w-4 h-4 rounded border-[#e6d7c3] accent-[#290806]"
+                />
+                <span className="text-xs text-[#8b5e3c]">
+                  Save as my default color
+                </span>
+              </label>
+            )}
+
+            {player.isGuest && (
+              <p className="text-xs text-[#b8a08c] italic mt-2">
+                Color saved to this game only
+              </p>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="flex justify-between items-center pt-2 border-t border-[#e6d7c3]">
+        <Button variant="ghost" size="sm" className="text-[#5a341f]" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back
+        </Button>
+        <Button
+          className="bg-[#2a6517] hover:bg-[#1d4a10] text-white font-medium px-6"
+          onClick={() => onConfirm(colors, saveAsDefault)}
+        >
+          <PlayCircle className="mr-2 h-4 w-4" />
+          Start Game
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scoring/GameColorStep.tsx
+++ b/src/components/scoring/GameColorStep.tsx
@@ -91,7 +91,7 @@ export function GameColorStep({ players, onConfirm, onBack }: GameColorStepProps
       })}
 
       <div className="flex justify-between items-center pt-2 border-t border-[#e6d7c3]">
-        <Button variant="ghost" size="sm" className="text-[#5a341f]" onClick={onBack}>
+        <Button type="button" variant="ghost" size="sm" className="text-[#5a341f]" onClick={onBack}>
           <ArrowLeft className="h-4 w-4 mr-1" />
           Back
         </Button>

--- a/src/components/scoring/GameOverView.tsx
+++ b/src/components/scoring/GameOverView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PlayerWithScore } from "./types";
+import { type PlayerWithScore, type RoundData } from "./types";
 import { type GameStats } from "@/lib/scoring/gameStats";
 import { RoundHistoryTable } from "./RoundHistoryTable";
 import { usePostHog } from "posthog-js/react";
@@ -9,14 +9,7 @@ interface GameOverViewProps {
   winner: PlayerWithScore;
   players: PlayerWithScore[];
   stats: GameStats;
-  rounds: {
-    scores: {
-      userId?: string | null;
-      guestId?: string | null;
-      blitzPileRemaining: number;
-      totalCardsPlayed: number;
-    }[];
-  }[];
+  rounds: RoundData[];
   onEditRound?: (roundIndex: number) => void;
   onRematch: () => void;
   onBackToCircle: () => void;

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -125,7 +125,7 @@ export function ScoringShell({
         )}
 
         {/* Inline round editor for finished games */}
-        {editingRoundIndex !== null && (
+        {editingRoundIndex !== null && editingRoundIndex < rounds.length && (
           <RoundEditor
             roundIndex={editingRoundIndex}
             players={players}

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -8,11 +8,12 @@ import { BetweenRoundsView } from "./BetweenRoundsView";
 import { CelebrationOverlay } from "./CelebrationOverlay";
 import { GameOverView } from "./GameOverView";
 import { RoundEditor } from "./RoundEditor";
-import { type PlayerWithScore } from "./types";
+import { findPlayerScore } from "./utils";
+import { useRoundEditing } from "./useRoundEditing";
+import { type PlayerWithScore, type RoundData } from "./types";
 import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { cloneGame } from "@/server/mutations/games";
-import { updateRoundScores } from "@/server/mutations/rounds";
 
 export type ScoringMode = "entry" | "betweenRounds" | "gameOver";
 
@@ -24,15 +25,7 @@ interface ScoringShellProps {
   isFinished: boolean;
   winnerId?: string;
   endedAt?: string;
-  rounds: {
-    id: string;
-    scores: {
-      userId?: string | null;
-      guestId?: string | null;
-      blitzPileRemaining: number;
-      totalCardsPlayed: number;
-    }[];
-  }[];
+  rounds: RoundData[];
 }
 
 export function ScoringShell({
@@ -61,10 +54,9 @@ export function ScoringShell({
     return Date.now() - new Date(endedAt).getTime() >= 30_000;
   });
 
-  // Editing state for game over view
-  const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(
-    null
-  );
+  // Editing state — shared hook for game-over round editing
+  const { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit } =
+    useRoundEditing({ gameId, rounds, players });
 
   if (currentRoundNumber !== prevRound) {
     setPrevRound(currentRoundNumber);
@@ -114,59 +106,7 @@ export function ScoringShell({
     router.push("/games");
   };
 
-  const handleEditRound = useCallback(
-    (roundIndex: number) => {
-      posthog.capture("scoring_edit_round_tapped", {
-        round_number: roundIndex + 1,
-      });
-      setEditingRoundIndex(roundIndex);
-    },
-    [posthog]
-  );
-
-  const handleSaveEdit = useCallback(
-    async (
-      updated: Record<
-        string,
-        { blitzPileRemaining: number; totalCardsPlayed: number }
-      >
-    ) => {
-      if (editingRoundIndex === null) return;
-      const round = rounds[editingRoundIndex];
-
-      const scores = players.map((player) => {
-        const data = updated[player.id];
-        return {
-          ...(player.isGuest
-            ? { guestId: player.guestId }
-            : { userId: player.userId }),
-          blitzPileRemaining: data.blitzPileRemaining,
-          totalCardsPlayed: data.totalCardsPlayed,
-        };
-      });
-
-      await updateRoundScores(gameId, round.id, scores);
-      posthog.capture("scoring_round_edited", {
-        game_id: gameId,
-        round_number: editingRoundIndex + 1,
-      });
-      setEditingRoundIndex(null);
-      router.refresh();
-    },
-    [editingRoundIndex, rounds, players, gameId, posthog, router]
-  );
-
   if (mode === "gameOver") {
-    const findPlayerScore = (
-      player: PlayerWithScore,
-      roundScores: ScoringShellProps["rounds"][0]["scores"]
-    ) =>
-      roundScores.find(
-        (s) =>
-          (player.userId && s.userId === player.userId) ||
-          (player.guestId && s.guestId === player.guestId)
-      );
-
     return (
       <>
         {showCelebration && winner && (
@@ -176,6 +116,12 @@ export function ScoringShell({
             winnerColor={winner.color}
             onComplete={handleCelebrationComplete}
           />
+        )}
+
+        {editError && (
+          <div className="mx-4 mb-2 p-3 bg-[#fef2f2] border border-[#fecaca] rounded-lg text-sm text-[#b91c1c]">
+            {editError}
+          </div>
         )}
 
         {/* Inline round editor for finished games */}
@@ -199,7 +145,7 @@ export function ScoringShell({
               })
             )}
             onSave={handleSaveEdit}
-            onCancel={() => setEditingRoundIndex(null)}
+            onCancel={cancelEdit}
           />
         )}
 

--- a/src/components/scoring/UndoToast.tsx
+++ b/src/components/scoring/UndoToast.tsx
@@ -25,7 +25,9 @@ export function UndoToast({
         const next = prev - (intervalMs / durationMs) * 100;
         if (next <= 0) {
           if (timerRef.current) clearInterval(timerRef.current);
-          onDismiss();
+          // Defer onDismiss out of the state updater to avoid calling
+          // setState on a parent component during React's render phase.
+          queueMicrotask(onDismiss);
           return 0;
         }
         return next;

--- a/src/components/scoring/types.ts
+++ b/src/components/scoring/types.ts
@@ -25,3 +25,15 @@ export function getEntryStatus(entry: PlayerEntry): EntryStatus {
   if (hasBlitz || hasCards) return "partial";
   return "empty";
 }
+
+export interface RoundScoreData {
+  userId?: string | null;
+  guestId?: string | null;
+  blitzPileRemaining: number;
+  totalCardsPlayed: number;
+}
+
+export interface RoundData {
+  id: string;
+  scores: RoundScoreData[];
+}

--- a/src/components/scoring/useGameColors.ts
+++ b/src/components/scoring/useGameColors.ts
@@ -1,0 +1,31 @@
+// src/components/scoring/useGameColors.ts
+"use client";
+
+import { useState, useCallback } from "react";
+import { assignColorsToPlayers } from "@/lib/scoring/colors";
+import { resolveColorCascade } from "@/lib/scoring/colorCascade";
+
+export interface ColorStepPlayer {
+  id: string;
+  name: string;
+  isGuest: boolean;
+  isCurrentUser: boolean;
+  defaultColor: string | null;
+  avatarUrl?: string | null;
+}
+
+export function useGameColors(players: ColorStepPlayer[]) {
+  const [colors, setColors] = useState<Record<string, string>>(() => {
+    const inputs = players.map((p) => ({
+      id: p.id,
+      resolvedColor: p.defaultColor,
+    }));
+    return assignColorsToPlayers(inputs);
+  });
+
+  const updateColor = useCallback((playerId: string, newColor: string) => {
+    setColors((prev) => resolveColorCascade(prev, playerId, newColor));
+  }, []);
+
+  return { colors, updateColor };
+}

--- a/src/components/scoring/useRoundEditing.ts
+++ b/src/components/scoring/useRoundEditing.ts
@@ -1,0 +1,65 @@
+// src/components/scoring/useRoundEditing.ts
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import { updateRoundScores } from "@/server/mutations/rounds";
+import { type PlayerWithScore, type RoundData } from "./types";
+
+interface UseRoundEditingParams {
+  gameId: string;
+  rounds: RoundData[];
+  players: PlayerWithScore[];
+}
+
+export function useRoundEditing({ gameId, rounds, players }: UseRoundEditingParams) {
+  const router = useRouter();
+  const posthog = usePostHog();
+  const [editingRoundIndex, setEditingRoundIndex] = useState<number | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const handleEditRound = useCallback((roundIndex: number) => {
+    posthog.capture("scoring_edit_round_tapped", { round_number: roundIndex + 1 });
+    setEditError(null);
+    setEditingRoundIndex(roundIndex);
+  }, [posthog]);
+
+  const handleSaveEdit = useCallback(async (
+    updated: Record<string, { blitzPileRemaining: number; totalCardsPlayed: number }>
+  ) => {
+    if (editingRoundIndex === null || editingRoundIndex >= rounds.length) return;
+    const round = rounds[editingRoundIndex];
+    setEditError(null);
+
+    const scores = players.map((player) => {
+      const data = updated[player.id];
+      return {
+        ...(player.isGuest
+          ? { guestId: player.guestId }
+          : { userId: player.userId }),
+        blitzPileRemaining: data.blitzPileRemaining,
+        totalCardsPlayed: data.totalCardsPlayed,
+      };
+    });
+
+    try {
+      await updateRoundScores(gameId, round.id, scores);
+      posthog.capture("scoring_round_edited", {
+        game_id: gameId,
+        round_number: editingRoundIndex + 1,
+      });
+      setEditingRoundIndex(null);
+      router.refresh();
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : "Failed to save changes");
+    }
+  }, [editingRoundIndex, rounds, players, gameId, posthog, router]);
+
+  const cancelEdit = useCallback(() => {
+    setEditingRoundIndex(null);
+    setEditError(null);
+  }, []);
+
+  return { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit };
+}

--- a/src/components/scoring/utils.ts
+++ b/src/components/scoring/utils.ts
@@ -1,0 +1,19 @@
+import { type PlayerWithScore } from "./types";
+
+type RoundScore = {
+  userId?: string | null;
+  guestId?: string | null;
+  blitzPileRemaining: number;
+  totalCardsPlayed: number;
+};
+
+export function findPlayerScore(
+  player: Pick<PlayerWithScore, "userId" | "guestId">,
+  roundScores: RoundScore[]
+) {
+  return roundScores.find(
+    (s) =>
+      (player.userId && s.userId === player.userId) ||
+      (player.guestId && s.guestId === player.guestId)
+  );
+}

--- a/src/lib/__tests__/colorCascade.test.ts
+++ b/src/lib/__tests__/colorCascade.test.ts
@@ -1,0 +1,62 @@
+import { resolveColorCascade } from "../scoring/colorCascade";
+
+describe("resolveColorCascade", () => {
+  it("sets the chosen color for the target player", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444" };
+    const result = resolveColorCascade(colors, "a", "#22c55e");
+    expect(result.a).toBe("#22c55e");
+    expect(result.b).toBe("#ef4444");
+  });
+
+  it("bumps displaced player to first unused ACCENT_COLOR", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444" };
+    // a takes red from b. After assignment: a=#ef4444, b=?
+    // Used colors: #ef4444. Free from palette: #3b82f6 (blue, index 0).
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    expect(result.a).toBe("#ef4444");
+    expect(result.b).toBe("#3b82f6"); // blue — first unused in ACCENT_COLORS order
+  });
+
+  it("never produces duplicate colors when palette has room", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444", c: "#eab308" };
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    const values = Object.values(result);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("handles no displacement when color is unoccupied", () => {
+    const colors = { a: "#3b82f6", b: "#ef4444" };
+    const result = resolveColorCascade(colors, "a", "#eab308");
+    expect(result).toEqual({ a: "#eab308", b: "#ef4444" });
+  });
+
+  it("handles displaced player getting first unused ACCENT_COLOR", () => {
+    const colors = {
+      a: "#3b82f6", // blue
+      b: "#ef4444", // red
+      c: "#eab308", // yellow
+    };
+    // a takes red from b. After assignment: a=red, b=?, c=yellow.
+    // Used colors in next state: {red, yellow}. Free from palette at index 0: blue (#3b82f6).
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    expect(result.a).toBe("#ef4444");
+    expect(result.b).toBe("#3b82f6"); // blue — first free in ACCENT_COLORS order after a vacates it
+    expect(result.c).toBe("#eab308"); // unchanged
+  });
+
+  it("falls back to freed color when palette is exhausted (7+ players)", () => {
+    const colors = {
+      a: "#3b82f6", // blue
+      b: "#ef4444", // red
+      c: "#eab308", // yellow
+      d: "#22c55e", // green
+      e: "#8b5cf6", // purple
+      f: "#f97316", // orange
+      g: "#3b82f6", // blue (wrapped — already a duplicate)
+    };
+    // a takes red from b — no free palette slot, b gets a's old color (blue)
+    const result = resolveColorCascade(colors, "a", "#ef4444");
+    expect(result.a).toBe("#ef4444");
+    expect(result.b).toBe("#3b82f6"); // gets a's freed blue
+  });
+});

--- a/src/lib/__tests__/tiebreak.test.ts
+++ b/src/lib/__tests__/tiebreak.test.ts
@@ -1,0 +1,52 @@
+import { breakTie } from "../scoring/tiebreak";
+
+describe("breakTie", () => {
+  it("returns the player with fewest blitz cards remaining", () => {
+    const candidates = [
+      { playerId: "a", blitzPileRemaining: 5 },
+      { playerId: "b", blitzPileRemaining: 2 },
+      { playerId: "c", blitzPileRemaining: 7 },
+    ];
+    expect(breakTie(candidates)).toBe("b");
+  });
+
+  it("returns the first player when all have equal remaining", () => {
+    const candidates = [
+      { playerId: "a", blitzPileRemaining: 3 },
+      { playerId: "b", blitzPileRemaining: 3 },
+    ];
+    expect(breakTie(candidates)).toBe("a");
+  });
+
+  it("returns the single candidate when only one", () => {
+    const candidates = [{ playerId: "a", blitzPileRemaining: 10 }];
+    expect(breakTie(candidates)).toBe("a");
+  });
+
+  it("uses default of 10 when blitzPileRemaining is null", () => {
+    const candidates = [
+      { playerId: "a", blitzPileRemaining: null },
+      { playerId: "b", blitzPileRemaining: 5 },
+    ];
+    expect(breakTie(candidates as any)).toBe("b");
+  });
+});
+
+describe("breakTie — rounds mutation usage pattern", () => {
+  it("selects winner from string playerIds mapped via scores", () => {
+    const topPlayers = ["user-1", "user-2"];
+    const finalRoundScores = [
+      { id: "s1", userId: "user-1", guestId: null, blitzPileRemaining: 4, totalCardsPlayed: 22 },
+      { id: "s2", userId: "user-2", guestId: null, blitzPileRemaining: 1, totalCardsPlayed: 25 },
+    ];
+
+    const candidates = topPlayers.map((pid) => {
+      const s = finalRoundScores.find(
+        (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+      );
+      return { playerId: pid, blitzPileRemaining: s?.blitzPileRemaining ?? 10 };
+    });
+
+    expect(breakTie(candidates)).toBe("user-2");
+  });
+});

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -1,6 +1,7 @@
 import { Game, User, Score, Round, GuestUser } from "@/generated/prisma/client";
 import { updateGameAsFinished } from "@/server/mutations";
 import { calculateRoundScore, isWinningScore } from "./validation/gameRules";
+import { breakTie } from "./scoring/tiebreak";
 
 export interface GameWithPlayersAndScores extends Game {
   players: {
@@ -159,23 +160,19 @@ async function determineWinner(
 
     // Tie-breaking: when multiple players have the same highest score,
     // the player with fewer blitz cards remaining in the final round wins.
+    let winnerId: string;
     if (potentialWinners.length > 1) {
       const finalRound = game.rounds[game.rounds.length - 1];
-      potentialWinners.sort((a, b) => {
-        const aScore = finalRound.scores.find(
-          (s) => s.userId === a.id || s.guestId === a.id
+      const candidates = potentialWinners.map((pw) => {
+        const score = finalRound.scores.find(
+          (s) => s.userId === pw.id || s.guestId === pw.id
         );
-        const bScore = finalRound.scores.find(
-          (s) => s.userId === b.id || s.guestId === b.id
-        );
-        return (
-          (aScore?.blitzPileRemaining ?? 10) -
-          (bScore?.blitzPileRemaining ?? 10)
-        );
+        return { playerId: pw.id, blitzPileRemaining: score?.blitzPileRemaining ?? 10 };
       });
+      winnerId = breakTie(candidates);
+    } else {
+      winnerId = potentialWinners[0].id;
     }
-
-    const winnerId = potentialWinners[0].id;
     if (!game.isFinished) {
       const winnerPlayer = game.players.find(
         (player) => player.guestId === winnerId || player.userId === winnerId

--- a/src/lib/scoring/colorCascade.ts
+++ b/src/lib/scoring/colorCascade.ts
@@ -1,0 +1,40 @@
+import { ACCENT_COLORS } from "./colors";
+
+/**
+ * Update a player's color and cascade-bump any displaced player.
+ * Returns a new color map (does not mutate the input).
+ *
+ * When fewer players than palette colors (≤6), duplicates are impossible.
+ * When palette is exhausted (7+ players), the displaced player keeps
+ * their current color — duplicates are tolerated, matching the base
+ * allocator behavior in assignColorsToPlayers (colors.ts:49).
+ */
+export function resolveColorCascade(
+  currentColors: Record<string, string>,
+  playerId: string,
+  newColor: string
+): Record<string, string> {
+  const next = { ...currentColors };
+
+  // Find who (if anyone) currently holds the new color
+  const displacedEntry = Object.entries(next).find(
+    ([id, c]) => id !== playerId && c === newColor
+  );
+
+  // Remember the outgoing color before overwriting
+  const oldColor = next[playerId];
+
+  // Assign the new color
+  next[playerId] = newColor;
+
+  // Bump the displaced player to the first available accent color.
+  // If the palette is exhausted (7+ players), fall back to the
+  // color that was just freed by the current player.
+  if (displacedEntry) {
+    const usedColors = new Set(Object.values(next));
+    const available = ACCENT_COLORS.find((c) => !usedColors.has(c.value));
+    next[displacedEntry[0]] = available ? available.value : oldColor;
+  }
+
+  return next;
+}

--- a/src/lib/scoring/tiebreak.ts
+++ b/src/lib/scoring/tiebreak.ts
@@ -1,0 +1,24 @@
+interface TieBreakCandidate {
+  playerId: string;
+  blitzPileRemaining: number;
+}
+
+/**
+ * Break a tie among players with equal scores.
+ * The player with the fewest blitz cards remaining wins.
+ * If still tied, first in the array wins (stable).
+ */
+export function breakTie(candidates: TieBreakCandidate[]): string {
+  let bestId = candidates[0].playerId;
+  let bestRemaining = candidates[0].blitzPileRemaining ?? 10;
+
+  for (let i = 1; i < candidates.length; i++) {
+    const remaining = candidates[i].blitzPileRemaining ?? 10;
+    if (remaining < bestRemaining) {
+      bestRemaining = remaining;
+      bestId = candidates[i].playerId;
+    }
+  }
+
+  return bestId;
+}

--- a/src/lib/scoring/tiebreak.ts
+++ b/src/lib/scoring/tiebreak.ts
@@ -9,6 +9,9 @@ interface TieBreakCandidate {
  * If still tied, first in the array wins (stable).
  */
 export function breakTie(candidates: TieBreakCandidate[]): string {
+  if (candidates.length === 0) {
+    throw new Error("breakTie requires at least one candidate");
+  }
   let bestId = candidates[0].playerId;
   let bestRemaining = candidates[0].blitzPileRemaining ?? 10;
 

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -12,6 +12,7 @@ export async function createGame(
     id: string;
     username?: string;
     isGuest?: boolean;
+    accentColor?: string;
   }[],
   winThreshold?: number
 ) {
@@ -90,7 +91,7 @@ export async function createGame(
       const userDefault = playerDefaults.find((p) => p.id === u.id);
       return {
         id: u.id,
-        resolvedColor: resolvePlayerColor({
+        resolvedColor: u.accentColor ?? resolvePlayerColor({
           gameColor: null,
           userDefault: userDefault?.accentColor ?? null,
         }),

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -7,6 +7,7 @@ import {
   ValidationError,
   calculateRoundScore,
 } from "@/lib/validation/gameRules";
+import { breakTie } from "@/lib/scoring/tiebreak";
 
 // Create new round with scores
 export async function createRoundForGame(
@@ -301,22 +302,14 @@ export async function updateRoundScores(
           .map(([pid]) => pid);
 
         // Tie-break by fewest blitz cards remaining in final round
-        let newWinnerId = topPlayers[0];
-        if (topPlayers.length > 1) {
-          const finalRound =
-            updatedGame.rounds[updatedGame.rounds.length - 1];
-          let bestRemaining = Infinity;
-          for (const pid of topPlayers) {
-            const s = finalRound.scores.find(
-              (sc) => (sc.userId ?? sc.guestId ?? "") === pid
-            );
-            const remaining = s?.blitzPileRemaining ?? 10;
-            if (remaining < bestRemaining) {
-              bestRemaining = remaining;
-              newWinnerId = pid;
-            }
-          }
-        }
+        const finalRound = updatedGame.rounds[updatedGame.rounds.length - 1];
+        const candidates = topPlayers.map((pid) => {
+          const s = finalRound.scores.find(
+            (sc) => (sc.userId ?? sc.guestId ?? "") === pid
+          );
+          return { playerId: pid, blitzPileRemaining: s?.blitzPileRemaining ?? 10 };
+        });
+        const newWinnerId = breakTie(candidates);
 
         if (newWinnerId && newWinnerId !== updatedGame.winnerId) {
           await prisma.game.update({


### PR DESCRIPTION
## Summary

- **Code extractions:** Deduplicated `findPlayerScore`, `breakTie`, round editing logic, and `RoundData` type — each now lives in one shared location used by BetweenRoundsView, ScoringShell, GameOverView, gameLogic.ts, and rounds.ts
- **Feature flag fix:** ScoreDisplay no longer renders alongside ScoringShell for circle members when `scoring-revamp` flag is on. Non-members/logged-out users still see the read-only ScoreDisplay.
- **Color selection step:** New 2-step game creation flow — players pick deck colors before the game starts. Cascade reassignment prevents duplicates. "Save as default" only for the game creator. Fire-and-forget save so failures don't block navigation.
- **Bug fixes from testing:** Next.js `router.replace()` ghost history entry (documented in `docs/solutions/`), UndoToast React render warning, ScoringShell game-over bounds check, `breakTie` empty-array guard

## Test plan

- [x] All 103 automated tests pass (`npm test`)
- [x] Create a new game: "Next" shows color step, colors pre-filled, cascade works, "Back" returns to players (browser back too)
- [x] Start Game creates game with chosen colors — colors visible on game page
- [x] "Save as my default" checkbox only shows for current user, not other registered users or guests
- [x] Flag on + circle member: only ScoringShell (no ScoreDisplay above it)
- [x] Flag on + logged out: ScoreDisplay still visible (read-only)
- [x] Edit a round on a finished game: error banner shows on failure, cancel clears error
- [x] Submit a round, dismiss undo toast — no React console warnings
- [x] Browser back from game page goes to `/games/new`, not `?step=colors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)