### PR TITLE
perf: cache server-side feature-flag lookups (#200)

### DIFF
--- a/src/__tests__/featureFlags.test.ts
+++ b/src/__tests__/featureFlags.test.ts
@@ -1,0 +1,95 @@
+const mockGetAllFlags = jest.fn();
+jest.mock("@/app/posthog", () => ({
+  __esModule: true,
+  default: () => ({ getAllFlags: mockGetAllFlags }),
+}));
+
+const mockAuth = jest.fn();
+const mockCurrentUser = jest.fn();
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: () => mockAuth(),
+  currentUser: () => mockCurrentUser(),
+}));
+
+// Each test re-imports the module after resetModules so the per-instance
+// flag cache starts empty.
+async function importFlags() {
+  return import("@/featureFlags");
+}
+
+describe("isFeatureEnabled (#200 — server-side flag caching)", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: "user-1" });
+    mockCurrentUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: "user-1@example.com" },
+      username: "user-one",
+    });
+    mockGetAllFlags.mockResolvedValue({ "llm-features": true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the flag value for an authenticated user", async () => {
+    const { isFeatureEnabled } = await importFlags();
+    await expect(isFeatureEnabled("llm-features")).resolves.toBe(true);
+    await expect(isFeatureEnabled("missing-flag")).resolves.toBe(false);
+  });
+
+  it("fetches flags from Clerk + PostHog only once per user within the TTL", async () => {
+    const { isFeatureEnabled } = await importFlags();
+
+    await isFeatureEnabled("llm-features");
+    await isFeatureEnabled("llm-features");
+    await isFeatureEnabled("scoring-revamp");
+
+    expect(mockGetAllFlags).toHaveBeenCalledTimes(1);
+    expect(mockCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after the TTL expires", async () => {
+    jest.useFakeTimers();
+    const { isFeatureEnabled } = await importFlags();
+
+    await isFeatureEnabled("llm-features");
+    jest.advanceTimersByTime(61_000);
+    await isFeatureEnabled("llm-features");
+
+    expect(mockGetAllFlags).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches per user, not globally", async () => {
+    const { isFeatureEnabled } = await importFlags();
+
+    mockAuth.mockResolvedValueOnce({ userId: "user-1" });
+    await isFeatureEnabled("llm-features");
+    mockAuth.mockResolvedValueOnce({ userId: "user-2" });
+    await isFeatureEnabled("llm-features");
+
+    expect(mockGetAllFlags).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failed fetches", async () => {
+    const { isFeatureEnabled } = await importFlags();
+
+    mockGetAllFlags.mockRejectedValueOnce(new Error("posthog down"));
+    await expect(isFeatureEnabled("llm-features")).rejects.toThrow(
+      "posthog down"
+    );
+
+    await expect(isFeatureEnabled("llm-features")).resolves.toBe(true);
+    expect(mockGetAllFlags).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns false for unauthenticated users without calling PostHog", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const { isFeatureEnabled } = await importFlags();
+
+    await expect(isFeatureEnabled("llm-features")).resolves.toBe(false);
+    expect(mockGetAllFlags).not.toHaveBeenCalled();
+    expect(mockCurrentUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -1,13 +1,19 @@
 import PostHogClient from "./app/posthog";
 import { auth, currentUser } from "@clerk/nextjs/server";
 
-// Server-side flag checking
-export async function isFeatureEnabled(flagKey: string): Promise<boolean> {
-  const { userId } = await auth();
+// Every uncached flag check costs two network calls (Clerk currentUser +
+// PostHog getAllFlags) and runs on hot paths like the game page, so flag
+// sets are cached per user for a short TTL within each server instance.
+const FLAG_CACHE_TTL_MS = 60_000;
 
-  // Only check flags for authenticated users
-  if (!userId) return false;
+type FlagSet = Record<string, string | boolean>;
 
+const flagCache = new Map<
+  string,
+  { flags: Promise<FlagSet>; expiresAt: number }
+>();
+
+async function fetchAllFlags(userId: string): Promise<FlagSet> {
   // Fetch person properties so flags targeted by email/username resolve
   // correctly on the server (posthog-node won't hit stored person props
   // unless we pass them, which causes preview/new envs to miss).
@@ -18,8 +24,34 @@ export async function isFeatureEnabled(flagKey: string): Promise<boolean> {
   if (user?.username) personProperties.username = user.username;
 
   const posthog = PostHogClient();
-  const flags = await posthog.getAllFlags(userId, { personProperties });
+  return posthog.getAllFlags(userId, { personProperties });
+}
 
+function getCachedFlags(userId: string): Promise<FlagSet> {
+  const now = Date.now();
+  const cached = flagCache.get(userId);
+  if (cached && cached.expiresAt > now) {
+    return cached.flags;
+  }
+
+  // Cache the promise immediately so concurrent checks share one fetch;
+  // evict on failure so an outage isn't cached for the full TTL.
+  const flags = fetchAllFlags(userId).catch((error) => {
+    flagCache.delete(userId);
+    throw error;
+  });
+  flagCache.set(userId, { flags, expiresAt: now + FLAG_CACHE_TTL_MS });
+  return flags;
+}
+
+// Server-side flag checking
+export async function isFeatureEnabled(flagKey: string): Promise<boolean> {
+  const { userId } = await auth();
+
+  // Only check flags for authenticated users
+  if (!userId) return false;
+
+  const flags = await getCachedFlags(userId);
   return !!flags[flagKey];
 }
 


### PR DESCRIPTION
Closes #200. From the 2026-06-12 codebase review.

## Problem

`isFeatureEnabled()` in `src/featureFlags.ts` cost **two network calls per check** — `currentUser()` (Clerk API, for person properties) plus `posthog.getAllFlags()` — with no caching anywhere. It gates the game detail page (`scoring-revamp`), the hottest route in the app, so every game view paid both round-trips.

## Fix

Per-user in-memory cache with a 60s TTL inside each server instance:
- the **promise** is cached, so concurrent checks during a burst share one in-flight fetch
- failed fetches are evicted immediately (an outage isn't cached for the TTL)
- flag changes in PostHog propagate within 60s — acceptable for these flags

On the client side (the other half of issue #200): `useFeatureFlag` wraps PostHog's `useFeatureFlagEnabled`, which already subscribes to the SDK's cached flag store rather than fetching per render — no change needed there.

## Tests (TDD)

New `src/__tests__/featureFlags.test.ts` — the driver (`fetches flags only once per user within the TTL`) failed on main with 3 fetches, passes with 1. Guards: TTL expiry refetches, per-user isolation, failure non-caching, unauthenticated short-circuit.

111/111 tests, typecheck, lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)