### PR TITLE
refactor: one auth-context seam for server actions (#225)

### DIFF
--- a/src/server/__tests__/mutations.test.ts
+++ b/src/server/__tests__/mutations.test.ts
@@ -15,9 +15,8 @@ import {
   cloneGame,
 } from "../mutations";
 import {
-  getAuthenticatedUser,
-  getAuthenticatedUserPrismaId,
-  getAuthenticatedUserWithOrg,
+  requireAuthContext,
+  requireGameInCircle,
 } from "../mutations/common";
 import prisma from "../db/db";
 import { auth } from "@clerk/nextjs/server";
@@ -501,39 +500,95 @@ describe("Game Mutations", () => {
     });
   });
 
-  describe("getAuthenticatedUserWithOrg", () => {
-    it("should return user with orgId when circle is active", async () => {
-      (auth as unknown as jest.Mock).mockResolvedValue({
-        userId: mockUserId,
-        orgId: "org_test123",
-      });
+  describe("requireAuthContext", () => {
+    it("returns org context when a circle is active", async () => {
+      const ctx = await requireAuthContext("org");
 
-      const result = await getAuthenticatedUserWithOrg();
-
-      expect(result.user.userId).toBe(mockUserId);
-      expect(result.orgId).toBe("org_test123");
-      expect(result.posthog).toBeDefined();
+      expect(ctx.user.userId).toBe(mockUserId);
+      expect(ctx.orgId).toBe(mockOrgId);
+      expect(ctx.posthog).toBeDefined();
     });
 
-    it("should throw if user has no active circle", async () => {
+    it("resolves the internal prisma id when required", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        id: "prisma-user-id",
+      });
+
+      const ctx = await requireAuthContext("orgWithPrismaId");
+
+      expect(ctx.orgId).toBe(mockOrgId);
+      expect(ctx.prismaUserId).toBe("prisma-user-id");
+    });
+
+    it("does not require a circle for prismaId-only actions", async () => {
+      (auth as unknown as jest.Mock).mockResolvedValue({
+        userId: mockUserId,
+        orgId: null,
+      });
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        id: "prisma-user-id",
+      });
+
+      const ctx = await requireAuthContext("prismaId");
+
+      expect(ctx.prismaUserId).toBe("prisma-user-id");
+    });
+
+    it("throws if the prisma user is missing", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(requireAuthContext("orgWithPrismaId")).rejects.toThrow(
+        "User not found"
+      );
+    });
+
+    it("throws if user has no active circle", async () => {
       (auth as unknown as jest.Mock).mockResolvedValue({
         userId: mockUserId,
         orgId: null,
       });
 
-      await expect(getAuthenticatedUserWithOrg()).rejects.toThrow(
+      await expect(requireAuthContext("org")).rejects.toThrow(
         "No active circle"
       );
     });
 
-    it("should throw if user is not authenticated", async () => {
+    it("throws if user is not authenticated", async () => {
       (auth as unknown as jest.Mock).mockResolvedValue({
         userId: null,
         orgId: null,
       });
 
-      await expect(getAuthenticatedUserWithOrg()).rejects.toThrow(
-        "Unauthorized"
+      await expect(requireAuthContext("user")).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("requireGameInCircle", () => {
+    it("returns the game when it belongs to the active circle", async () => {
+      const mockGame = { id: mockGameId, organizationId: mockOrgId };
+      (prisma.game.findUnique as jest.Mock).mockResolvedValue(mockGame);
+
+      await expect(
+        requireGameInCircle(mockGameId, mockOrgId)
+      ).resolves.toEqual(mockGame);
+    });
+
+    it("throws when the game does not exist", async () => {
+      (prisma.game.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(requireGameInCircle(mockGameId, mockOrgId)).rejects.toThrow(
+        "Game not found"
+      );
+    });
+
+    it("throws when the game belongs to another circle", async () => {
+      (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+        id: mockGameId,
+        organizationId: "org_other",
+      });
+
+      await expect(requireGameInCircle(mockGameId, mockOrgId)).rejects.toThrow(
+        "Game does not belong to your active circle"
       );
     });
   });

--- a/src/server/mutations/common.ts
+++ b/src/server/mutations/common.ts
@@ -1,50 +1,109 @@
-"use server";
-
 import { auth } from "@clerk/nextjs/server";
 import prisma from "@/server/db/db";
 import posthogClient from "@/app/posthog";
+import type { Game } from "@/generated/prisma/client";
+
+// One auth seam for all server actions. Declare what the action needs and
+// destructure a context guaranteed to satisfy it — instead of picking the
+// right helper from three overlapping ones and re-implementing org checks.
+
+type Requirement = "user" | "prismaId" | "org" | "orgWithPrismaId";
+
+// Clerk's auth() returns a signed-in/signed-out union discriminated by
+// userId — the context carries the signed-in variant
+type SignedInAuth = Extract<
+  Awaited<ReturnType<typeof auth>>,
+  { userId: string }
+>;
+
+export type AuthedUserContext = {
+  user: SignedInAuth;
+  /** Clerk user id, narrowed to non-null */
+  userId: string;
+  posthog: ReturnType<typeof posthogClient>;
+};
+export type AuthedPrismaIdContext = AuthedUserContext & {
+  /** Internal (Prisma) user id */
+  prismaUserId: string;
+};
+export type AuthedOrgContext = AuthedUserContext & {
+  /** Active circle (Clerk organization) id */
+  orgId: string;
+};
+export type AuthedOrgPrismaIdContext = AuthedOrgContext & AuthedPrismaIdContext;
 
 /**
- * Helper function to get authenticated user and posthog client
- * @throws {Error} If user is not authenticated
+ * Resolve the authenticated context a server action requires.
+ * @throws {Error} "Unauthorized" if not signed in
+ * @throws {Error} "No active circle" if an org is required but none is active
+ * @throws {Error} "User not found" if a Prisma id is required but missing
  */
-export async function getAuthenticatedUser() {
+export async function requireAuthContext(
+  requires: "user"
+): Promise<AuthedUserContext>;
+export async function requireAuthContext(
+  requires: "prismaId"
+): Promise<AuthedPrismaIdContext>;
+export async function requireAuthContext(
+  requires: "org"
+): Promise<AuthedOrgContext>;
+export async function requireAuthContext(
+  requires: "orgWithPrismaId"
+): Promise<AuthedOrgPrismaIdContext>;
+export async function requireAuthContext(
+  requires: Requirement
+): Promise<AuthedUserContext & { orgId?: string; prismaUserId?: string }> {
   const user = await auth();
   const posthog = posthogClient();
 
   if (!user.userId) throw new Error("Unauthorized");
+  const userId = user.userId;
 
-  return { user, posthog };
-}
+  const context: AuthedUserContext & {
+    orgId?: string;
+    prismaUserId?: string;
+  } = { user, userId, posthog };
 
-/**
- * Helper that requires both authentication AND an active circle (org).
- * Use in mutations that must be scoped to a circle.
- * @throws {Error} If user is not authenticated or has no active circle
- */
-export async function getAuthenticatedUserWithOrg() {
-  const { user, posthog } = await getAuthenticatedUser();
-
-  if (!user.orgId) {
-    throw new Error("No active circle");
+  if (requires === "org" || requires === "orgWithPrismaId") {
+    if (!user.orgId) throw new Error("No active circle");
+    context.orgId = user.orgId;
   }
 
-  return { user, posthog, orgId: user.orgId };
+  if (requires === "prismaId" || requires === "orgWithPrismaId") {
+    const prismaUser = await prisma.user.findUnique({
+      where: { clerk_user_id: userId },
+      select: { id: true },
+    });
+    if (!prismaUser) throw new Error("User not found");
+    context.prismaUserId = prismaUser.id;
+  }
+
+  return context;
 }
 
 /**
- * Helper function to get authenticated user's internal Prisma ID
- * @throws {Error} If user is not authenticated or not found
+ * Assert that an already-loaded game belongs to the active circle.
+ * @throws {Error} If the game is missing or belongs to another circle
  */
-export async function getAuthenticatedUserPrismaId() {
-  const { user, posthog } = await getAuthenticatedUser();
+export function assertGameInCircle<G extends Pick<Game, "organizationId">>(
+  game: G | null,
+  orgId: string
+): asserts game is G {
+  if (!game) throw new Error("Game not found");
+  if (game.organizationId !== orgId) {
+    throw new Error("Game does not belong to your active circle");
+  }
+}
 
-  const prismaUser = await prisma.user.findUnique({
-    where: { clerk_user_id: user.userId },
-    select: { id: true },
-  });
-
-  if (!prismaUser) throw new Error("User not found");
-
-  return { userId: user.userId, id: prismaUser.id, posthog };
+/**
+ * Load a game and assert it belongs to the active circle.
+ * @throws {Error} If the game is missing or belongs to another circle
+ */
+export async function requireGameInCircle(
+  gameId: string,
+  orgId: string
+): Promise<Game> {
+  const game = await prisma.game.findUnique({ where: { id: gameId } });
+  assertGameInCircle(game, orgId);
+  return game;
 }

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -3,7 +3,7 @@
 import prisma from "@/server/db/db";
 import { clerkClient } from "@clerk/nextjs/server";
 import { after } from "next/server";
-import { getAuthenticatedUserWithOrg } from "./common";
+import { requireAuthContext, assertGameInCircle } from "./common";
 import { sendGameCompleteEmail, EMAIL_INTER_SEND_DELAY_MS } from "../email";
 import { resolvePlayerColor, assignColorsToPlayers } from "@/lib/scoring/colors";
 
@@ -17,13 +17,9 @@ export async function createGame(
   }[],
   winThreshold?: number
 ) {
-  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
-  const currentUser = await prisma.user.findUnique({
-    where: { clerk_user_id: user.userId },
-    select: { id: true },
-  });
-
-  if (!currentUser) throw new Error("User not found");
+  const { user, posthog, orgId, prismaUserId } = await requireAuthContext(
+    "orgWithPrismaId"
+  );
 
   // Validate that non-guest players are members of the active circle
   const regularPlayerIds = users
@@ -72,7 +68,7 @@ export async function createGame(
         const guestUser = await prisma.guestUser.create({
           data: {
             name: player.username,
-            createdById: currentUser.id,
+            createdById: prismaUserId,
             organizationId: orgId,
           },
         });
@@ -153,7 +149,7 @@ export async function updateGameAsFinished(
   winnerId: string,
   isGuestWinner: boolean = false
 ) {
-  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
+  const { user, posthog, orgId } = await requireAuthContext("org");
 
   // Fetch game with all player details
   const game = await prisma.game.findUnique({
@@ -182,11 +178,7 @@ export async function updateGameAsFinished(
     },
   });
 
-  if (!game) throw new Error("Game not found");
-
-  if (game.organizationId !== orgId) {
-    throw new Error("Game does not belong to your active circle");
-  }
+  assertGameInCircle(game, orgId);
 
   // Get winner's details
   let winnerName = "";
@@ -301,14 +293,12 @@ export async function updateGameAsFinished(
 
 // Save user's default accent color preference
 export async function saveUserAccentColor(color: string) {
-  const { user, posthog } = await getAuthenticatedUserWithOrg();
-  const currentUser = await prisma.user.findUnique({
-    where: { clerk_user_id: user.userId },
-  });
-  if (!currentUser) throw new Error("User not found");
+  const { user, posthog, prismaUserId } = await requireAuthContext(
+    "orgWithPrismaId"
+  );
 
   await prisma.user.update({
-    where: { id: currentUser.id },
+    where: { id: prismaUserId },
     data: { accentColor: color },
   });
 
@@ -321,7 +311,7 @@ export async function saveUserAccentColor(color: string) {
 
 // Clone an existing game
 export async function cloneGame(originalGameId: string) {
-  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
+  const { user, posthog, orgId } = await requireAuthContext("org");
 
   // Fetch the original game with its players
   const originalGame = await prisma.game.findUnique({
@@ -337,10 +327,7 @@ export async function cloneGame(originalGameId: string) {
   });
 
   if (!originalGame) throw new Error("Original game not found");
-
-  if (originalGame.organizationId !== orgId) {
-    throw new Error("Game does not belong to your active circle");
-  }
+  assertGameInCircle(originalGame, orgId);
 
   // Start a transaction to ensure consistency
   const newGameId = await prisma.$transaction(async (tx) => {

--- a/src/server/mutations/guests.ts
+++ b/src/server/mutations/guests.ts
@@ -1,24 +1,19 @@
 "use server";
 
 import prisma from "@/server/db/db";
-import { getAuthenticatedUserPrismaId, getAuthenticatedUserWithOrg } from "./common";
+import { requireAuthContext } from "./common";
 import { sendGuestInvitationEmail } from "@/server/email";
 
 // Create a guest user
 export async function createGuestUser(name: string) {
-  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
-
-  const prismaUser = await prisma.user.findUnique({
-    where: { clerk_user_id: user.userId },
-    select: { id: true },
-  });
-
-  if (!prismaUser) throw new Error("User not found");
+  const { user, posthog, orgId, prismaUserId } = await requireAuthContext(
+    "orgWithPrismaId"
+  );
 
   const guestUser = await prisma.guestUser.create({
     data: {
       name,
-      createdById: prismaUser.id,
+      createdById: prismaUserId,
       organizationId: orgId,
     },
   });
@@ -34,7 +29,7 @@ export async function createGuestUser(name: string) {
 
 // Get guest users in the active circle
 export async function getCircleGuestUsers() {
-  const { orgId } = await getAuthenticatedUserWithOrg();
+  const { orgId } = await requireAuthContext("org");
 
   const guestUsers = await prisma.guestUser.findMany({
     where: { organizationId: orgId },
@@ -48,9 +43,9 @@ export async function getCircleGuestUsers() {
 export async function inviteGuestUser(guestId: string, email: string) {
   const {
     userId: clerkUserId,
-    id,
+    prismaUserId,
     posthog,
-  } = await getAuthenticatedUserPrismaId();
+  } = await requireAuthContext("prismaId");
 
   // Check if user owns this guest
   const guestUser = await prisma.guestUser.findUnique({
@@ -67,7 +62,7 @@ export async function inviteGuestUser(guestId: string, email: string) {
   });
 
   if (!guestUser) throw new Error("Guest user not found");
-  if (guestUser.createdById !== id)
+  if (guestUser.createdById !== prismaUserId)
     throw new Error("Unauthorized - not the creator of this guest");
 
   const emailResult = await sendGuestInvitationEmail({

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -1,15 +1,17 @@
 "use server";
 
 import prisma from "@/server/db/db";
-import { getAuthenticatedUserWithOrg } from "./common";
+import {
+  requireAuthContext,
+  requireGameInCircle,
+  type AuthedOrgContext,
+} from "./common";
 import { validateGameRules, ValidationError } from "@/lib/validation/gameRules";
 import {
   getGameCompletion,
   type GameWithPlayersAndScores,
 } from "@/lib/gameLogic";
 import { updateGameAsFinished } from "./games";
-
-type AuthenticatedContext = Awaited<ReturnType<typeof getAuthenticatedUserWithOrg>>;
 
 async function loadGameForCompletion(gameId: string) {
   return prisma.game.findUnique({
@@ -32,7 +34,7 @@ async function loadGameForCompletion(gameId: string) {
 async function syncGameCompletionAfterScoreWrite(
   gameId: string,
   userId: string,
-  posthog: AuthenticatedContext["posthog"]
+  posthog: AuthedOrgContext["posthog"]
 ) {
   const updatedGame = await loadGameForCompletion(gameId);
   if (!updatedGame) return;
@@ -89,20 +91,9 @@ export async function createRoundForGame(
     totalCardsPlayed: number;
   }[]
 ) {
-  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
+  const { user, posthog, orgId } = await requireAuthContext("org");
 
-  const game = await prisma.game.findUnique({
-    where: { id: gameId },
-  });
-
-  if (!game) {
-    throw new Error("Game not found");
-  }
-
-  // Verify game belongs to the active circle
-  if (game.organizationId !== orgId) {
-    throw new Error("Game does not belong to your active circle");
-  }
+  const game = await requireGameInCircle(gameId, orgId);
 
   // Validate scores using centralized validation
   try {
@@ -189,20 +180,9 @@ export async function updateRoundScores(
     totalCardsPlayed: number;
   }[]
 ) {
-  const { user, posthog, orgId } = await getAuthenticatedUserWithOrg();
+  const { user, posthog, orgId } = await requireAuthContext("org");
 
-  // Check if game exists and is not finished
-  const game = await prisma.game.findUnique({
-    where: { id: gameId },
-  });
-
-  if (!game) {
-    throw new Error("Game not found");
-  }
-
-  if (game.organizationId !== orgId) {
-    throw new Error("Game does not belong to your active circle");
-  }
+  await requireGameInCircle(gameId, orgId);
 
   // Finished games are still editable — if an edit drops all players
   // below the threshold, the game will be reopened (see below).


### PR DESCRIPTION
Closes #225. From the 2026-06-12 codebase review. **Merge this one last** — see merge notes below.

## What

- **`requireAuthContext(requires)`** replaces the three overlapping helpers. Actions declare what they need — `"user" | "prismaId" | "org" | "orgWithPrismaId"` — and destructure a context typed per requirement (overloads): `{ user, userId, posthog, orgId?, prismaUserId? }`. The `user` in the context is Clerk's *signed-in* variant, so `userId` is `string`, not `string | null`.
- **`requireGameInCircle(gameId, orgId)` / `assertGameInCircle(game, orgId)`** replace the four hand-copied org-membership checks (`rounds.ts` ×2, `updateGameAsFinished`, `cloneGame`). The assert variant covers call sites that load the game with their own include tree.
- `createGame`, `saveUserAccentColor`, and `createGuestUser` drop their hand-rolled prisma-user lookups (`saveUserAccentColor` was fetching the entire User row just for the id).
- `common.ts` loses its `"use server"` directive — these are plain server utilities, and the directive was needlessly registering them as client-invokable action endpoints.

## Deviation from the issue's sketch

#225 sketched a higher-order `authedAction({requires, track}, fn)` wrapper. Two practical reasons this lands as a context resolver instead:
1. **`track` at the wrapper level can't know domain properties** — every action's PostHog event carries per-action data (gameId, playerCount…), so tracking stays with the action per the project convention.
2. **An HOF re-indents every mutation body and fights Next's "use server" export rules**, maximizing both merge conflicts with the other open PRs and compiler risk. The one-line `await requireAuthContext("org")` delivers the same consolidation (one place for auth policy, declarative requirements, org check written once) with a minimal diff.

`circles.ts` keeps its inline auth — it predates the helpers and the whole legacy-friends flow is separately proposed for retirement.

## Merge notes

This PR is based on `main` and intentionally merged **after** the others. Expect two small, mechanical conflicts: the opening lines of `createGame` (vs #249) and the import block of `rounds.ts` (vs #256). Happy to rebase once those land.

## Tests (TDD)

9 new tests for `requireAuthContext` (all four requirement levels + failure modes) and `requireGameInCircle` (found / missing / wrong circle) — written first, watched fail, then implemented. The three old helper tests are superseded. 15/15 suites, 111/111 tests, typecheck, lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)