### PR TITLE
fix: createGame rejects valid players in circles with >10 members

### DIFF
--- a/src/server/__tests__/mutations.test.ts
+++ b/src/server/__tests__/mutations.test.ts
@@ -48,9 +48,11 @@ jest.mock("../db/db", () => ({
     },
     guestUser: {
       findUnique: jest.fn(),
+      create: jest.fn(),
     },
     gamePlayers: {
       create: jest.fn(),
+      createMany: jest.fn(),
     },
     $transaction: jest.fn((callback) => Promise.all(callback)),
   },
@@ -453,14 +455,26 @@ describe("Game Mutations", () => {
   });
 
   describe("createGame", () => {
-    it("should create a game with organizationId from active circle", async () => {
+    beforeEach(() => {
+      // Interactive transaction: invoke the callback with the prisma mock as tx
+      (prisma.$transaction as jest.Mock).mockImplementation(
+        async (callback: (tx: typeof prisma) => Promise<unknown>) =>
+          callback(prisma)
+      );
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({
         id: "prisma-user-id",
       });
+      (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.game.create as jest.Mock).mockResolvedValue({
         id: "new-game-id",
       });
       (prisma.gamePlayers.create as jest.Mock).mockResolvedValue({});
+      (prisma.gamePlayers.createMany as jest.Mock).mockResolvedValue({
+        count: 1,
+      });
+    });
+
+    it("should create a game with organizationId from active circle", async () => {
       // Mock Clerk membership check — player-2 has clerk ID "clerk-player-2"
       mockGetOrganizationMembershipList.mockResolvedValue({
         data: [
@@ -470,8 +484,8 @@ describe("Game Mutations", () => {
       });
       // Mock Prisma lookup of clerk_user_ids for submitted player IDs
       (prisma.user.findMany as jest.Mock).mockResolvedValue([
-        { id: "prisma-user-id", clerk_user_id: mockUserId },
-        { id: "player-2", clerk_user_id: "clerk-player-2" },
+        { id: "prisma-user-id", clerk_user_id: mockUserId, accentColor: null },
+        { id: "player-2", clerk_user_id: "clerk-player-2", accentColor: null },
       ]);
 
       const players = [
@@ -486,6 +500,89 @@ describe("Game Mutations", () => {
           organizationId: mockOrgId,
         },
       });
+      expect(result).toEqual({ gameId: "new-game-id" });
+    });
+
+    it("should add all players in a single batched write", async () => {
+      mockGetOrganizationMembershipList.mockResolvedValue({
+        data: [
+          { publicUserData: { userId: mockUserId } },
+          { publicUserData: { userId: "clerk-player-2" } },
+        ],
+      });
+      (prisma.user.findMany as jest.Mock).mockResolvedValue([
+        { id: "prisma-user-id", clerk_user_id: mockUserId, accentColor: null },
+        { id: "player-2", clerk_user_id: "clerk-player-2", accentColor: null },
+      ]);
+
+      await createGame([
+        { id: "prisma-user-id", username: "TestUser" },
+        { id: "player-2", username: "Player2" },
+      ]);
+
+      expect(prisma.gamePlayers.createMany).toHaveBeenCalledTimes(1);
+      const { data: rows } = (prisma.gamePlayers.createMany as jest.Mock).mock
+        .calls[0][0];
+      expect(rows).toEqual([
+        expect.objectContaining({
+          gameId: "new-game-id",
+          userId: "prisma-user-id",
+        }),
+        expect.objectContaining({ gameId: "new-game-id", userId: "player-2" }),
+      ]);
+      expect(prisma.gamePlayers.create).not.toHaveBeenCalled();
+    });
+
+    it("should create guest players and map them into the batched write", async () => {
+      (prisma.guestUser.create as jest.Mock).mockResolvedValue({
+        id: "guest-db-1",
+      });
+
+      await createGame([
+        { id: "temp-guest-1", username: "Guest Bob", isGuest: true },
+      ]);
+
+      expect(prisma.guestUser.create).toHaveBeenCalledWith({
+        data: {
+          name: "Guest Bob",
+          createdById: "prisma-user-id",
+          organizationId: mockOrgId,
+        },
+      });
+      expect(prisma.gamePlayers.createMany).toHaveBeenCalledTimes(1);
+      const { data: rows } = (prisma.gamePlayers.createMany as jest.Mock).mock
+        .calls[0][0];
+      expect(rows).toEqual([
+        expect.objectContaining({
+          gameId: "new-game-id",
+          guestId: "guest-db-1",
+        }),
+      ]);
+    });
+
+    it("should accept members beyond Clerk's default membership page size (#246)", async () => {
+      // 12-member circle; the selected player is the 12th member. Clerk's
+      // API returns only 10 memberships when no limit is passed.
+      const memberships = Array.from({ length: 12 }, (_, i) => ({
+        publicUserData: { userId: `clerk-member-${i + 1}` },
+      }));
+      mockGetOrganizationMembershipList.mockImplementation(
+        (params?: { limit?: number; offset?: number }) => {
+          const limit = params?.limit ?? 10;
+          const offset = params?.offset ?? 0;
+          return Promise.resolve({
+            data: memberships.slice(offset, offset + limit),
+          });
+        }
+      );
+      (prisma.user.findMany as jest.Mock).mockResolvedValue([
+        { id: "player-12", clerk_user_id: "clerk-member-12", accentColor: null },
+      ]);
+
+      const result = await createGame([
+        { id: "player-12", username: "TwelfthMember" },
+      ]);
+
       expect(result).toEqual({ gameId: "new-game-id" });
     });
 

--- a/src/server/clerkOrgs.ts
+++ b/src/server/clerkOrgs.ts
@@ -1,0 +1,35 @@
+import { clerkClient } from "@clerk/nextjs/server";
+
+const MEMBERSHIP_PAGE_SIZE = 100;
+
+/**
+ * Fetch the Clerk user IDs of every member of an organization (circle).
+ *
+ * Clerk's getOrganizationMembershipList defaults to 10 results per page,
+ * so callers that skip pagination silently miss members in larger circles.
+ */
+export async function getOrgMemberClerkIds(
+  organizationId: string
+): Promise<Set<string>> {
+  const client = await clerkClient();
+  const memberIds = new Set<string>();
+  let offset = 0;
+
+  while (true) {
+    const page = await client.organizations.getOrganizationMembershipList({
+      organizationId,
+      limit: MEMBERSHIP_PAGE_SIZE,
+      offset,
+    });
+
+    for (const membership of page.data) {
+      const memberId = membership.publicUserData?.userId;
+      if (memberId) memberIds.add(memberId);
+    }
+
+    if (page.data.length < MEMBERSHIP_PAGE_SIZE) break;
+    offset += MEMBERSHIP_PAGE_SIZE;
+  }
+
+  return memberIds;
+}

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -1,9 +1,10 @@
 "use server";
 
 import prisma from "@/server/db/db";
-import { clerkClient } from "@clerk/nextjs/server";
+import { Prisma } from "@/generated/prisma/client";
 import { after } from "next/server";
 import { getAuthenticatedUserWithOrg } from "./common";
+import { getOrgMemberClerkIds } from "../clerkOrgs";
 import { sendGameCompleteEmail, EMAIL_INTER_SEND_DELAY_MS } from "../email";
 import { resolvePlayerColor, assignColorsToPlayers } from "@/lib/scoring/colors";
 
@@ -25,106 +26,85 @@ export async function createGame(
 
   if (!currentUser) throw new Error("User not found");
 
-  // Validate that non-guest players are members of the active circle
   const regularPlayerIds = users
     .filter((u) => !u.isGuest)
     .map((u) => u.id);
 
+  // One lookup serves both membership validation and accent-color defaults
+  const regularPlayers =
+    regularPlayerIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: regularPlayerIds } },
+          select: { id: true, clerk_user_id: true, accentColor: true },
+        })
+      : [];
+
+  // Validate that non-guest players are members of the active circle
   if (regularPlayerIds.length > 0) {
-    const client = await clerkClient();
-    const memberships =
-      await client.organizations.getOrganizationMembershipList({
-        organizationId: orgId,
-      });
+    const memberClerkIds = await getOrgMemberClerkIds(orgId);
 
-    const memberClerkIds = new Set(
-      memberships.data
-        .map((m) => m.publicUserData?.userId)
-        .filter(Boolean)
-    );
-
-    // Look up clerk_user_ids for the submitted player Prisma IDs
-    const players = await prisma.user.findMany({
-      where: { id: { in: regularPlayerIds } },
-      select: { id: true, clerk_user_id: true },
-    });
-
-    for (const player of players) {
+    for (const player of regularPlayers) {
       if (!memberClerkIds.has(player.clerk_user_id)) {
         throw new Error("All players must be members of the active circle");
       }
     }
   }
 
+  // Resolve colors: game override (none at creation) > user default > auto-assign
+  const colorInputs = users.map((u) => {
+    const userDefault = regularPlayers.find((p) => p.id === u.id);
+    return {
+      id: u.id,
+      resolvedColor: u.accentColor ?? resolvePlayerColor({
+        gameColor: null,
+        userDefault: userDefault?.accentColor ?? null,
+      }),
+    };
+  });
+  const playerColors = assignColorsToPlayers(colorInputs);
+
   try {
-    // Step 1: First create a game (with optional custom win threshold)
-    const newGame = await prisma.game.create({
-      data: {
-        organizationId: orgId,
-        ...(winThreshold && winThreshold !== 75 ? { winThreshold } : {}),
-      },
-    });
+    // Game, guests, and players are created atomically so a failure part-way
+    // through can't leave an orphaned game behind
+    const newGame = await prisma.$transaction(async (tx) => {
+      const game = await tx.game.create({
+        data: {
+          organizationId: orgId,
+          ...(winThreshold && winThreshold !== 75 ? { winThreshold } : {}),
+        },
+      });
 
-    // Step 2: Create guest users if needed
-    const guestUserIds = new Map();
-    for (const player of users) {
-      if (player.isGuest && player.username) {
-        const guestUser = await prisma.guestUser.create({
-          data: {
-            name: player.username,
-            createdById: currentUser.id,
-            organizationId: orgId,
-          },
-        });
-        guestUserIds.set(player.id, guestUser.id);
-      }
-    }
-
-    // Step 3: Resolve accent colors for all players
-    // Look up accent color defaults for regular players
-    const playerDefaults = await prisma.user.findMany({
-      where: { id: { in: regularPlayerIds } },
-      select: { id: true, accentColor: true },
-    });
-
-    // Resolve colors: game override (none at creation) > user default > auto-assign
-    const colorInputs = users.map((u) => {
-      const userDefault = playerDefaults.find((p) => p.id === u.id);
-      return {
-        id: u.id,
-        resolvedColor: u.accentColor ?? resolvePlayerColor({
-          gameColor: null,
-          userDefault: userDefault?.accentColor ?? null,
-        }),
-      };
-    });
-    const playerColors = assignColorsToPlayers(colorInputs);
-
-    // Step 4: Add players to the game one by one
-    for (const player of users) {
-      if (player.isGuest) {
-        const dbGuestId = guestUserIds.get(player.id);
-        if (dbGuestId) {
-          // For guest players, omit userId entirely
-          await prisma.gamePlayers.create({
+      // Guests need individual creates to map their temporary client-side
+      // IDs to real rows (createMany does not return rows)
+      const guestDbIds = new Map<string, string>();
+      for (const player of users) {
+        if (player.isGuest && player.username) {
+          const guestUser = await tx.guestUser.create({
             data: {
-              gameId: newGame.id,
-              guestId: dbGuestId,
-              accentColor: playerColors[player.id] ?? null,
+              name: player.username,
+              createdById: currentUser.id,
+              organizationId: orgId,
             },
           });
+          guestDbIds.set(player.id, guestUser.id);
         }
-      } else {
-        // For regular players, omit guestId entirely
-        await prisma.gamePlayers.create({
-          data: {
-            gameId: newGame.id,
-            userId: player.id,
-            accentColor: playerColors[player.id] ?? null,
-          },
-        });
       }
-    }
+
+      const playerRows = users.flatMap(
+        (player): Prisma.GamePlayersCreateManyInput[] => {
+          const accentColor = playerColors[player.id] ?? null;
+          if (player.isGuest) {
+            const guestId = guestDbIds.get(player.id);
+            return guestId ? [{ gameId: game.id, guestId, accentColor }] : [];
+          }
+          return [{ gameId: game.id, userId: player.id, accentColor }];
+        }
+      );
+
+      await tx.gamePlayers.createMany({ data: playerRows });
+
+      return game;
+    });
 
     // Track event in PostHog
     posthog.capture({


### PR DESCRIPTION
Closes #246. From the 2026-06-12 codebase review.

## Bug

`createGame` called Clerk's `getOrganizationMembershipList({ organizationId })` with no `limit`/pagination. Clerk defaults to **10 results per page**, so in a circle with more than 10 members, any selected player outside the first page failed validation with *"All players must be members of the active circle"*. (The dashboard already paginated this same call correctly — the two call sites had drifted.)

## Fix

- New `src/server/clerkOrgs.ts` → `getOrgMemberClerkIds(orgId)`: paginates at 100/page until exhausted, returns a `Set` of member Clerk IDs. `createGame` now uses it. (A follow-up PR points the dashboard at this same helper.)

## Also in this PR (same code path)

- **One lookup instead of two**: membership validation and accent-color defaults shared the same `user.findMany` predicate — merged into a single select.
- **Atomic creation**: game + guest users + game players now run in one `$transaction`, so a mid-flight failure can't leave an orphaned `Game` row.
- **Batched player insert**: `gamePlayers.createMany` replaces one `create` per player (a game with N players was N+1 sequential round-trips).

## Tests (TDD — watched each fail first)

- `should accept members beyond Clerk's default membership page size (#246)` — fails on `main` with the exact production error, passes here
- `should add all players in a single batched write`
- `should create guest players and map them into the batched write`

108/108 tests, typecheck, and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)