### PR TITLE
fix: surface error digests in production + gate dev routes (#110)

### DIFF
--- a/src/app/__tests__/error-boundaries.test.tsx
+++ b/src/app/__tests__/error-boundaries.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import GamesListError from "../games/error";
+import DashboardError from "../dashboard/error";
+import GameDetailError from "../games/[id]/error";
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: { captureException: jest.fn() },
+}));
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ id: "game-123" }),
+}));
+
+const makeError = () => {
+  const error = new Error("boom") as Error & { digest?: string };
+  error.digest = "digest-abc123";
+  return error;
+};
+
+// Jest runs with NODE_ENV=test — like production, anything gated to
+// NODE_ENV === "development" is hidden. Issue #110: users in prod saw a
+// generic error card with nothing reportable, because the digest was
+// inside the dev-only block.
+describe("route error boundaries outside development", () => {
+  it.each([
+    ["games list", GamesListError],
+    ["dashboard", DashboardError],
+    ["game detail", GameDetailError],
+  ])("%s boundary shows the error digest", (_name, Boundary) => {
+    render(<Boundary error={makeError()} reset={() => {}} />);
+    expect(screen.getByText(/digest-abc123/)).toBeInTheDocument();
+  });
+
+  it("does not leak the raw error message", () => {
+    render(<GamesListError error={makeError()} reset={() => {}} />);
+    expect(screen.queryByText(/boom/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/api/dev/route.ts
+++ b/src/app/api/dev/route.ts
@@ -2,6 +2,11 @@ import { auth, currentUser } from "@clerk/nextjs/server";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
+  // Debug endpoint — never reachable in production
+  if (process.env.NODE_ENV !== "development") {
+    return new NextResponse(null, { status: 404 });
+  }
+
   const { userId } = await auth();
   const user = await currentUser();
 

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -51,12 +51,12 @@ export default function DashboardError({
           {process.env.NODE_ENV === "development" && (
             <pre className="p-4 mt-4 overflow-auto text-sm bg-muted rounded-md">
               {error.message}
-              {error.digest && (
-                <div className="mt-2 text-xs text-muted-foreground">
-                  Error ID: {error.digest}
-                </div>
-              )}
             </pre>
+          )}
+          {error.digest && (
+            <p className="mt-4 text-xs text-muted-foreground">
+              Error ID: {error.digest}
+            </p>
           )}
         </CardContent>
         <CardFooter className="flex justify-between">

--- a/src/app/dev/debug/page.tsx
+++ b/src/app/dev/debug/page.tsx
@@ -1,8 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { cookies } from "next/headers";
 
 export default async function DebugPage() {
+  // Debug page — never reachable in production
+  if (process.env.NODE_ENV !== "development") {
+    notFound();
+  }
+
   const { userId } = await auth();
   const cookieStore = await cookies();
 

--- a/src/app/dev/error-test/page.tsx
+++ b/src/app/dev/error-test/page.tsx
@@ -1,6 +1,12 @@
 import ErrorTestTrigger from "@/components/ErrorTestTrigger";
+import { notFound } from "next/navigation";
 
 export default function ErrorTestPage() {
+  // Error-testing page — never reachable in production
+  if (process.env.NODE_ENV !== "development") {
+    notFound();
+  }
+
   return (
     <div className="container py-8 max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold mb-6">Error Tracking Test Page</h1>

--- a/src/app/games/[id]/error.tsx
+++ b/src/app/games/[id]/error.tsx
@@ -59,12 +59,12 @@ export default function GameDetailError({
           {process.env.NODE_ENV === "development" && (
             <pre className="p-4 mt-4 overflow-auto text-sm bg-muted rounded-md">
               {error.message}
-              {error.digest && (
-                <div className="mt-2 text-xs text-muted-foreground">
-                  Error ID: {error.digest}
-                </div>
-              )}
             </pre>
+          )}
+          {error.digest && (
+            <p className="mt-4 text-xs text-muted-foreground">
+              Error ID: {error.digest}
+            </p>
           )}
         </CardContent>
         <CardFooter className="flex justify-between">

--- a/src/app/games/error.tsx
+++ b/src/app/games/error.tsx
@@ -51,12 +51,12 @@ export default function GamesListError({
           {process.env.NODE_ENV === "development" && (
             <pre className="p-4 mt-4 overflow-auto text-sm bg-muted rounded-md">
               {error.message}
-              {error.digest && (
-                <div className="mt-2 text-xs text-muted-foreground">
-                  Error ID: {error.digest}
-                </div>
-              )}
             </pre>
+          )}
+          {error.digest && (
+            <p className="mt-4 text-xs text-muted-foreground">
+              Error ID: {error.digest}
+            </p>
           )}
         </CardContent>
         <CardFooter className="flex justify-between">

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -52,12 +52,12 @@ export default function GlobalError({
             {process.env.NODE_ENV === "development" && (
               <pre className="p-4 mt-4 overflow-auto text-sm bg-muted rounded-md">
                 {error.message}
-                {error.digest && (
-                  <div className="mt-2 text-xs text-muted-foreground">
-                    Error ID: {error.digest}
-                  </div>
-                )}
               </pre>
+            )}
+            {error.digest && (
+              <p className="mt-4 text-xs text-muted-foreground">
+                Error ID: {error.digest}
+              </p>
             )}
           </CardContent>
           <CardFooter className="flex justify-center">


### PR DESCRIPTION
Closes #110. From the 2026-06-12 codebase review.

## Why detailed errors "weren't passing through" in prod

All four error boundaries (`global-error.tsx`, `games/error.tsx`, `games/[id]/error.tsx`, `dashboard/error.tsx`) rendered error details only when `NODE_ENV === "development"` — including `error.digest`. Next.js masks server error messages in prod *by design* and hands you the digest precisely so users can report it; hiding the digest too meant prod users saw "Something went wrong" with nothing actionable, while Sentry held a digest nobody could cross-reference.

## Changes

- **Digest always visible** in all four boundaries (`Error ID: <digest>`); raw `error.message` stays dev-only, so nothing internal leaks.
- **Dev surfaces gated out of production**:
  - `/api/dev` — returned full Clerk user object to any signed-in user in prod → now 404 outside development
  - `/dev/debug` — auth-gated only → now `notFound()` outside development
  - `/dev/error-test` — had **no gate at all** (anyone could fire test errors into Sentry/PostHog from prod) → now `notFound()` outside development

## Tests (TDD)

New `src/app/__tests__/error-boundaries.test.tsx` (Jest runs `NODE_ENV=test`, matching prod behavior for these gates):
- each section boundary shows the digest — failed before, passes now
- raw error message is not rendered — guards against over-correcting

109/109 tests, typecheck, lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)