### PR TITLE
perf: parallelize dashboard stats, stream the invite banner

### DIFF
--- a/src/app/dashboard/_components/InviteBannerSection.tsx
+++ b/src/app/dashboard/_components/InviteBannerSection.tsx
@@ -1,0 +1,71 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import prisma from "@/server/db/db";
+import legacyFriends from "@/data/legacy-friends.json";
+import InviteFriendsBanner from "@/components/InviteFriendsBanner";
+import { getOrgMemberClerkIds } from "@/server/clerkOrgs";
+
+const friendMap = legacyFriends as Record<
+  string,
+  { username: string; email: string }[]
+>;
+
+const INVITATION_PAGE_SIZE = 100;
+
+async function getCircleMemberEmails(orgId: string): Promise<Set<string>> {
+  const memberClerkIds = await getOrgMemberClerkIds(orgId);
+  if (memberClerkIds.size === 0) return new Set();
+
+  const memberUsers = await prisma.user.findMany({
+    where: { clerk_user_id: { in: [...memberClerkIds] } },
+    select: { email: true },
+  });
+  return new Set(memberUsers.map((u) => u.email.toLowerCase()));
+}
+
+async function getPendingInvitationEmails(orgId: string): Promise<Set<string>> {
+  const client = await clerkClient();
+  const pendingEmails = new Set<string>();
+  let offset = 0;
+
+  while (true) {
+    const page = await client.organizations.getOrganizationInvitationList({
+      organizationId: orgId,
+      status: ["pending"],
+      limit: INVITATION_PAGE_SIZE,
+      offset,
+    });
+    for (const invitation of page.data) {
+      pendingEmails.add(invitation.emailAddress.toLowerCase());
+    }
+    if (page.data.length < INVITATION_PAGE_SIZE) break;
+    offset += INVITATION_PAGE_SIZE;
+  }
+
+  return pendingEmails;
+}
+
+async function getUninvitedFriendCount(): Promise<number> {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return 0;
+
+  const allFriends = friendMap[userId] ?? [];
+  if (allFriends.length === 0) return 0;
+
+  const [memberEmails, pendingEmails] = await Promise.all([
+    getCircleMemberEmails(orgId),
+    getPendingInvitationEmails(orgId),
+  ]);
+
+  return allFriends.filter(
+    (friend) =>
+      !memberEmails.has(friend.email.toLowerCase()) &&
+      !pendingEmails.has(friend.email.toLowerCase())
+  ).length;
+}
+
+// The uninvited-friend count needs two paginated Clerk API sweeps, so it
+// lives in its own async component: the dashboard stats render immediately
+// and the banner streams in behind a Suspense boundary.
+export default async function InviteBannerSection() {
+  return <InviteFriendsBanner uninvitedCount={await getUninvitedFriendCount()} />;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,91 +1,32 @@
+import { Suspense } from "react";
 import {
   getPlayerBattingAverage,
   getHighestAndLowestScore,
   getCumulativeScore,
   getLongestAndShortestGamesByRounds,
 } from "@/server/queries";
-import { auth, clerkClient } from "@clerk/nextjs/server";
-import prisma from "@/server/db/db";
-import legacyFriends from "@/data/legacy-friends.json";
 import BasicStatBlock from "@/components/BasicStatBlock";
-import InviteFriendsBanner from "@/components/InviteFriendsBanner";
-
-const friendMap = legacyFriends as Record<
-  string,
-  { username: string; email: string }[]
->;
+import InviteBannerSection from "./_components/InviteBannerSection";
 
 export default async function Dashboard() {
-  const battingAverage = await getPlayerBattingAverage();
-  const { highest, lowest } = await getHighestAndLowestScore();
-  const cumulativeScore = await getCumulativeScore();
-  const { longest, shortest } = await getLongestAndShortestGamesByRounds();
-
-  // Compute uninvited friend count for the banner
-  // Paginate Clerk API calls (defaults to 10 per page)
-  let uninvitedCount = 0;
-  const { userId, orgId } = await auth();
-  if (userId && orgId) {
-    const allFriends = friendMap[userId] ?? [];
-    if (allFriends.length > 0) {
-      const client = await clerkClient();
-
-      const memberClerkIds: string[] = [];
-      let memberOffset = 0;
-      while (true) {
-        const page =
-          await client.organizations.getOrganizationMembershipList({
-            organizationId: orgId,
-            limit: 100,
-            offset: memberOffset,
-          });
-        for (const m of page.data) {
-          if (m.publicUserData?.userId) {
-            memberClerkIds.push(m.publicUserData.userId);
-          }
-        }
-        if (page.data.length < 100) break;
-        memberOffset += 100;
-      }
-
-      const memberUsers = memberClerkIds.length > 0
-        ? await prisma.user.findMany({
-            where: { clerk_user_id: { in: memberClerkIds } },
-            select: { email: true },
-          })
-        : [];
-      const memberEmails = new Set(
-        memberUsers.map((u) => u.email.toLowerCase())
-      );
-
-      const pendingEmails = new Set<string>();
-      let inviteOffset = 0;
-      while (true) {
-        const page =
-          await client.organizations.getOrganizationInvitationList({
-            organizationId: orgId,
-            status: ["pending"],
-            limit: 100,
-            offset: inviteOffset,
-          });
-        for (const inv of page.data) {
-          pendingEmails.add(inv.emailAddress.toLowerCase());
-        }
-        if (page.data.length < 100) break;
-        inviteOffset += 100;
-      }
-
-      uninvitedCount = allFriends.filter(
-        (f) =>
-          !memberEmails.has(f.email.toLowerCase()) &&
-          !pendingEmails.has(f.email.toLowerCase())
-      ).length;
-    }
-  }
+  // The four stats are independent — fetch them in parallel
+  const [
+    battingAverage,
+    { highest, lowest },
+    cumulativeScore,
+    { longest, shortest },
+  ] = await Promise.all([
+    getPlayerBattingAverage(),
+    getHighestAndLowestScore(),
+    getCumulativeScore(),
+    getLongestAndShortestGamesByRounds(),
+  ]);
 
   return (
     <section className="border-zinc-500 p-5">
-      <InviteFriendsBanner uninvitedCount={uninvitedCount} />
+      <Suspense fallback={null}>
+        <InviteBannerSection />
+      </Suspense>
       <div className="mb-4">
         <BasicStatBlock
           label="Batting Average"


### PR DESCRIPTION
Refs #30 (first Suspense/streaming boundary). From the 2026-06-12 codebase review. **Stacked on #249** — merge that first (GitHub will retarget this to main).

## Before

`dashboard/page.tsx` did, in series, all blocking first paint:
1. four independent stats queries, awaited one at a time
2. a paginated Clerk member-list sweep
3. a Prisma email lookup
4. a paginated Clerk invitation sweep

Worst-case latency ≈ sum of all seven round-trips.

## After

- The four stats queries run in `Promise.all` — latency ≈ the slowest query.
- The legacy-friends invite counting moves into `dashboard/_components/InviteBannerSection.tsx`, an async server component behind `<Suspense fallback={null}>`: stats paint immediately, the banner streams in when Clerk responds.
- Inside the section, member emails and pending invitations fetch in parallel, and the member sweep reuses `getOrgMemberClerkIds()` from #249 instead of a hand-rolled pagination loop.

Behavior is unchanged (same count, same banner) — this is pure re-composition, so no new unit tests; existing suite, typecheck, and lint pass.

Note: this whole banner exists to migrate pre-Circles friends — flagged separately in the review as a candidate for retirement, at which point this section deletes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)