### PR TITLE
refactor: Stats module aggregates in SQL; AI tools become thin adapters (#226)

### DIFF
--- a/src/server/__tests__/queries.test.ts
+++ b/src/server/__tests__/queries.test.ts
@@ -5,6 +5,7 @@ import {
   getPlayerBattingAverage,
   getHighestAndLowestScore,
   getCumulativeScore,
+  getLongestAndShortestGamesByRounds,
 } from "../queries";
 import prisma from "../db/db";
 import { auth } from "@clerk/nextjs/server";
@@ -24,6 +25,9 @@ jest.mock("../db/db", () => {
     score: {
       count: jest.fn(),
       aggregate: jest.fn(),
+    },
+    round: {
+      groupBy: jest.fn(),
     },
     $queryRaw: jest.fn(),
   };
@@ -229,16 +233,18 @@ describe("Queries", () => {
     });
 
     describe("getHighestAndLowestScore", () => {
-      it("should return highest and lowest scores", async () => {
-        const mockScores = [
-          { score: 30, totalCardsPlayed: 40, blitzPileRemaining: 5 },
-          { score: 10, totalCardsPlayed: 20, blitzPileRemaining: 5 },
-        ];
-
-        (prisma.$queryRaw as jest.Mock).mockResolvedValue(mockScores);
+      it("should fetch highest and lowest with one LIMIT 1 query each", async () => {
+        (prisma.$queryRaw as jest.Mock)
+          .mockResolvedValueOnce([
+            { score: 30, totalCardsPlayed: 40, blitzPileRemaining: 5 },
+          ])
+          .mockResolvedValueOnce([
+            { score: 10, totalCardsPlayed: 20, blitzPileRemaining: 5 },
+          ]);
 
         const result = await getHighestAndLowestScore();
 
+        expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
         expect(result).toEqual({
           highest: {
             score: 30,
@@ -253,13 +259,15 @@ describe("Queries", () => {
         });
       });
 
-      it("should handle single score case", async () => {
+      it("should report lowest as null when it equals the highest", async () => {
         const mockScore = {
           score: 30,
           totalCardsPlayed: 40,
           blitzPileRemaining: 5,
         };
-        (prisma.$queryRaw as jest.Mock).mockResolvedValue([mockScore]);
+        (prisma.$queryRaw as jest.Mock)
+          .mockResolvedValueOnce([mockScore])
+          .mockResolvedValueOnce([mockScore]);
 
         const result = await getHighestAndLowestScore();
 
@@ -274,7 +282,9 @@ describe("Queries", () => {
       });
 
       it("should handle no scores", async () => {
-        (prisma.$queryRaw as jest.Mock).mockResolvedValue([]);
+        (prisma.$queryRaw as jest.Mock)
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([]);
 
         const result = await getHighestAndLowestScore();
 
@@ -282,6 +292,44 @@ describe("Queries", () => {
           highest: null,
           lowest: null,
         });
+      });
+    });
+
+    describe("getLongestAndShortestGamesByRounds", () => {
+      it("should aggregate round counts in the database, not JS", async () => {
+        (prisma.round.groupBy as jest.Mock)
+          .mockResolvedValueOnce([{ gameId: "game-long", _count: { _all: 9 } }])
+          .mockResolvedValueOnce([
+            { gameId: "game-short", _count: { _all: 2 } },
+          ]);
+
+        const result = await getLongestAndShortestGamesByRounds();
+
+        expect(result).toEqual({
+          longest: { id: "game-long", roundCount: 9 },
+          shortest: { id: "game-short", roundCount: 2 },
+        });
+        // Only the user's finished games count
+        expect(prisma.round.groupBy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              game: {
+                isFinished: true,
+                players: { some: { userId: mockUserId } },
+              },
+            },
+          })
+        );
+      });
+
+      it("should return nulls when the user has no finished games with rounds", async () => {
+        (prisma.round.groupBy as jest.Mock)
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([]);
+
+        const result = await getLongestAndShortestGamesByRounds();
+
+        expect(result).toEqual({ longest: null, shortest: null });
       });
     });
 

--- a/src/server/ai/tools.ts
+++ b/src/server/ai/tools.ts
@@ -6,11 +6,11 @@ import { Prisma } from "@/generated/prisma/client";
 import {
   calculateRoundScore,
   calculateCumulativeScore,
-  ROUND_SCORE_SQL,
 } from "@/lib/validation/gameRules";
-
-// Canonical single-round score expression — see ROUND_SCORE_SQL
-const scoreExpr = Prisma.raw(ROUND_SCORE_SQL);
+import {
+  getHighestAndLowestScoreForUser,
+  getCumulativeScoreForUser,
+} from "@/server/queries/stats";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 const MAX_RECENT_GAMES = 50;
@@ -232,42 +232,14 @@ const getExtremes = (
     execute: async () => {
       const internalId = await getInternalUserId(clerkUserId);
 
-      const rows = await runWithTracing(
+      // Thin adapter over the stats module, reading from the replica
+      return await runWithTracing(
         posthog,
         clerkUserId,
         "getExtremes",
         {},
-        async () => {
-          return await prisma.$queryRaw<Array<{
-            score: number;
-            totalCardsPlayed: number;
-            blitzPileRemaining: number;
-          }>>`
-      SELECT
-        ${scoreExpr} as score,
-        "totalCardsPlayed",
-        "blitzPileRemaining"
-      FROM "Score"
-      WHERE "userId" = ${internalId}
-      AND (
-        ${scoreExpr} = (
-          SELECT MAX(${scoreExpr})
-          FROM "Score" WHERE "userId" = ${internalId}
-        )
-        OR
-        ${scoreExpr} = (
-          SELECT MIN(${scoreExpr})
-          FROM "Score" WHERE "userId" = ${internalId}
-        )
-      )`;
-        },
-        (rows) => rows.length
+        async () => getHighestAndLowestScoreForUser(internalId, prisma)
       );
-
-      if (!rows.length) return { highest: null, lowest: null };
-      const highest = rows.reduce((a, b) => (a.score > b.score ? a : b));
-      const lowest = rows.reduce((a, b) => (a.score < b.score ? a : b));
-      return { highest, lowest: highest === lowest ? null : lowest };
     },
   });
 
@@ -283,25 +255,15 @@ const getCumulativeScore = (
     execute: async () => {
       const internalId = await getInternalUserId(clerkUserId);
 
+      // Thin adapter over the stats module, reading from the replica
       return await runWithTracing(
         posthog,
         clerkUserId,
         "getCumulativeScore",
         {},
-        async () => {
-          const agg = await prisma.score.aggregate({
-            where: { userId: internalId },
-            _sum: { totalCardsPlayed: true, blitzPileRemaining: true },
-          });
-          const totalCardsPlayed = agg._sum.totalCardsPlayed ?? 0;
-          const blitzPileRemaining = agg._sum.blitzPileRemaining ?? 0;
-          return {
-            totalScore: calculateCumulativeScore({
-              totalCardsPlayed,
-              blitzPileRemaining,
-            }),
-          };
-        }
+        async () => ({
+          totalScore: await getCumulativeScoreForUser(internalId, prisma),
+        })
       );
     },
   });

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { Prisma } from "@/generated/prisma/client";
+import { Prisma, type PrismaClient } from "@/generated/prisma/client";
 import prisma from "@/server/db/db";
 import { getUserIdFromAuth } from "@/server/utils";
 import {
@@ -11,26 +11,39 @@ import {
 // Canonical single-round score expression — see ROUND_SCORE_SQL
 const scoreExpr = Prisma.raw(ROUND_SCORE_SQL);
 
+// The ...ForUser variants take an explicit internal user id and an optional
+// Prisma client, so callers that already resolved the user — or that read
+// from the replica, like the AI tool layer — don't repeat the lookup. The
+// zero-arg exports resolve the authenticated user and delegate.
+
+type Db = PrismaClient | typeof prisma;
+
+type ScoreExtreme = {
+  score: number;
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
+};
+
 // Batting average
 // Fetch players total rounds and rounds won
 // This assumes that only one player blitzed per round (edge case)
-// Maybe move this to some kind of computed property on the user model?
-// https://www.prisma.io/docs/orm/prisma-client/queries/computed-fields
-export async function getPlayerBattingAverage() {
-  const id = await getUserIdFromAuth();
-
-  const totalHandsPlayed = await prisma.score.count({
-    where: {
-      userId: id,
-    },
-  });
-
-  const totalHandsWon = await prisma.score.count({
-    where: {
-      userId: id,
-      blitzPileRemaining: 0,
-    },
-  });
+export async function getPlayerBattingAverageForUser(
+  userId: string,
+  db: Db = prisma
+) {
+  const [totalHandsPlayed, totalHandsWon] = await Promise.all([
+    db.score.count({
+      where: {
+        userId,
+      },
+    }),
+    db.score.count({
+      where: {
+        userId,
+        blitzPileRemaining: 0,
+      },
+    }),
+  ]);
 
   const rawBattingAverage =
     totalHandsPlayed === 0 ? 0 : totalHandsWon / totalHandsPlayed;
@@ -44,77 +57,70 @@ export async function getPlayerBattingAverage() {
   };
 }
 
-// Highest / lowest score
-export async function getHighestAndLowestScore() {
-  const id = await getUserIdFromAuth();
+export async function getPlayerBattingAverage() {
+  return getPlayerBattingAverageForUser(await getUserIdFromAuth());
+}
 
-  const scores = await prisma.$queryRaw<
-    Array<{
-      score: number;
-      totalCardsPlayed: number;
-      blitzPileRemaining: number;
-    }>
-  >(
-    Prisma.sql`
-      SELECT
-        ${scoreExpr} as score,
-        "totalCardsPlayed",
-        "blitzPileRemaining"
-      FROM "Score"
-      WHERE "userId" = ${id}
-      AND (
-        ${scoreExpr} = (
-          SELECT MAX(${scoreExpr})
-          FROM "Score"
-          WHERE "userId" = ${id}
-        )
-        OR
-        ${scoreExpr} = (
-          SELECT MIN(${scoreExpr})
-          FROM "Score"
-          WHERE "userId" = ${id}
-        )
-      )
-    `
-  );
+// Highest / lowest single-round score, each fetched with ORDER BY + LIMIT 1
+// so the database does the aggregation instead of JS reducing every row
+export async function getHighestAndLowestScoreForUser(
+  userId: string,
+  db: Db = prisma
+) {
+  const [highestRows, lowestRows] = await Promise.all([
+    db.$queryRaw<ScoreExtreme[]>(
+      Prisma.sql`
+        SELECT
+          ${scoreExpr} as score,
+          "totalCardsPlayed",
+          "blitzPileRemaining"
+        FROM "Score"
+        WHERE "userId" = ${userId}
+        ORDER BY ${scoreExpr} DESC
+        LIMIT 1
+      `
+    ),
+    db.$queryRaw<ScoreExtreme[]>(
+      Prisma.sql`
+        SELECT
+          ${scoreExpr} as score,
+          "totalCardsPlayed",
+          "blitzPileRemaining"
+        FROM "Score"
+        WHERE "userId" = ${userId}
+        ORDER BY ${scoreExpr} ASC
+        LIMIT 1
+      `
+    ),
+  ]);
 
-  const highestScore = scores.reduce(
-    (max, score) => (max.score > score.score ? max : score),
-    scores[0]
-  );
-  const lowestScore = scores.reduce(
-    (min, score) => (min.score < score.score ? min : score),
-    scores[0]
-  );
+  const highest = highestRows[0] ?? null;
+  const lowest = lowestRows[0] ?? null;
 
-  if (!highestScore) {
+  if (!highest) {
     return { highest: null, lowest: null };
   }
 
-  const createScoreObject = (score: typeof highestScore) => ({
-    score: score.score,
-    totalCardsPlayed: score.totalCardsPlayed,
-    blitzPileRemaining: score.blitzPileRemaining,
-  });
-
-  const highest = createScoreObject(highestScore);
-
-  if (!lowestScore || lowestScore === highestScore) {
+  // A lone score (or an all-equal history) has no distinct lowest
+  if (!lowest || lowest.score === highest.score) {
     return { highest, lowest: null };
   }
-
-  const lowest = createScoreObject(lowestScore);
 
   return { highest, lowest };
 }
 
-// Cumulative score
-export async function getCumulativeScore() {
-  const id = await getUserIdFromAuth();
+export async function getHighestAndLowestScore() {
+  return getHighestAndLowestScoreForUser(await getUserIdFromAuth());
+}
 
-  const cumulativeScore = await prisma.score.aggregate({
+// Cumulative score
+export async function getCumulativeScoreForUser(
+  userId: string,
+  db: Db = prisma
+) {
+  const cumulativeScore = await db.score.aggregate({
     where: {
-      userId: id,
+      userId,
     },
     _sum: {
       totalCardsPlayed: true,
@@ -132,50 +138,44 @@ export async function getCumulativeScore() {
   return calculateCumulativeScore({ totalCardsPlayed, blitzPileRemaining });
 }
 
-export async function getLongestAndShortestGamesByRounds() {
-  const id = await getUserIdFromAuth();
+export async function getCumulativeScore() {
+  return getCumulativeScoreForUser(await getUserIdFromAuth());
+}
 
-  const games = await prisma.game.findMany({
-    where: {
-      players: {
-        some: {
-          userId: id,
+// Longest / shortest finished game by round count, aggregated with GROUP BY
+// instead of loading every game and its rounds into memory
+export async function getLongestAndShortestGamesByRoundsForUser(
+  userId: string,
+  db: Db = prisma
+) {
+  const roundCountExtreme = (order: "asc" | "desc") =>
+    db.round.groupBy({
+      by: ["gameId"],
+      where: {
+        game: {
+          isFinished: true,
+          players: { some: { userId } },
         },
       },
-      isFinished: true, // Only include completed games
-    },
-    include: {
-      rounds: true,
-    },
-  });
+      _count: { _all: true },
+      orderBy: { _count: { gameId: order } },
+      take: 1,
+    });
 
-  if (!games.length) {
-    return { longest: null, shortest: null };
-  }
+  const [longestRows, shortestRows] = await Promise.all([
+    roundCountExtreme("desc"),
+    roundCountExtreme("asc"),
+  ]);
 
-  const gamesWithRoundCount = games.map((game) => ({
-    id: game.id,
-    roundCount: game.rounds.length,
-    isFinished: game.isFinished,
-  }));
+  const toGame = (row?: { gameId: string; _count: { _all: number } }) =>
+    row ? { id: row.gameId, roundCount: row._count._all } : null;
 
-  const longestGame = gamesWithRoundCount.reduce(
-    (longest, current) =>
-      current.roundCount > longest.roundCount ? current : longest,
-    gamesWithRoundCount[0]
-  );
+  return {
+    longest: toGame(longestRows[0]),
+    shortest: toGame(shortestRows[0]),
+  };
+}
 
-  const gamesWithRounds = gamesWithRoundCount.filter(game => game.roundCount > 0);
-
-  if (!gamesWithRounds.length) {
-    return { longest: longestGame, shortest: null };
-  }
-
-  const shortestGame = gamesWithRounds.reduce(
-    (shortest, current) =>
-      current.roundCount < shortest.roundCount ? current : shortest,
-    gamesWithRounds[0]
-  );
-
-  return { longest: longestGame, shortest: shortestGame };
+export async function getLongestAndShortestGamesByRounds() {
+  return getLongestAndShortestGamesByRoundsForUser(await getUserIdFromAuth());
 }


### PR DESCRIPTION
Closes #226. From the 2026-06-12 codebase review. **Stacked on #254** (uses `ROUND_SCORE_SQL`) — merge that first.

## What

- **`getHighestAndLowestScore`** — was one query with three repeated score subqueries, then *re-reduced in JS over rows that were already only the max/min*. Now: two `ORDER BY <score> LIMIT 1` queries in parallel. Edge semantics preserved (single/all-equal history → `lowest: null`).
- **`getLongestAndShortestGamesByRounds`** — was `findMany` of **every finished game with every round** for the user, reduced in JS. Now: `round.groupBy` with `_count` ordered asc/desc, `take: 1`. For a long history this stops shipping the whole game tree over the wire on every dashboard load.
- **`...ForUser(userId, db?)` variants** — each stat now has a core that takes the resolved internal user id and an optional Prisma client. The zero-arg exports keep their signatures (dashboard untouched here, to avoid colliding with #252; switching it to the `ForUser` variants once both merge is a two-line follow-up that drops 3 duplicate user lookups per load).
- **AI tools deduped** — `getExtremes` and `getCumulativeScore` in `ai/tools.ts` were parallel implementations of the same stats (one in raw SQL, one in JS). They are now thin adapters over the stats module, **still reading from the replica** via the injected `db-readonly` client.

## Tests (TDD)

- Rewrote `getHighestAndLowestScore` tests to the two-query contract (failed on the old impl — it made one call and re-reduced).
- `getLongestAndShortestGamesByRounds` had **zero coverage** (lines 130-175 uncovered); now tested against the groupBy contract including the finished-games-only predicate.
- 15/15 suites, 111/111 tests, typecheck, lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)