### PR TITLE
Clean up dashboard stats aggregation

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,26 +1,15 @@
 import { Suspense } from "react";
-import {
-  getPlayerBattingAverage,
-  getHighestAndLowestScore,
-  getCumulativeScore,
-  getLongestAndShortestGamesByRounds,
-} from "@/server/queries";
+import { getDashboardStats } from "@/server/queries";
 import BasicStatBlock from "@/components/BasicStatBlock";
 import InviteBannerSection from "./_components/InviteBannerSection";
 
 export default async function Dashboard() {
-  // The four stats are independent — fetch them in parallel
-  const [
+  const {
     battingAverage,
-    { highest, lowest },
+    scoreExtremes: { highest, lowest },
     cumulativeScore,
-    { longest, shortest },
-  ] = await Promise.all([
-    getPlayerBattingAverage(),
-    getHighestAndLowestScore(),
-    getCumulativeScore(),
-    getLongestAndShortestGamesByRounds(),
-  ]);
+    gameRoundExtremes: { longest, shortest },
+  } = await getDashboardStats();
 
   return (
     <section className="border-zinc-500 p-5">

--- a/src/server/__tests__/queries.test.ts
+++ b/src/server/__tests__/queries.test.ts
@@ -2,6 +2,7 @@ import {
   getGameById,
   getGames,
   getLegacyGames,
+  getDashboardStats,
   getPlayerBattingAverage,
   getHighestAndLowestScore,
   getCumulativeScore,
@@ -9,7 +10,6 @@ import {
 } from "../queries";
 import prisma from "../db/db";
 import { auth } from "@clerk/nextjs/server";
-import { Prisma } from "@/generated/prisma/client";
 
 // Mock dependencies
 jest.mock("../db/db", () => {
@@ -207,9 +207,9 @@ describe("Queries", () => {
 
     describe("getPlayerBattingAverage", () => {
       it("should calculate batting average correctly", async () => {
-        (prisma.score.count as jest.Mock)
-          .mockResolvedValueOnce(10) // totalHandsPlayed
-          .mockResolvedValueOnce(4); // totalHandsWon
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([
+          { totalHandsPlayed: 10, totalHandsWon: 4 },
+        ]);
 
         const result = await getPlayerBattingAverage();
 
@@ -221,9 +221,9 @@ describe("Queries", () => {
       });
 
       it("should handle zero hands played", async () => {
-        (prisma.score.count as jest.Mock)
-          .mockResolvedValueOnce(0)
-          .mockResolvedValueOnce(0);
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([
+          { totalHandsPlayed: 0, totalHandsWon: 0 },
+        ]);
 
         const result = await getPlayerBattingAverage();
 
@@ -338,74 +338,83 @@ describe("Queries", () => {
 
     describe("getCumulativeScore", () => {
       it("should calculate cumulative score correctly", async () => {
-        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
-          _sum: {
-            totalCardsPlayed: 100,
-            blitzPileRemaining: 20,
-          },
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ totalScore: 60 }]);
 
         const result = await getCumulativeScore();
 
-        // 100 - (20 * 2) = 60
         expect(result).toBe(60);
       });
 
-      it("should return 0 when either totalCardsPlayed or blitzPileRemaining is null", async () => {
-        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
-          _sum: {
-            totalCardsPlayed: 100,
-            blitzPileRemaining: null,
-          },
-        });
-
-        let result = await getCumulativeScore();
-        expect(result).toBe(0);
-
-        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
-          _sum: {
-            totalCardsPlayed: null,
-            blitzPileRemaining: 20,
-          },
-        });
-
-        result = await getCumulativeScore();
-        expect(result).toBe(0);
-      });
-
       it("should handle zero values correctly", async () => {
-        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
-          _sum: {
-            totalCardsPlayed: 0,
-            blitzPileRemaining: 20,
-          },
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValueOnce([
+          { totalScore: -40 },
+        ]);
 
         let result = await getCumulativeScore();
         expect(result).toBe(-40);
 
-        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
-          _sum: {
-            totalCardsPlayed: 100,
-            blitzPileRemaining: 0,
-          },
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValueOnce([
+          { totalScore: 100 },
+        ]);
 
         result = await getCumulativeScore();
         expect(result).toBe(100);
       });
 
       it("should return 0 for no scores", async () => {
-        (prisma.score.aggregate as jest.Mock).mockResolvedValue({
-          _sum: {
-            totalCardsPlayed: null,
-            blitzPileRemaining: null,
-          },
-        });
+        (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ totalScore: 0 }]);
 
         const result = await getCumulativeScore();
 
         expect(result).toBe(0);
+      });
+    });
+
+    describe("getDashboardStats", () => {
+      it("should fetch dashboard stats through the shared helper", async () => {
+        (prisma.$queryRaw as jest.Mock)
+          .mockResolvedValueOnce([
+            { totalHandsPlayed: 10, totalHandsWon: 4 },
+          ])
+          .mockResolvedValueOnce([
+            { score: 30, totalCardsPlayed: 40, blitzPileRemaining: 5 },
+          ])
+          .mockResolvedValueOnce([
+            { score: 10, totalCardsPlayed: 20, blitzPileRemaining: 5 },
+          ])
+          .mockResolvedValueOnce([{ totalScore: 60 }]);
+        (prisma.round.groupBy as jest.Mock)
+          .mockResolvedValueOnce([{ gameId: "game-long", _count: { _all: 9 } }])
+          .mockResolvedValueOnce([
+            { gameId: "game-short", _count: { _all: 2 } },
+          ]);
+
+        const result = await getDashboardStats();
+
+        expect(result).toEqual({
+          battingAverage: {
+            totalHandsPlayed: 10,
+            totalHandsWon: 4,
+            battingAverage: "0.400",
+          },
+          scoreExtremes: {
+            highest: {
+              score: 30,
+              totalCardsPlayed: 40,
+              blitzPileRemaining: 5,
+            },
+            lowest: {
+              score: 10,
+              totalCardsPlayed: 20,
+              blitzPileRemaining: 5,
+            },
+          },
+          cumulativeScore: 60,
+          gameRoundExtremes: {
+            longest: { id: "game-long", roundCount: 9 },
+            shortest: { id: "game-short", roundCount: 2 },
+          },
+        });
       });
     });
   });

--- a/src/server/ai/tools.ts
+++ b/src/server/ai/tools.ts
@@ -238,7 +238,9 @@ const getExtremes = (
         clerkUserId,
         "getExtremes",
         {},
-        async () => getHighestAndLowestScoreForUser(internalId, prisma)
+        async () => getHighestAndLowestScoreForUser(internalId, prisma),
+        (result) =>
+          Number(Boolean(result.highest)) + Number(Boolean(result.lowest))
       );
     },
   });

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -3,6 +3,7 @@ export {
   getGames,
   getGameById,
   getLegacyGames,
+  getDashboardStats,
   getPlayerBattingAverage,
   getHighestAndLowestScore,
   getCumulativeScore,

--- a/src/server/queries/index.ts
+++ b/src/server/queries/index.ts
@@ -1,2 +1,8 @@
 export { getGames, getGameById, getLegacyGames } from "./games";
-export { getPlayerBattingAverage, getHighestAndLowestScore, getCumulativeScore, getLongestAndShortestGamesByRounds } from "./stats";
+export {
+  getDashboardStats,
+  getPlayerBattingAverage,
+  getHighestAndLowestScore,
+  getCumulativeScore,
+  getLongestAndShortestGamesByRounds,
+} from "./stats";

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -3,10 +3,7 @@ import "server-only";
 import { Prisma, type PrismaClient } from "@/generated/prisma/client";
 import prisma from "@/server/db/db";
 import { getUserIdFromAuth } from "@/server/utils";
-import {
-  calculateCumulativeScore,
-  ROUND_SCORE_SQL,
-} from "@/lib/validation/gameRules";
+import { ROUND_SCORE_SQL } from "@/lib/validation/gameRules";
 
 // Canonical single-round score expression — see ROUND_SCORE_SQL
 const scoreExpr = Prisma.raw(ROUND_SCORE_SQL);
@@ -18,32 +15,69 @@ const scoreExpr = Prisma.raw(ROUND_SCORE_SQL);
 
 type Db = PrismaClient | typeof prisma;
 
-type ScoreExtreme = {
+type CountRow = {
+  totalHandsPlayed: number | bigint;
+  totalHandsWon: number | bigint;
+};
+
+type TotalScoreRow = {
+  totalScore: number | bigint | null;
+};
+
+export type BattingAverageStats = {
+  totalHandsPlayed: number;
+  totalHandsWon: number;
+  battingAverage: string;
+};
+
+export type ScoreExtreme = {
   score: number;
   totalCardsPlayed: number;
   blitzPileRemaining: number;
 };
 
+export type ScoreExtremes = {
+  highest: ScoreExtreme | null;
+  lowest: ScoreExtreme | null;
+};
+
+export type GameRoundCount = {
+  id: string;
+  roundCount: number;
+};
+
+export type GameRoundExtremes = {
+  longest: GameRoundCount | null;
+  shortest: GameRoundCount | null;
+};
+
+export type DashboardStats = {
+  battingAverage: BattingAverageStats;
+  scoreExtremes: ScoreExtremes;
+  cumulativeScore: number;
+  gameRoundExtremes: GameRoundExtremes;
+};
+
 // Batting average
-// Fetch players total rounds and rounds won
+// Fetch player's total rounds and rounds won in one aggregate query.
 // This assumes that only one player blitzed per round (edge case)
 export async function getPlayerBattingAverageForUser(
   userId: string,
   db: Db = prisma
-) {
-  const [totalHandsPlayed, totalHandsWon] = await Promise.all([
-    db.score.count({
-      where: {
-        userId,
-      },
-    }),
-    db.score.count({
-      where: {
-        userId,
-        blitzPileRemaining: 0,
-      },
-    }),
-  ]);
+): Promise<BattingAverageStats> {
+  const rows = await db.$queryRaw<CountRow[]>(
+    Prisma.sql`
+      SELECT
+        COUNT(*) AS "totalHandsPlayed",
+        COUNT(*) FILTER (WHERE "blitzPileRemaining" = 0) AS "totalHandsWon"
+      FROM "Score"
+      WHERE "userId" = ${userId}
+    `
+  );
+
+  const row = rows[0] ?? { totalHandsPlayed: 0, totalHandsWon: 0 };
+  const totalHandsPlayed = Number(row.totalHandsPlayed);
+  const totalHandsWon = Number(row.totalHandsWon);
 
   const rawBattingAverage =
     totalHandsPlayed === 0 ? 0 : totalHandsWon / totalHandsPlayed;
@@ -66,7 +100,7 @@ export async function getPlayerBattingAverage() {
 export async function getHighestAndLowestScoreForUser(
   userId: string,
   db: Db = prisma
-) {
+): Promise<ScoreExtremes> {
   const [highestRows, lowestRows] = await Promise.all([
     db.$queryRaw<ScoreExtreme[]>(
       Prisma.sql`
@@ -76,7 +110,7 @@ export async function getHighestAndLowestScoreForUser(
           "blitzPileRemaining"
         FROM "Score"
         WHERE "userId" = ${userId}
-        ORDER BY ${scoreExpr} DESC
+        ORDER BY ${scoreExpr} DESC, "created_at" DESC, id DESC
         LIMIT 1
       `
     ),
@@ -88,7 +122,7 @@ export async function getHighestAndLowestScoreForUser(
           "blitzPileRemaining"
         FROM "Score"
         WHERE "userId" = ${userId}
-        ORDER BY ${scoreExpr} ASC
+        ORDER BY ${scoreExpr} ASC, "created_at" DESC, id DESC
         LIMIT 1
       `
     ),
@@ -117,25 +151,16 @@ export async function getHighestAndLowestScore() {
 export async function getCumulativeScoreForUser(
   userId: string,
   db: Db = prisma
-) {
-  const cumulativeScore = await db.score.aggregate({
-    where: {
-      userId,
-    },
-    _sum: {
-      totalCardsPlayed: true,
-      blitzPileRemaining: true,
-    },
-  });
+): Promise<number> {
+  const rows = await db.$queryRaw<TotalScoreRow[]>(
+    Prisma.sql`
+      SELECT COALESCE(SUM(${scoreExpr}), 0) AS "totalScore"
+      FROM "Score"
+      WHERE "userId" = ${userId}
+    `
+  );
 
-  const totalCardsPlayed = cumulativeScore._sum.totalCardsPlayed;
-  const blitzPileRemaining = cumulativeScore._sum.blitzPileRemaining;
-
-  if (totalCardsPlayed === null || blitzPileRemaining === null) {
-    return 0;
-  }
-
-  return calculateCumulativeScore({ totalCardsPlayed, blitzPileRemaining });
+  return Number(rows[0]?.totalScore ?? 0);
 }
 
 export async function getCumulativeScore() {
@@ -147,7 +172,7 @@ export async function getCumulativeScore() {
 export async function getLongestAndShortestGamesByRoundsForUser(
   userId: string,
   db: Db = prisma
-) {
+): Promise<GameRoundExtremes> {
   const roundCountExtreme = (order: "asc" | "desc") =>
     db.round.groupBy({
       by: ["gameId"],
@@ -178,4 +203,28 @@ export async function getLongestAndShortestGamesByRoundsForUser(
 
 export async function getLongestAndShortestGamesByRounds() {
   return getLongestAndShortestGamesByRoundsForUser(await getUserIdFromAuth());
+}
+
+export async function getDashboardStatsForUser(
+  userId: string,
+  db: Db = prisma
+): Promise<DashboardStats> {
+  const [battingAverage, scoreExtremes, cumulativeScore, gameRoundExtremes] =
+    await Promise.all([
+      getPlayerBattingAverageForUser(userId, db),
+      getHighestAndLowestScoreForUser(userId, db),
+      getCumulativeScoreForUser(userId, db),
+      getLongestAndShortestGamesByRoundsForUser(userId, db),
+    ]);
+
+  return {
+    battingAverage,
+    scoreExtremes,
+    cumulativeScore,
+    gameRoundExtremes,
+  };
+}
+
+export async function getDashboardStats() {
+  return getDashboardStatsForUser(await getUserIdFromAuth());
 }


### PR DESCRIPTION
## Summary

Replacement for #244 that keeps the useful stats-query cleanup without reintroducing stale dashboard/banner code from the pre-integration branch.

Changes include:
- Add `getDashboardStats()` as the dashboard-facing helper while preserving the streamed `InviteBannerSection`.
- Move batting average and cumulative score aggregation into SQL using the shared canonical score expression.
- Keep high/low score queries on the existing canonical score expression and add deterministic tie ordering.
- Preserve the current AI stats-tool adapter and add row-count telemetry for extremes.
- Refresh query tests for the SQL-backed stats behavior and dashboard helper.

## Validation

- `npx prisma generate`
- `npm test -- --runTestsByPath src/server/__tests__/queries.test.ts --runInBand`
- `npm test -- --runInBand --testPathIgnorePatterns='<rootDir>/cypress/' --testPathIgnorePatterns='<rootDir>/.claude/'`
- `npm run typecheck`
- `npx eslint . --ignore-pattern '.claude/**'`

Notes: the plain local Jest/ESLint commands discover the nested `.claude/worktrees/review-prs` checkout in this workspace, so the broad local validation explicitly ignored `.claude/**`. CI should not have that nested worktree.