### PR TITLE
refactor: one Game-read module owns the include shapes (#223)

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -27,51 +27,14 @@ export default async function GameView(props: {
     notFound();
   }
 
-  // Validate that game data is properly formed
-  if (!gameData.players || !Array.isArray(gameData.players)) {
-    throw new Error("Game data is malformed: players array is missing");
-  }
+  // The query layer guarantees this shape — no per-request adaptation needed
+  const game: GameWithPlayersAndScores = gameData;
 
-  // Check for any null/undefined players
-  const validPlayers = gameData.players.filter(
-    (player) => player !== null && player !== undefined
-  );
-  if (validPlayers.length !== gameData.players.length) {
-    console.warn(
-      "Some players in the game are null or undefined, filtering them out"
-    );
-    gameData.players = validPlayers;
-  }
+  const displayScores = transformGameData(game);
 
-  // Adapt the database model to match our application interface
-  // This converts 'null' values to 'undefined' for optional properties
-  const game: GameWithPlayersAndScores = {
-    ...gameData,
-    players: gameData.players.map((player) => ({
-      ...player,
-      id: player.id || "",
-      gameId: player.gameId,
-      userId: player.userId || undefined,
-      guestId: player.guestId || undefined,
-      accentColor: player.accentColor ?? undefined,
-      user: player.user || undefined,
-      guestUser: player.guestUser || undefined,
-    })),
-  };
-
-  // Ensure each player has a valid ID
-  for (const player of game.players) {
-    if (!player.id && !player.userId && !player.guestId) {
-      console.warn("Player is missing an ID, assigning a temporary one");
-      player.id = `temp-${crypto.randomUUID()}`;
-    }
-  }
-
-  const displayScores = await transformGameData(game);
-
-  // Derive isFinished from transformGameData result: it may have just
-  // detected a winner and updated the DB, but game.isFinished was read
-  // before that update, so use the display scores as source of truth.
+  // Completion is synced when scores are written, but a winner can still be
+  // derived from the loaded rounds before the snapshot reflects it — trust
+  // the computed scores over the isFinished flag we read.
   const isFinished = game.isFinished || displayScores.some((s) => s.isWinner);
 
   // calculate the current round number

--- a/src/components/GamesList.tsx
+++ b/src/components/GamesList.tsx
@@ -44,21 +44,13 @@ import {
   differenceInWeeks,
   isThisYear,
 } from "date-fns";
-import { Game, GamePlayers, User } from "@/generated/prisma/client";
+import type { GameSummary } from "@/server/queries/games";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 
-type GameWithPlayersAndUsers = Game & {
-  players: (GamePlayers & {
-    user?: User | null;
-    guestUser?: { id: string; name: string } | null;
-  })[];
-  rounds: { id: string }[];
-};
-
 type GameStatusFilter = "all" | "completed" | "active" | "ended";
 
-function GameList({ games }: { games: GameWithPlayersAndUsers[] }) {
+function GameList({ games }: { games: GameSummary[] }) {
   const router = useRouter();
   const { organization } = useOrganization();
   const circleName = organization?.name ?? "the active Circle";
@@ -118,7 +110,7 @@ function GameList({ games }: { games: GameWithPlayersAndUsers[] }) {
     return format(date, "MMM d, yyyy"); // e.g. "Jul 15, 2023"
   };
 
-  const getGameStatus = (game: GameWithPlayersAndUsers) => {
+  const getGameStatus = (game: GameSummary) => {
     if (game.isFinished) {
       return <Badge variant="success">Completed</Badge>;
     }
@@ -128,7 +120,7 @@ function GameList({ games }: { games: GameWithPlayersAndUsers[] }) {
     return <Badge variant="default">Ongoing</Badge>;
   };
 
-  const getWinnerName = (game: GameWithPlayersAndUsers) => {
+  const getWinnerName = (game: GameSummary) => {
     if (!game.winnerId) return null;
     const winner = game.players.find(
       (p) =>
@@ -445,7 +437,7 @@ function GameList({ games }: { games: GameWithPlayersAndUsers[] }) {
 
 // Wrap with ErrorBoundary and export
 export default function GameListWithErrorBoundary(props: {
-  games: GameWithPlayersAndUsers[];
+  games: GameSummary[];
 }) {
   return (
     <ErrorBoundary

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -2,15 +2,17 @@ import { Game, User, Score, Round, GuestUser } from "@/generated/prisma/client";
 import { calculateRoundScore, isWinningScore } from "./validation/gameRules";
 import { breakTie } from "./scoring/tiebreak";
 
+// Accepts both the raw Prisma payload (null-able fields) and looser
+// hand-built shapes, so query results flow in without adaptation
 export interface GameWithPlayersAndScores extends Game {
   players: {
     id: string;
     gameId: string;
-    userId?: string;
-    guestId?: string;
+    userId?: string | null;
+    guestId?: string | null;
     accentColor?: string | null;
-    user?: User;
-    guestUser?: GuestUser;
+    user?: User | null;
+    guestUser?: GuestUser | null;
   }[];
   rounds: (Round & { scores: Score[] })[];
 }

--- a/src/server/__tests__/queries.test.ts
+++ b/src/server/__tests__/queries.test.ts
@@ -117,6 +117,9 @@ describe("Queries", () => {
             include: {
               scores: true,
             },
+            orderBy: {
+              round: "asc",
+            },
           },
         },
       });

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -3,41 +3,21 @@
 import prisma from "@/server/db/db";
 import { getAuthenticatedUserWithOrg } from "./common";
 import { validateGameRules, ValidationError } from "@/lib/validation/gameRules";
-import {
-  getGameCompletion,
-  type GameWithPlayersAndScores,
-} from "@/lib/gameLogic";
+import { getGameCompletion } from "@/lib/gameLogic";
+import { getGameById } from "@/server/queries/games";
 import { updateGameAsFinished } from "./games";
 
 type AuthenticatedContext = Awaited<ReturnType<typeof getAuthenticatedUserWithOrg>>;
-
-async function loadGameForCompletion(gameId: string) {
-  return prisma.game.findUnique({
-    where: { id: gameId },
-    include: {
-      players: {
-        include: {
-          user: true,
-          guestUser: true,
-        },
-      },
-      rounds: {
-        include: { scores: true },
-        orderBy: { round: "asc" },
-      },
-    },
-  });
-}
 
 async function syncGameCompletionAfterScoreWrite(
   gameId: string,
   userId: string,
   posthog: AuthenticatedContext["posthog"]
 ) {
-  const updatedGame = await loadGameForCompletion(gameId);
+  const updatedGame = await getGameById(gameId);
   if (!updatedGame) return;
 
-  const completion = getGameCompletion(updatedGame as GameWithPlayersAndScores);
+  const completion = getGameCompletion(updatedGame);
 
   if (!completion.winnerId) {
     if (updatedGame.isFinished) {

--- a/src/server/queries/games.ts
+++ b/src/server/queries/games.ts
@@ -2,46 +2,74 @@ import "server-only";
 
 import prisma from "@/server/db/db";
 import { auth } from "@clerk/nextjs/server";
-import posthogClient from "@/app/posthog";
+import { Prisma } from "@/generated/prisma/client";
+
+// One place owns the Game include trees. The query functions are annotated
+// with the payload types these shapes produce, so include drift surfaces as
+// a type error here instead of a partially-populated object at a renderer.
+
+// List views: players resolved, rounds for counting (no per-round scores)
+const gameSummaryInclude = {
+  players: {
+    include: {
+      user: true,
+      guestUser: true,
+    },
+  },
+  rounds: true,
+} satisfies Prisma.GameInclude;
+
+// Single-game views: the full scores tree, rounds in play order
+const gameDetailInclude = {
+  players: {
+    include: {
+      user: true,
+      guestUser: true,
+    },
+  },
+  rounds: {
+    include: {
+      scores: true,
+    },
+    orderBy: {
+      round: "asc",
+    },
+  },
+} satisfies Prisma.GameInclude;
+
+export type GameSummary = Prisma.GameGetPayload<{
+  include: typeof gameSummaryInclude;
+}>;
+
+export type GameDetail = Prisma.GameGetPayload<{
+  include: typeof gameDetailInclude;
+}>;
 
 // Fetch all games in the active circle
-export async function getGames() {
+export async function getGames(): Promise<GameSummary[]> {
   const user = await auth();
-  const posthog = posthogClient();
 
   if (!user.userId) throw new Error("Unauthorized");
   if (!user.orgId) throw new Error("No active circle");
 
-  const games = await prisma.game.findMany({
+  return prisma.game.findMany({
     where: {
       organizationId: user.orgId,
     },
-    include: {
-      players: {
-        include: {
-          user: true,
-          guestUser: true,
-        },
-      },
-      rounds: true,
-    },
+    include: gameSummaryInclude,
     orderBy: {
       createdAt: "desc",
     },
   });
-
-  posthog.capture({ distinctId: user.userId, event: "get_games" });
-
-  return games;
 }
 
 // Fetch games without an organizationId (pre-circle legacy games)
-export async function getLegacyGames() {
+export async function getLegacyGames(): Promise<GameSummary[]> {
   const user = await auth();
 
   if (!user.userId) throw new Error("Unauthorized");
 
-  const games = await prisma.game.findMany({
+  return prisma.game.findMany({
     where: {
       organizationId: null,
       players: {
@@ -52,43 +80,20 @@ export async function getLegacyGames() {
         },
       },
     },
-    include: {
-      players: {
-        include: {
-          user: true,
-          guestUser: true,
-        },
-      },
-      rounds: true,
-    },
+    include: gameSummaryInclude,
     orderBy: {
       createdAt: "desc",
     },
   });
-
-  return games;
 }
 
-// Fetch a single game by ID (public - no auth required)
-export async function getGameById(id: string) {
-  const game = await prisma.game.findUnique({
+// Fetch a single game by ID (public — game pages are shareable by link;
+// score entry is still gated to circle members at the page level)
+export async function getGameById(id: string): Promise<GameDetail | null> {
+  return prisma.game.findUnique({
     where: {
       id: id,
     },
-    include: {
-      players: {
-        include: {
-          user: true,
-          guestUser: true,
-        },
-      },
-      rounds: {
-        include: {
-          scores: true,
-        },
-      },
-    },
+    include: gameDetailInclude,
   });
-
-  return game;
 }


### PR DESCRIPTION
Closes #223. From the 2026-06-12 codebase review.

## What

Four copies of the Game include tree (three in `queries/games.ts`, one hiding in `rounds.ts` as `loadGameForCompletion`) collapse into two canonical shapes with **enforced payload types**:

- `gameSummaryInclude` → `GameSummary` — list views (players + rounds, no scores)
- `gameDetailInclude` → `GameDetail` — single-game views (full scores tree, rounds ordered by round number)

Every query is annotated with its payload type, so include drift now fails `tsc` at the query layer instead of producing a partially-populated object some renderer trusts.

## The payoff: the defensive blob is gone

`games/[id]/page.tsx` carried ~38 lines of per-request adaptation — null-player filtering, null→undefined conversion, temp-UUID assignment — because no query was forced to satisfy `GameWithPlayersAndScores`. That interface now accepts the raw Prisma payload (null-able fields), so the page is just `const game = gameData`. Also fixed the stale comment claiming `transformGameData` "may have updated the DB" — it's been pure since #240.

## Also

- `GamesList` imports the canonical `GameSummary` instead of re-declaring its own `GameWithPlayersAndUsers`.
- `rounds.ts` reuses `getGameById` for the post-score-write completion reload.
- `getGameById` now orders rounds by round number — the game page indexes `scoresByRound` by array position, so it was silently relying on insertion order.
- Removed the `get_games` PostHog capture from the read path (fired on every list view; reads aren't user actions).

## Tests (TDD)

The rounds-ordering contract was pinned in `queries.test.ts` first (failed against the unordered query, passes now). 15/15 suites, 105/105 tests, typecheck, lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)