### PR TITLE
refactor: one deep module owns the Round scoring formula (#222)

### DIFF
--- a/src/app/api/slack/whois/route.ts
+++ b/src/app/api/slack/whois/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/server/db/db";
 import crypto from "crypto";
+import { calculateCumulativeScore } from "@/lib/validation/gameRules";
 
 // Slack slash command payload interface
 interface SlackCommand {
@@ -105,9 +106,12 @@ async function getUserStats(userId: string) {
     },
   });
 
-  const cumulativeScore = scoreAgg._sum.totalCardsPlayed && scoreAgg._sum.blitzPileRemaining
-    ? scoreAgg._sum.totalCardsPlayed - (scoreAgg._sum.blitzPileRemaining * 2)
-    : 0;
+  // ?? instead of && — a user who always blitzed has a legitimate sum of 0
+  // blitz cards remaining, which the old truthiness check scored as 0 total
+  const cumulativeScore = calculateCumulativeScore({
+    totalCardsPlayed: scoreAgg._sum.totalCardsPlayed ?? 0,
+    blitzPileRemaining: scoreAgg._sum.blitzPileRemaining ?? 0,
+  });
 
   // Get last activity date
   const lastGame = await prisma.game.findFirst({

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -5,8 +5,10 @@ import {
   isValidBlitz,
   hasBlitz,
   calculateRoundScore,
+  calculateCumulativeScore,
   isWinningScore,
   GAME_RULES,
+  ROUND_SCORE_SQL,
 } from "../validation/gameRules";
 import { type Score, type ScoreValidation } from "../validation/schema";
 
@@ -129,6 +131,54 @@ describe("Game Rules", () => {
 
       expect(hasBlitz(scoresWithBlitz)).toBe(true);
       expect(hasBlitz(scoresWithoutBlitz)).toBe(false);
+    });
+  });
+
+  describe("Cumulative Scores", () => {
+    it("should compute the cumulative score from summed totals", () => {
+      expect(
+        calculateCumulativeScore({
+          totalCardsPlayed: 100,
+          blitzPileRemaining: 20,
+        })
+      ).toBe(60); // 100 - (20 * 2)
+    });
+
+    it("should equal the sum of per-round scores (the formula is linear)", () => {
+      const rounds = [
+        { blitzPileRemaining: 0, totalCardsPlayed: 12 },
+        { blitzPileRemaining: 3, totalCardsPlayed: 20 },
+        { blitzPileRemaining: 10, totalCardsPlayed: 0 },
+      ];
+
+      const summedPerRound = rounds.reduce(
+        (total, round) => total + calculateRoundScore(round),
+        0
+      );
+      const totals = rounds.reduce(
+        (acc, round) => ({
+          totalCardsPlayed: acc.totalCardsPlayed + round.totalCardsPlayed,
+          blitzPileRemaining:
+            acc.blitzPileRemaining + round.blitzPileRemaining,
+        }),
+        { totalCardsPlayed: 0, blitzPileRemaining: 0 }
+      );
+
+      expect(calculateCumulativeScore(totals)).toBe(summedPerRound);
+    });
+
+    it("should score a perfect blitz run as total cards played", () => {
+      expect(
+        calculateCumulativeScore({ totalCardsPlayed: 42, blitzPileRemaining: 0 })
+      ).toBe(42);
+    });
+  });
+
+  describe("Canonical SQL fragment", () => {
+    it("embeds the blitz penalty multiplier from GAME_RULES", () => {
+      expect(ROUND_SCORE_SQL).toBe(
+        `("totalCardsPlayed" - ("blitzPileRemaining" * ${GAME_RULES.BLITZ_PENALTY_MULTIPLIER}))`
+      );
     });
   });
 });

--- a/src/lib/validation/gameRules.ts
+++ b/src/lib/validation/gameRules.ts
@@ -68,6 +68,22 @@ export function calculateRoundScore(score: Score | ScoreValidation): number {
   );
 }
 
+// Cumulative score across many rounds, from pre-summed totals. The formula
+// is linear, so the aggregate form is the per-round form applied to sums —
+// delegating makes that explicit and keeps one owner for the arithmetic.
+export function calculateCumulativeScore(totals: {
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
+}): number {
+  return calculateRoundScore(totals);
+}
+
+// Canonical SQL expression for a single-round score. Server queries
+// interpolate this with Prisma.raw() instead of re-inlining the formula;
+// it is derived from GAME_RULES so the SQL and TS forms cannot drift.
+// (Plain string on purpose — this module is also imported client-side.)
+export const ROUND_SCORE_SQL = `("totalCardsPlayed" - ("blitzPileRemaining" * ${GAME_RULES.BLITZ_PENALTY_MULTIPLIER}))`;
+
 // Check if score meets winning threshold
 export function isWinningScore(total: number, threshold: number = GAME_RULES.POINTS_TO_WIN): boolean {
   return total >= threshold;

--- a/src/server/__tests__/queries.test.ts
+++ b/src/server/__tests__/queries.test.ts
@@ -33,13 +33,14 @@ jest.mock("../db/db", () => {
   };
 });
 
-// Mock Prisma.sql template literal tag
+// Mock Prisma.sql template literal tag and Prisma.raw
 jest.mock("@/generated/prisma/client", () => ({
   Prisma: {
     sql: jest.fn((strings, ...values) => ({
       strings,
       values,
     })),
+    raw: jest.fn((value) => ({ raw: value })),
   },
 }));
 

--- a/src/server/ai/enhancedSystemPrompt.ts
+++ b/src/server/ai/enhancedSystemPrompt.ts
@@ -3,6 +3,7 @@
  */
 
 import { getUserGameSummary, getUserStats } from "./utils";
+import { GAME_RULES } from "@/lib/validation/gameRules";
 
 export async function buildEnhancedSystemPrompt(
   userId: string,
@@ -30,10 +31,10 @@ export async function buildEnhancedSystemPrompt(
     Dutch Blitz is a fast-paced card game where:
     - Players have a "blitz pile" of cards they need to get rid of
     - They play cards during rounds
-    - Score is calculated as: totalCardsPlayed - (blitzPileRemaining * 2)
+    - Score is calculated as: totalCardsPlayed - (blitzPileRemaining * ${GAME_RULES.BLITZ_PENALTY_MULTIPLIER})
     - A player "blitzes" when they have 0 cards remaining in their blitz pile
     - Games usually consist of multiple rounds
-    - The first player to reach 75 points wins the game
+    - The first player to reach ${GAME_RULES.POINTS_TO_WIN} points wins the game
     
     When answering questions, provide specific insights based on the user's statistics shown above.
     For example, if they ask about their win rate, you can calculate it from games won divided by games played.

--- a/src/server/ai/tools.ts
+++ b/src/server/ai/tools.ts
@@ -3,6 +3,14 @@ import { z } from "zod";
 import prisma from "@/server/db/db-readonly";
 import PostHogClient from "@/app/posthog";
 import { Prisma } from "@/generated/prisma/client";
+import {
+  calculateRoundScore,
+  calculateCumulativeScore,
+  ROUND_SCORE_SQL,
+} from "@/lib/validation/gameRules";
+
+// Canonical single-round score expression — see ROUND_SCORE_SQL
+const scoreExpr = Prisma.raw(ROUND_SCORE_SQL);
 
 // ── Constants ────────────────────────────────────────────────────────────────
 const MAX_RECENT_GAMES = 50;
@@ -137,7 +145,7 @@ const getUserOverview = (
             totalCardsPlayed += s.totalCardsPlayed;
             totalBlitzRemaining += s.blitzPileRemaining;
             if (s.blitzPileRemaining === 0) totalBlitzes += 1;
-            const calc = s.totalCardsPlayed - s.blitzPileRemaining * 2;
+            const calc = calculateRoundScore(s);
             if (calc > highestScore) highestScore = calc;
             if (calc < lowestScore) lowestScore = calc;
           }
@@ -236,19 +244,19 @@ const getExtremes = (
             blitzPileRemaining: number;
           }>>`
       SELECT
-        ("totalCardsPlayed" - ("blitzPileRemaining" * 2)) as score,
+        ${scoreExpr} as score,
         "totalCardsPlayed",
         "blitzPileRemaining"
       FROM "Score"
       WHERE "userId" = ${internalId}
       AND (
-        ("totalCardsPlayed" - ("blitzPileRemaining" * 2)) = (
-          SELECT MAX("totalCardsPlayed" - ("blitzPileRemaining" * 2))
+        ${scoreExpr} = (
+          SELECT MAX(${scoreExpr})
           FROM "Score" WHERE "userId" = ${internalId}
         )
         OR
-        ("totalCardsPlayed" - ("blitzPileRemaining" * 2)) = (
-          SELECT MIN("totalCardsPlayed" - ("blitzPileRemaining" * 2))
+        ${scoreExpr} = (
+          SELECT MIN(${scoreExpr})
           FROM "Score" WHERE "userId" = ${internalId}
         )
       )`;
@@ -287,7 +295,12 @@ const getCumulativeScore = (
           });
           const totalCardsPlayed = agg._sum.totalCardsPlayed ?? 0;
           const blitzPileRemaining = agg._sum.blitzPileRemaining ?? 0;
-          return { totalScore: totalCardsPlayed - blitzPileRemaining * 2 };
+          return {
+            totalScore: calculateCumulativeScore({
+              totalCardsPlayed,
+              blitzPileRemaining,
+            }),
+          };
         }
       );
     },
@@ -341,7 +354,10 @@ const getTrends = (clerkUserId: string, posthog: ReturnType<typeof PostHogClient
           return {
             periodStart: new Date(r.period).toISOString(),
             rounds,
-            totalScore: totalCards - 2 * totalBlitz,
+            totalScore: calculateCumulativeScore({
+              totalCardsPlayed: totalCards,
+              blitzPileRemaining: totalBlitz,
+            }),
           };
         })
         .reverse();

--- a/src/server/ai/utils.ts
+++ b/src/server/ai/utils.ts
@@ -1,4 +1,5 @@
 import prisma from "@/server/db/db";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
 
 /**
  * Get game summary for a user
@@ -121,11 +122,10 @@ export async function getUserStats(userId: string) {
   let totalCardsPlayed = 0;
   let totalBlitzRemaining = 0;
 
-  // Calculate total score for each record (totalCardsPlayed - (blitzPileRemaining * 2))
   const calculatedScores = scores.map((score) => {
     return {
       ...score,
-      calculatedScore: score.totalCardsPlayed - score.blitzPileRemaining * 2,
+      calculatedScore: calculateRoundScore(score),
     };
   });
 

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -3,6 +3,13 @@ import "server-only";
 import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/server/db/db";
 import { getUserIdFromAuth } from "@/server/utils";
+import {
+  calculateCumulativeScore,
+  ROUND_SCORE_SQL,
+} from "@/lib/validation/gameRules";
+
+// Canonical single-round score expression — see ROUND_SCORE_SQL
+const scoreExpr = Prisma.raw(ROUND_SCORE_SQL);
 
 // Batting average
 // Fetch players total rounds and rounds won
@@ -50,20 +57,20 @@ export async function getHighestAndLowestScore() {
   >(
     Prisma.sql`
       SELECT
-        ("totalCardsPlayed" - ("blitzPileRemaining" * 2)) as score,
+        ${scoreExpr} as score,
         "totalCardsPlayed",
         "blitzPileRemaining"
       FROM "Score"
       WHERE "userId" = ${id}
       AND (
-        ("totalCardsPlayed" - ("blitzPileRemaining" * 2)) = (
-          SELECT MAX("totalCardsPlayed" - ("blitzPileRemaining" * 2))
+        ${scoreExpr} = (
+          SELECT MAX(${scoreExpr})
           FROM "Score"
           WHERE "userId" = ${id}
         )
         OR
-        ("totalCardsPlayed" - ("blitzPileRemaining" * 2)) = (
-          SELECT MIN("totalCardsPlayed" - ("blitzPileRemaining" * 2))
+        ${scoreExpr} = (
+          SELECT MIN(${scoreExpr})
           FROM "Score"
           WHERE "userId" = ${id}
         )
@@ -122,9 +129,7 @@ export async function getCumulativeScore() {
     return 0;
   }
 
-  const totalScore = totalCardsPlayed - blitzPileRemaining * 2;
-
-  return totalScore;
+  return calculateCumulativeScore({ totalCardsPlayed, blitzPileRemaining });
 }
 
 export async function getLongestAndShortestGamesByRounds() {


### PR DESCRIPTION
Closes #222. From the 2026-06-12 codebase review.

## What

`totalCardsPlayed − 2·blitzPileRemaining` lived in **six places in two languages**. Now `src/lib/validation/gameRules.ts` is the single owner of scoring arithmetic in all its forms:

- **`calculateCumulativeScore(totals)`** — the aggregate form. The formula is linear, so it delegates to `calculateRoundScore` applied to sums; the delegation makes the linearity explicit.
- **`ROUND_SCORE_SQL`** — the canonical SQL expression, *derived from `GAME_RULES.BLITZ_PENALTY_MULTIPLIER`* so the SQL and TS forms cannot drift. It's a plain string (this module is imported client-side); server queries interpolate it with `Prisma.raw()`.

Rewired call sites: `queries/stats.ts` (raw SQL ×2 + cumulative), `ai/tools.ts` (raw SQL + JS ×3), `ai/utils.ts` (JS), `api/slack/whois` (JS), and the AI system prompt now interpolates `GAME_RULES` instead of hardcoding "× 2" and "75 points" in prose.

Changing the penalty multiplier is now a one-line edit instead of a 7-file sweep.

## Bug fixed along the way

The Slack `/whois` cumulative score used `sum(cards) && sum(blitz) ? … : 0` — a player whose blitz-pile **sum is legitimately 0** (always blitzed) reported a cumulative score of 0 instead of their full total. Now uses `?? 0` through the module.

## Tests (TDD)

- New: `calculateCumulativeScore` (incl. a linearity property test: aggregate form ≡ sum of per-round scores) and `ROUND_SCORE_SQL` is pinned to `GAME_RULES` — watched fail first.
- `queries.test.ts`'s Prisma mock gained `raw` (it only stubbed `sql`).
- 15/15 suites, 109/109 tests, typecheck, lint pass.

Sets up #226 (stats-in-SQL), which builds on `ROUND_SCORE_SQL` — that PR is stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)