### PR TITLE
perf: add missing index on Score.roundId

### DIFF
--- a/src/server/db/migrations/20260612000000_add_score_round_id_index/migration.sql
+++ b/src/server/db/migrations/20260612000000_add_score_round_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Score_roundId_idx" ON "Score"("roundId");

--- a/src/server/db/schema.prisma
+++ b/src/server/db/schema.prisma
@@ -80,6 +80,7 @@ model Score {
 
   @@index([userId])
   @@index([guestId])
+  @@index([roundId])
 }
 
 model GamePlayers {


### PR DESCRIPTION
Closes #247. From the 2026-06-12 codebase review.

`Score` indexes `userId` and `guestId` but not `roundId`, and Postgres doesn't auto-index FK columns. The `WHERE "roundId" IN (...)` predicate runs on **every game-detail load** (`getGameById` includes `rounds.scores`) and **every score write** (`syncGameCompletionAfterScoreWrite` reloads the full game after each submission) — the hottest read path in the app.

- `@@index([roundId])` added to the `Score` model
- Migration generated with `prisma migrate diff` (plain `CREATE INDEX`; the table is small enough that the brief lock during `migrate deploy` is a non-issue)

Schema validates; tests/typecheck/lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)