### PR TITLE
feat(insights): Phase 1 — post-game LLM summaries (M0a + M1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
 # OpenAI
 ***REMOVED***
 
+# Anthropic (Claude) — LLM Insights
+ANTHROPIC_API_KEY="sk-ant-..."
+
+# Cron secret guarding the insights summary sweep route (/api/insights/sweep)
+CRON_SECRET=""
+
 # Email (Resend)
 ***REMOVED***
 

--- a/docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md
+++ b/docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md
@@ -1484,3 +1484,48 @@ Plan complete and saved to `docs/superpowers/plans/2026-06-13-llm-insights-phase
 2. **Inline Execution** — execute tasks in this session with batch checkpoints.
 
 Which approach?
+
+---
+
+## Codex Review Revisions (applied 2026-06-13)
+
+Codex reviewed this plan against the codebase: 3 blockers + 9 should-fix + 2 nice-to-have, all accepted. The changes below **override the task bodies above where they conflict** — the implementation follows these.
+
+### Durability & triggers (blockers #1, #2, #3)
+
+`after()` is post-response best-effort, not a queue, and the original plan created the `GameSummary` row *inside* the async callback — so a dropped `after()` left nothing for the sweep to retry. Also, this app lets users **edit finished games** (`src/server/mutations/rounds.ts:167`), and that path never called the trigger.
+
+- **Split generation into a synchronous enqueue + an async run** in `src/server/ai/summary.ts`:
+  - `enqueueGameSummary(gameId): Promise<{ enqueued: boolean }>` — runs **in-request** (primary DB). Loads the game via `getGameById` (primary), builds facts, hashes. Writes nothing and returns `{enqueued:false}` if there's no game or an existing `ready` row already matches the hash; upserts `insufficient_data` (returns false) for `<2` rounds / `<2` players; otherwise upserts a `pending` row with the new hash and returns `{enqueued:true}`. A durable row therefore exists before the response returns.
+  - `runGameSummary(gameId): Promise<void>` — the LLM call; idempotent (re-checks `ready`+hash); writes `ready` or `failed` (+`retryCount`).
+  - `scheduleGameSummary(gameId): Promise<void>` — `if (!(await isLlmFeaturesEnabled())) return; const { enqueued } = await enqueueGameSummary(gameId); if (enqueued) after(() => runGameSummary(gameId));`
+  - `regeneratePendingSummaries(limit=20)` — sweeps `pending`/`failed` (retryCount<5) → `runGameSummary`.
+- **Trigger from both finish paths:** `updateGameAsFinished` calls `await scheduleGameSummary(gameId)` (covers the direct "Finish" button and the finalize-via-score-write branch, which routes through `updateGameAsFinished`). ADD a trailing `await scheduleGameSummary(gameId)` at the end of `syncGameCompletionAfterScoreWrite` in `rounds.ts` so edits that keep a game finished regenerate when the hash changes (hash-gating ⇒ no-op when nothing changed; a reopened game falls out because the page renders only when finished). This replaces Task 9's single `after(() => generateGameSummary(...))`.
+- **Sweep route:** add `src/app/api/insights/sweep/route.ts` (GET, guarded by a `CRON_SECRET` request header) calling `regeneratePendingSummaries()`. Vercel cron schedule + `CRON_SECRET` env = human step.
+- **Read status from primary:** `getGameSummary` reads from `@/server/db/db` (primary; one indexed row) to dodge replica lag on a just-finished game, and the page renders the pending state when `isFinished && !summary`.
+- **Flag-gated:** `scheduleGameSummary` early-returns unless `isLlmFeaturesEnabled()`; the page only renders the card when the flag is on. Phase 1 ships dark.
+
+### Recap correctness (#5, #6, #7, #8) — build in pseudonym-ready, playerKey space
+
+`buildGameRecap(game)` now returns `{ facts: GameRecapFacts; playerNames: Record<playerKey, realName> }`:
+- Feeds `calcGameStats` an **identity** name map (`{key: key}`) so `biggestRound`/`worstRound` carry the **playerKey**, not a display name.
+- `GameRecapFacts` identifiers are all `playerKey`; it contains **no real names and no raw score arrays** — only aggregates — so the hash is order-stable.
+- `standings` sorted by **(isWinner first, total desc, playerKey asc)** ⇒ `standings[0]` is the real winner even under the final-round blitz-pile tiebreak; `rank` follows that order. `winnerKey` replaces `winnerName`.
+- `blitzLeader` ties broken by lowest `playerKey` (deterministic).
+- `pseudonymizeRecap(facts, playerNames)` assigns `keyToPseudo` ("Player A/B"…) by standings order, replaces every `playerKey` in the facts with its pseudonym, and returns `{ promptFacts, nameMap: { "Player A": realName } }`. Real names never enter `calcGameStats` or the prompt; internal UUIDs never reach the LLM; duplicate guest names no longer collapse (keyed by playerKey). `rehydrateNames(text, nameMap)` maps pseudonym→real for storage.
+- `hashRecapFacts` hashes `facts` (no timestamps). `sourceUpdatedAt` is computed separately (below), not hashed.
+
+### Claude client (#9, #10, #11)
+
+- Use `satisfies Anthropic.MessageCreateParamsNonStreaming` (Codex confirmed the installed SDK 0.104.x types support `claude-opus-4-8`, `thinking:{type:"adaptive"}`, `output_config.effort`); fall back to a typed cast only if `tsc` rejects it.
+- `generateSummaryText` **throws** when the text is empty or `res.stop_reason === "refusal"` ⇒ the row becomes `failed`, never `ready` with empty content.
+- `tokensUsed = input_tokens + output_tokens + (cache_creation_input_tokens ?? 0) + (cache_read_input_tokens ?? 0)`.
+- `sourceUpdatedAt` = `max(score.updatedAt across loaded rounds)`, falling back to `game.endedAt ?? new Date()` — computed in the orchestration from the loaded game, **not** `new Date()`.
+
+### Tests (#12)
+
+- Add `jest.mock("@/server/ai/summary", () => ({ scheduleGameSummary: jest.fn() }))` to `src/server/__tests__/mutations.test.ts` so existing finalization tests don't run real summary work. The Task 9 wiring test asserts `scheduleGameSummary` was called.
+
+### Kept as-is (#13)
+
+- `@updatedAt` on `GameSummary` is intentional (status-machine timing); it knowingly diverges from the repo's manual `updated_at` convention.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^3.0.64",
         "@ai-sdk/react": "^3.0.186",
+        "@anthropic-ai/sdk": "^0.104.1",
         "@clerk/nextjs": "^7.3.5",
         "@eslint/compat": "^2.1.0",
         "@posthog/ai": "^7.18.7",
@@ -178,12 +179,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
-      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "version": "0.104.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
+      "integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1018,7 +1020,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,7 +1036,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,7 +1052,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,7 +1068,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,7 +1084,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,7 +1100,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,7 +1116,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,7 +1132,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,7 +1148,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,7 +1164,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1188,7 +1180,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1205,7 +1196,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,7 +1212,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1239,7 +1228,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,7 +1244,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1273,7 +1260,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1290,7 +1276,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1307,7 +1292,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,7 +1308,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1341,7 +1324,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,7 +1340,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,7 +1356,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1392,7 +1372,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,7 +1388,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1426,7 +1404,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1443,7 +1420,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3547,173 +3523,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.200.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.200.0.tgz",
-      "integrity": "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/otlp-exporter-base": "0.200.0",
-        "@opentelemetry/otlp-transformer": "0.200.0",
-        "@opentelemetry/resources": "2.0.0",
-        "@opentelemetry/sdk-trace-base": "2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.200.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
-      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.200.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
-      "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/otlp-transformer": "0.200.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.200.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
-      "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.200.0",
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/resources": "2.0.0",
-        "@opentelemetry/sdk-logs": "0.200.0",
-        "@opentelemetry/sdk-metrics": "2.0.0",
-        "@opentelemetry/sdk-trace-base": "2.0.0",
-        "protobufjs": "^7.3.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.200.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
-      "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.200.0",
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/resources": "2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-      "integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/resources": "2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
-      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/resources": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.214.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
@@ -4381,6 +4190,26 @@
           "optional": true
         },
         "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@posthog/ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -18572,23 +18401,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.64",
     "@ai-sdk/react": "^3.0.186",
+    "@anthropic-ai/sdk": "^0.104.1",
     "@clerk/nextjs": "^7.3.5",
     "@eslint/compat": "^2.1.0",
     "@posthog/ai": "^7.18.7",

--- a/src/app/api/insights/sweep/route.ts
+++ b/src/app/api/insights/sweep/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { regeneratePendingSummaries } from "@/server/ai/summary";
+
+// Cron-only durability sweep: retries game summaries that never reached `ready`.
+// Vercel Cron sends `Authorization: Bearer ${CRON_SECRET}`. Not Clerk-gated
+// (it's not in proxy.ts's protected matcher), so the CRON_SECRET check is the
+// only guard — keep it set in production.
+export async function GET(req: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || req.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const processed = await regeneratePendingSummaries();
+  return NextResponse.json({ processed });
+}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { ScoringShell } from "@/components/scoring/ScoringShell";
-import { getGameById } from "@/server/queries";
+import { getGameById, getGameSummary } from "@/server/queries";
 import { notFound } from "next/navigation";
 import transformGameData, { GameWithPlayersAndScores } from "@/lib/gameLogic";
 import {
@@ -7,6 +7,8 @@ import {
   assignColorsToPlayers,
 } from "@/lib/scoring/colors";
 import { auth } from "@clerk/nextjs/server";
+import { isLlmFeaturesEnabled } from "@/featureFlags";
+import { GameSummaryCard } from "@/components/insights/GameSummaryCard";
 
 export default async function GameView(props: {
   params: Promise<{ id: string }>;
@@ -14,10 +16,14 @@ export default async function GameView(props: {
   const params = await props.params;
 
   // Parallelize independent async calls — they don't depend on each other
-  const [gameData, { userId, orgId }] = await Promise.all([
-    getGameById(params.id),
-    auth(),
-  ]);
+  const [gameData, { userId, orgId }, summary, showInsights] = await Promise.all(
+    [
+      getGameById(params.id),
+      auth(),
+      getGameSummary(params.id),
+      isLlmFeaturesEnabled(),
+    ]
+  );
 
   if (!gameData) {
     notFound();
@@ -94,6 +100,12 @@ export default async function GameView(props: {
           })),
         }))}
       />
+      {isFinished && showInsights && (
+        <GameSummaryCard
+          status={summary?.status ?? "pending"}
+          content={summary?.content ?? null}
+        />
+      )}
     </section>
   );
 }

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -100,11 +100,8 @@ export default async function GameView(props: {
           })),
         }))}
       />
-      {isFinished && showInsights && (
-        <GameSummaryCard
-          status={summary?.status ?? "pending"}
-          content={summary?.content ?? null}
-        />
+      {isFinished && showInsights && summary && (
+        <GameSummaryCard status={summary.status} content={summary.content} />
       )}
     </section>
   );

--- a/src/components/__tests__/insights/GameSummaryCard.test.tsx
+++ b/src/components/__tests__/insights/GameSummaryCard.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { GameSummaryCard } from "@/components/insights/GameSummaryCard";
+
+describe("GameSummaryCard", () => {
+  it("renders the recap content when ready", () => {
+    render(<GameSummaryCard status="ready" content="Mike edged Sarah." />);
+    expect(screen.getByText("Mike edged Sarah.")).toBeInTheDocument();
+  });
+
+  it("shows a pending message while generating", () => {
+    render(<GameSummaryCard status="pending" content={null} />);
+    expect(screen.getByText(/being written/i)).toBeInTheDocument();
+  });
+
+  it("shows the insufficient-data message", () => {
+    render(<GameSummaryCard status="insufficient_data" content={null} />);
+    expect(screen.getByText(/not enough rounds/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing on failure", () => {
+    const { container } = render(
+      <GameSummaryCard status="failed" content={null} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/insights/GameSummaryCard.tsx
+++ b/src/components/insights/GameSummaryCard.tsx
@@ -1,0 +1,35 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Presentational: the number-bearing content is produced server-side; this only
+// renders the stored prose or a status placeholder.
+export function GameSummaryCard({
+  status,
+  content,
+}: {
+  status: string;
+  content: string | null;
+}) {
+  if (status === "failed") return null;
+
+  return (
+    <Card className="max-w-2xl mx-auto mt-4">
+      <CardHeader>
+        <CardTitle>Game Recap</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {status === "ready" && content ? (
+          <p>{content}</p>
+        ) : status === "insufficient_data" ? (
+          <p className="text-muted-foreground">Not enough rounds for a recap.</p>
+        ) : (
+          <p className="text-muted-foreground">Your recap is being written…</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/insights/__tests__/gameRecap.test.ts
+++ b/src/lib/insights/__tests__/gameRecap.test.ts
@@ -1,0 +1,136 @@
+import {
+  buildGameRecap,
+  latestSourceUpdatedAt,
+} from "@/lib/insights/gameRecap";
+import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
+
+type ScoreInput = { key: string; cards: number; blitz: number };
+
+function makeGame(
+  winThreshold: number,
+  names: Record<string, string>,
+  roundsData: ScoreInput[][]
+): GameWithPlayersAndScores {
+  const players = Object.entries(names).map(([key, username]) => ({
+    id: `gp_${key}`,
+    gameId: "game_1",
+    userId: key,
+    guestId: null,
+    accentColor: null,
+    user: { id: key, username } as never,
+    guestUser: null,
+  }));
+  const rounds = roundsData.map((scores, ri) => ({
+    id: `r${ri + 1}`,
+    gameId: "game_1",
+    round: ri + 1,
+    createdAt: new Date("2026-06-13T00:00:00Z"),
+    scores: scores.map((s) => ({
+      id: `s_${ri}_${s.key}`,
+      roundId: `r${ri + 1}`,
+      userId: s.key,
+      guestId: null,
+      totalCardsPlayed: s.cards,
+      blitzPileRemaining: s.blitz,
+      createdAt: new Date("2026-06-13T00:00:00Z"),
+      updatedAt: new Date(`2026-06-13T00:0${ri}:00Z`),
+    })),
+  }));
+  return {
+    id: "game_1",
+    winThreshold,
+    organizationId: "org_1",
+    isFinished: true,
+    createdAt: new Date("2026-06-13T00:00:00Z"),
+    endedAt: new Date("2026-06-13T01:00:00Z"),
+    winnerId: null,
+    players,
+    rounds,
+  } as unknown as GameWithPlayersAndScores;
+}
+
+describe("buildGameRecap", () => {
+  it("keys facts by playerKey and keeps real names out of the facts", () => {
+    // u1: 20-0=20, 18-4=14 -> 34 (wins, threshold 30). u2: 8, 10 -> 18.
+    const { facts, playerNames } = buildGameRecap(
+      makeGame(
+        30,
+        { u1: "Mike", u2: "Sarah" },
+        [
+          [
+            { key: "u1", cards: 20, blitz: 0 },
+            { key: "u2", cards: 14, blitz: 3 },
+          ],
+          [
+            { key: "u1", cards: 18, blitz: 2 },
+            { key: "u2", cards: 10, blitz: 0 },
+          ],
+        ]
+      )
+    );
+
+    expect(facts.winnerKey).toBe("u1");
+    expect(facts.standings[0].playerKey).toBe("u1");
+    expect(facts.standings[0].total).toBe(34);
+    expect(facts.standings[1].total).toBe(18);
+    expect(facts.biggestRound).toEqual({
+      delta: 20,
+      playerKey: "u1",
+      roundNumber: 1,
+    });
+    expect(facts.totalBlitzes).toBe(2);
+    expect(facts.blitzLeader?.blitzes).toBe(1);
+    // No real names leaked into the facts.
+    expect(JSON.stringify(facts)).not.toContain("Mike");
+    expect(JSON.stringify(facts)).not.toContain("Sarah");
+    expect(playerNames).toEqual({ u1: "Mike", u2: "Sarah" });
+  });
+
+  it("puts the tiebreak winner at rank 1 even when totals are equal", () => {
+    // Both reach 20 (threshold 20). Final round blitz: u1=1, u2=0 -> u2 wins.
+    const { facts } = buildGameRecap(
+      makeGame(
+        20,
+        { u1: "Mike", u2: "Sarah" },
+        [
+          [
+            { key: "u1", cards: 12, blitz: 0 },
+            { key: "u2", cards: 14, blitz: 1 },
+          ],
+          [
+            { key: "u1", cards: 10, blitz: 1 },
+            { key: "u2", cards: 8, blitz: 0 },
+          ],
+        ]
+      )
+    );
+
+    expect(facts.standings[0].total).toBe(facts.standings[1].total); // tie
+    expect(facts.winnerKey).toBe("u2");
+    expect(facts.standings[0].playerKey).toBe("u2");
+    expect(facts.tiebreakUsed).toBe(true);
+  });
+});
+
+describe("latestSourceUpdatedAt", () => {
+  it("returns the newest score updatedAt", () => {
+    const game = makeGame(
+      30,
+      { u1: "Mike", u2: "Sarah" },
+      [
+        [
+          { key: "u1", cards: 20, blitz: 0 },
+          { key: "u2", cards: 14, blitz: 3 },
+        ],
+        [
+          { key: "u1", cards: 18, blitz: 2 },
+          { key: "u2", cards: 10, blitz: 0 },
+        ],
+      ]
+    );
+    // round index 1 -> 2026-06-13T00:01:00Z is the newest
+    expect(latestSourceUpdatedAt(game).toISOString()).toBe(
+      "2026-06-13T00:01:00.000Z"
+    );
+  });
+});

--- a/src/lib/insights/__tests__/gameRecap.test.ts
+++ b/src/lib/insights/__tests__/gameRecap.test.ts
@@ -2,6 +2,7 @@ import {
   buildGameRecap,
   latestSourceUpdatedAt,
 } from "@/lib/insights/gameRecap";
+import { hashRecapFacts } from "@/lib/insights/recapHash";
 import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
 
 type ScoreInput = { key: string; cards: number; blitz: number };
@@ -109,6 +110,35 @@ describe("buildGameRecap", () => {
     expect(facts.winnerKey).toBe("u2");
     expect(facts.standings[0].playerKey).toBe("u2");
     expect(facts.tiebreakUsed).toBe(true);
+  });
+
+  it("produces an order-independent hash and tied biggest round", () => {
+    // Round 1 is a tie (both 12); the biggest round must resolve to the lowest
+    // playerKey (u1) no matter what order the DB returns players/scores in.
+    const r1: { key: string; cards: number; blitz: number }[] = [
+      { key: "u1", cards: 12, blitz: 0 },
+      { key: "u2", cards: 14, blitz: 1 },
+    ];
+    const r2: { key: string; cards: number; blitz: number }[] = [
+      { key: "u1", cards: 10, blitz: 1 },
+      { key: "u2", cards: 8, blitz: 0 },
+    ];
+    const forward = buildGameRecap(
+      makeGame(75, { u1: "Mike", u2: "Sarah" }, [r1, r2])
+    ).facts;
+    const reversed = buildGameRecap(
+      makeGame(75, { u2: "Sarah", u1: "Mike" }, [
+        [...r1].reverse(),
+        [...r2].reverse(),
+      ])
+    ).facts;
+
+    expect(forward.biggestRound).toEqual({
+      delta: 12,
+      playerKey: "u1",
+      roundNumber: 1,
+    });
+    expect(hashRecapFacts(forward)).toBe(hashRecapFacts(reversed));
   });
 });
 

--- a/src/lib/insights/__tests__/grounding.test.ts
+++ b/src/lib/insights/__tests__/grounding.test.ts
@@ -1,0 +1,30 @@
+import {
+  findUngroundedNumbers,
+  collectFactNumbers,
+} from "@/lib/insights/grounding";
+
+const facts = {
+  winThreshold: 75,
+  roundsPlayed: 3,
+  standings: [
+    { player: "Player A", total: 80, rank: 1 },
+    { player: "Player B", total: 40, rank: 2 },
+  ],
+  totalBlitzes: 3,
+};
+
+describe("findUngroundedNumbers", () => {
+  it("returns nothing when every number is grounded", () => {
+    const text = "Player A reached 80 over 3 rounds, beating 40.";
+    expect(findUngroundedNumbers(text, facts)).toEqual([]);
+  });
+
+  it("flags a fabricated number", () => {
+    const text = "Player A scored a record 999 points.";
+    expect(findUngroundedNumbers(text, facts)).toContain("999");
+  });
+
+  it("collects fact numbers as strings", () => {
+    expect(collectFactNumbers(facts).has("80")).toBe(true);
+  });
+});

--- a/src/lib/insights/__tests__/pseudonymize.test.ts
+++ b/src/lib/insights/__tests__/pseudonymize.test.ts
@@ -1,0 +1,58 @@
+import { pseudonymizeRecap, rehydrateNames } from "@/lib/insights/pseudonymize";
+import type { GameRecapFacts } from "@/lib/insights/gameRecap";
+
+const facts: GameRecapFacts = {
+  gameId: "g1",
+  organizationId: "o1",
+  winThreshold: 75,
+  roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { playerKey: "u1", total: 80, isWinner: true, rank: 1 },
+    { playerKey: "u2", total: 40, isWinner: false, rank: 2 },
+  ],
+  winnerKey: "u1",
+  tiebreakUsed: false,
+  biggestRound: { delta: 20, playerKey: "u1", roundNumber: 1 },
+  worstRound: { delta: -4, playerKey: "u2", roundNumber: 2 },
+  blitzLeader: { playerKey: "u1", blitzes: 2 },
+  totalBlitzes: 3,
+  leadChanges: 1,
+};
+
+describe("pseudonymizeRecap", () => {
+  it("maps players to positional pseudonyms and drops internal ids", () => {
+    const { promptFacts, nameMap } = pseudonymizeRecap(facts, {
+      u1: "Mike",
+      u2: "Sarah",
+    });
+
+    expect(promptFacts.winner).toBe("Player A");
+    expect(promptFacts.standings[0].player).toBe("Player A");
+    expect(promptFacts.standings[1].player).toBe("Player B");
+    expect(promptFacts.biggestRound.player).toBe("Player A");
+    expect(promptFacts.blitzLeader?.player).toBe("Player A");
+    expect(nameMap).toEqual({ "Player A": "Mike", "Player B": "Sarah" });
+
+    const json = JSON.stringify(promptFacts);
+    expect(json).not.toContain("Mike");
+    expect(json).not.toContain("u1"); // no internal playerKey
+    expect(json).not.toContain("g1"); // no gameId
+  });
+});
+
+describe("rehydrateNames", () => {
+  it("restores real names", () => {
+    const { nameMap } = pseudonymizeRecap(facts, { u1: "Mike", u2: "Sarah" });
+    expect(rehydrateNames("Player A edged out Player B.", nameMap)).toBe(
+      "Mike edged out Sarah."
+    );
+  });
+
+  it("replaces longer pseudonyms first to avoid numeric prefix clobbering", () => {
+    const map = { "Player 1": "Ann", "Player 10": "Bob" };
+    expect(rehydrateNames("Player 10 beat Player 1.", map)).toBe(
+      "Bob beat Ann."
+    );
+  });
+});

--- a/src/lib/insights/__tests__/recapHash.test.ts
+++ b/src/lib/insights/__tests__/recapHash.test.ts
@@ -1,0 +1,38 @@
+import { hashRecapFacts, stableStringify } from "@/lib/insights/recapHash";
+import type { GameRecapFacts } from "@/lib/insights/gameRecap";
+
+const facts = (overrides: Partial<GameRecapFacts> = {}): GameRecapFacts => ({
+  gameId: "g1",
+  organizationId: "o1",
+  winThreshold: 75,
+  roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { playerKey: "u1", total: 80, isWinner: true, rank: 1 },
+    { playerKey: "u2", total: 40, isWinner: false, rank: 2 },
+  ],
+  winnerKey: "u1",
+  tiebreakUsed: false,
+  biggestRound: { delta: 20, playerKey: "u1", roundNumber: 1 },
+  worstRound: { delta: -4, playerKey: "u2", roundNumber: 2 },
+  blitzLeader: { playerKey: "u1", blitzes: 2 },
+  totalBlitzes: 3,
+  leadChanges: 1,
+  ...overrides,
+});
+
+describe("hashRecapFacts", () => {
+  it("is stable for equal facts", () => {
+    expect(hashRecapFacts(facts())).toBe(hashRecapFacts(facts()));
+  });
+
+  it("changes when a number changes", () => {
+    expect(hashRecapFacts(facts())).not.toBe(
+      hashRecapFacts(facts({ totalBlitzes: 4 }))
+    );
+  });
+
+  it("stableStringify sorts object keys", () => {
+    expect(stableStringify({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+});

--- a/src/lib/insights/__tests__/summaryPrompt.test.ts
+++ b/src/lib/insights/__tests__/summaryPrompt.test.ts
@@ -1,0 +1,40 @@
+import {
+  buildSummaryPrompt,
+  PROMPT_VERSION,
+  DEFAULT_SUMMARY_OPTIONS,
+} from "@/lib/insights/summaryPrompt";
+import type { PromptFacts } from "@/lib/insights/pseudonymize";
+
+const promptFacts: PromptFacts = {
+  winThreshold: 75,
+  roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { player: "Player A", total: 80, isWinner: true, rank: 1 },
+    { player: "Player B", total: 40, isWinner: false, rank: 2 },
+  ],
+  winner: "Player A",
+  tiebreakUsed: false,
+  biggestRound: { delta: 20, player: "Player A", roundNumber: 1 },
+  worstRound: { delta: -4, player: "Player B", roundNumber: 2 },
+  blitzLeader: { player: "Player A", blitzes: 2 },
+  totalBlitzes: 3,
+  leadChanges: 1,
+};
+
+describe("buildSummaryPrompt", () => {
+  it("forbids second-person and invented facts, and embeds the facts", () => {
+    const { system, user } = buildSummaryPrompt(
+      promptFacts,
+      DEFAULT_SUMMARY_OPTIONS
+    );
+    expect(system.toLowerCase()).toContain("never invent");
+    expect(system).toMatch(/do not address.*"you"/i);
+    expect(user).toContain("Player A");
+    expect(user).toContain('"winner"');
+  });
+
+  it("exposes a stable prompt version", () => {
+    expect(PROMPT_VERSION).toBe("summary-v1");
+  });
+});

--- a/src/lib/insights/gameRecap.ts
+++ b/src/lib/insights/gameRecap.ts
@@ -1,0 +1,164 @@
+import transformGameData, { type GameWithPlayersAndScores } from "@/lib/gameLogic";
+import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+
+export const MIN_ROUNDS_FOR_SUMMARY = 2;
+export const MIN_PLAYERS_FOR_SUMMARY = 2;
+
+// A playerKey is a registered user's id OR a guest's id — never a display name,
+// so two guests sharing a name stay distinct.
+export interface RecapStanding {
+  playerKey: string;
+  total: number;
+  isWinner: boolean;
+  rank: number;
+}
+
+// Facts are built entirely in playerKey space with no real names and no raw
+// score rows, so the hash is order-stable and no display names reach the LLM.
+export interface GameRecapFacts {
+  gameId: string;
+  organizationId: string | null;
+  winThreshold: number;
+  roundsPlayed: number;
+  playerCount: number;
+  standings: RecapStanding[];
+  winnerKey: string | null;
+  tiebreakUsed: boolean;
+  biggestRound: { delta: number; playerKey: string; roundNumber: number };
+  worstRound: { delta: number; playerKey: string; roundNumber: number };
+  blitzLeader: { playerKey: string; blitzes: number } | null;
+  totalBlitzes: number;
+  leadChanges: number;
+}
+
+export interface BuiltRecap {
+  facts: GameRecapFacts;
+  /** playerKey -> real display name. Used only server-side for rehydration. */
+  playerNames: Record<string, string>;
+}
+
+export function buildGameRecap(game: GameWithPlayersAndScores): BuiltRecap {
+  const display = transformGameData(game);
+
+  const playerNames: Record<string, string> = {};
+  const identityNames: Record<string, string> = {};
+  for (const d of display) {
+    playerNames[d.id] = d.username;
+    identityNames[d.id] = d.id; // feed playerKeys as "names" so stats are keyed
+  }
+
+  // Per-round deltas + blitz counts, keyed by playerKey.
+  const rounds: RoundResult[] = game.rounds.map((round) => {
+    const deltas: Record<string, number> = {};
+    const blitzCounts: Record<string, number> = {};
+    for (const id of Object.keys(identityNames)) {
+      deltas[id] = 0;
+      blitzCounts[id] = 0;
+    }
+    for (const s of round.scores) {
+      const key = s.userId || s.guestId;
+      if (!key || !(key in identityNames)) continue;
+      deltas[key] = calculateRoundScore({
+        blitzPileRemaining: s.blitzPileRemaining,
+        totalCardsPlayed: s.totalCardsPlayed,
+      });
+      if (s.blitzPileRemaining === 0) blitzCounts[key] += 1;
+    }
+    return { deltas, blitzCounts };
+  });
+
+  // biggestRound/worstRound.playerName is now a playerKey (identity map).
+  const stats = calcGameStats(rounds, identityNames);
+
+  // Winner first, then total desc, then playerKey asc — so standings[0] is the
+  // real winner even when totals tie and the blitz-pile tiebreak decided it.
+  const sorted = [...display].sort(
+    (a, b) =>
+      (b.isWinner ? 1 : 0) - (a.isWinner ? 1 : 0) ||
+      b.total - a.total ||
+      a.id.localeCompare(b.id)
+  );
+  const standings: RecapStanding[] = sorted.map((d, i) => ({
+    playerKey: d.id,
+    total: d.total,
+    isWinner: !!d.isWinner,
+    rank: i + 1,
+  }));
+
+  const winner = display.find((d) => d.isWinner) ?? null;
+
+  const topTotal = standings.length
+    ? Math.max(...standings.map((s) => s.total))
+    : 0;
+  const reachedTop = standings.filter(
+    (s) => s.total >= game.winThreshold && s.total === topTotal
+  );
+  const tiebreakUsed = reachedTop.length > 1;
+
+  // Blitz leader: most blitzes, ties broken by lowest playerKey (deterministic).
+  let blitzLeader: { playerKey: string; blitzes: number } | null = null;
+  for (const key of Object.keys(stats.blitzCounts).sort()) {
+    const n = stats.blitzCounts[key];
+    if (n > 0 && (!blitzLeader || n > blitzLeader.blitzes)) {
+      blitzLeader = { playerKey: key, blitzes: n };
+    }
+  }
+
+  // Lead changes: cumulative leader transitions, leader ties broken by lowest key.
+  const cumulative: Record<string, number> = {};
+  for (const id of Object.keys(identityNames)) cumulative[id] = 0;
+  let prevLeader: string | null = null;
+  let leadChanges = 0;
+  for (const r of rounds) {
+    for (const [id, delta] of Object.entries(r.deltas)) cumulative[id] += delta;
+    let leader: string | null = null;
+    let best = -Infinity;
+    for (const id of Object.keys(cumulative).sort()) {
+      if (cumulative[id] > best) {
+        best = cumulative[id];
+        leader = id;
+      }
+    }
+    if (leader && prevLeader && leader !== prevLeader) leadChanges++;
+    prevLeader = leader;
+  }
+
+  const facts: GameRecapFacts = {
+    gameId: game.id,
+    organizationId: game.organizationId ?? null,
+    winThreshold: game.winThreshold,
+    roundsPlayed: stats.roundsPlayed,
+    playerCount: display.length,
+    standings,
+    winnerKey: winner?.id ?? null,
+    tiebreakUsed,
+    biggestRound: {
+      delta: stats.biggestRound.delta,
+      playerKey: stats.biggestRound.playerName,
+      roundNumber: stats.biggestRound.roundNumber,
+    },
+    worstRound: {
+      delta: stats.worstRound.delta,
+      playerKey: stats.worstRound.playerName,
+      roundNumber: stats.worstRound.roundNumber,
+    },
+    blitzLeader,
+    totalBlitzes: stats.totalBlitzes,
+    leadChanges,
+  };
+
+  return { facts, playerNames };
+}
+
+// Source timestamp for stale-summary detection: the newest score edit, falling
+// back to game end. Not part of the hashed facts.
+export function latestSourceUpdatedAt(game: GameWithPlayersAndScores): Date {
+  let latest: Date | null = null;
+  for (const r of game.rounds) {
+    for (const s of r.scores) {
+      if (s.updatedAt && (!latest || s.updatedAt > latest)) latest = s.updatedAt;
+    }
+  }
+  return latest ?? game.endedAt ?? new Date();
+}

--- a/src/lib/insights/gameRecap.ts
+++ b/src/lib/insights/gameRecap.ts
@@ -41,18 +41,23 @@ export interface BuiltRecap {
 export function buildGameRecap(game: GameWithPlayersAndScores): BuiltRecap {
   const display = transformGameData(game);
 
+  // Insert keys in sorted order so calcGameStats — which keeps the first of any
+  // tied biggest/worst round — is deterministic regardless of the DB's player
+  // ordering, keeping the recap hash stable.
+  const sortedKeys = display.map((d) => d.id).sort();
+  const nameByKey = new Map(display.map((d) => [d.id, d.username]));
   const playerNames: Record<string, string> = {};
   const identityNames: Record<string, string> = {};
-  for (const d of display) {
-    playerNames[d.id] = d.username;
-    identityNames[d.id] = d.id; // feed playerKeys as "names" so stats are keyed
+  for (const key of sortedKeys) {
+    playerNames[key] = nameByKey.get(key) ?? key;
+    identityNames[key] = key; // feed playerKeys as "names" so stats are keyed
   }
 
   // Per-round deltas + blitz counts, keyed by playerKey.
   const rounds: RoundResult[] = game.rounds.map((round) => {
     const deltas: Record<string, number> = {};
     const blitzCounts: Record<string, number> = {};
-    for (const id of Object.keys(identityNames)) {
+    for (const id of sortedKeys) {
       deltas[id] = 0;
       blitzCounts[id] = 0;
     }

--- a/src/lib/insights/grounding.ts
+++ b/src/lib/insights/grounding.ts
@@ -1,0 +1,19 @@
+// Soft guard: any integer in the prose that is not present in the facts is a
+// candidate hallucination. Used as a runtime warning and as the seed of the
+// fact-based eval. Works on any plain facts object.
+export function collectFactNumbers(facts: unknown): Set<string> {
+  const nums = new Set<string>();
+  const walk = (v: unknown): void => {
+    if (typeof v === "number") nums.add(String(v));
+    else if (Array.isArray(v)) v.forEach(walk);
+    else if (v && typeof v === "object") Object.values(v).forEach(walk);
+  };
+  walk(facts);
+  return nums;
+}
+
+export function findUngroundedNumbers(text: string, facts: unknown): string[] {
+  const allowed = collectFactNumbers(facts);
+  const inText = text.match(/-?\d+/g) ?? [];
+  return inText.filter((n) => !allowed.has(n));
+}

--- a/src/lib/insights/pseudonymize.ts
+++ b/src/lib/insights/pseudonymize.ts
@@ -35,8 +35,10 @@ export function pseudonymizeRecap(
   facts.standings.forEach((s, i) => {
     keyToPseudo[s.playerKey] = `Player ${ALPHABET[i] ?? String(i)}`;
   });
+  // Never fall back to a raw playerKey — if a fact somehow references a player
+  // outside standings, emit a neutral label instead of leaking an internal id.
   const px = (key: string | null): string | null =>
-    key == null ? null : keyToPseudo[key] ?? key;
+    key == null ? null : keyToPseudo[key] ?? "another player";
 
   const promptFacts: PromptFacts = {
     winThreshold: facts.winThreshold,

--- a/src/lib/insights/pseudonymize.ts
+++ b/src/lib/insights/pseudonymize.ts
@@ -1,0 +1,87 @@
+import type { GameRecapFacts } from "./gameRecap";
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+// The LLM-facing projection: pseudonymous players, no internal ids (gameId,
+// organizationId, playerKey are all dropped or replaced).
+export interface PromptFacts {
+  winThreshold: number;
+  roundsPlayed: number;
+  playerCount: number;
+  standings: { player: string; total: number; isWinner: boolean; rank: number }[];
+  winner: string | null;
+  tiebreakUsed: boolean;
+  biggestRound: { delta: number; player: string; roundNumber: number };
+  worstRound: { delta: number; player: string; roundNumber: number };
+  blitzLeader: { player: string; blitzes: number } | null;
+  totalBlitzes: number;
+  leadChanges: number;
+}
+
+export interface Pseudonymized {
+  promptFacts: PromptFacts;
+  /** pseudonym -> real display name, for rehydrating the model's output. */
+  nameMap: Record<string, string>;
+}
+
+// Pseudonyms are assigned by standings order (deterministic) and keyed by
+// playerKey — so duplicate display names never collapse, and real names /
+// internal ids never reach the model.
+export function pseudonymizeRecap(
+  facts: GameRecapFacts,
+  playerNames: Record<string, string>
+): Pseudonymized {
+  const keyToPseudo: Record<string, string> = {};
+  facts.standings.forEach((s, i) => {
+    keyToPseudo[s.playerKey] = `Player ${ALPHABET[i] ?? String(i)}`;
+  });
+  const px = (key: string | null): string | null =>
+    key == null ? null : keyToPseudo[key] ?? key;
+
+  const promptFacts: PromptFacts = {
+    winThreshold: facts.winThreshold,
+    roundsPlayed: facts.roundsPlayed,
+    playerCount: facts.playerCount,
+    standings: facts.standings.map((s) => ({
+      player: keyToPseudo[s.playerKey] ?? s.playerKey,
+      total: s.total,
+      isWinner: s.isWinner,
+      rank: s.rank,
+    })),
+    winner: px(facts.winnerKey),
+    tiebreakUsed: facts.tiebreakUsed,
+    biggestRound: {
+      delta: facts.biggestRound.delta,
+      player: px(facts.biggestRound.playerKey)!,
+      roundNumber: facts.biggestRound.roundNumber,
+    },
+    worstRound: {
+      delta: facts.worstRound.delta,
+      player: px(facts.worstRound.playerKey)!,
+      roundNumber: facts.worstRound.roundNumber,
+    },
+    blitzLeader: facts.blitzLeader
+      ? { player: px(facts.blitzLeader.playerKey)!, blitzes: facts.blitzLeader.blitzes }
+      : null,
+    totalBlitzes: facts.totalBlitzes,
+    leadChanges: facts.leadChanges,
+  };
+
+  const nameMap: Record<string, string> = {};
+  for (const [key, pseudo] of Object.entries(keyToPseudo)) {
+    nameMap[pseudo] = playerNames[key] ?? key;
+  }
+
+  return { promptFacts, nameMap };
+}
+
+export function rehydrateNames(
+  text: string,
+  nameMap: Record<string, string>
+): string {
+  // Replace longer pseudonyms first so "Player 1" doesn't clobber "Player 10".
+  const pairs = Object.entries(nameMap).sort((a, b) => b[0].length - a[0].length);
+  let out = text;
+  for (const [pseudo, real] of pairs) out = out.split(pseudo).join(real);
+  return out;
+}

--- a/src/lib/insights/recapHash.ts
+++ b/src/lib/insights/recapHash.ts
@@ -1,0 +1,18 @@
+import { createHash } from "crypto";
+import type { GameRecapFacts } from "./gameRecap";
+
+// Deterministic JSON with recursively sorted object keys, so the hash is stable
+// regardless of property insertion order.
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+export function hashRecapFacts(facts: GameRecapFacts): string {
+  return createHash("sha256").update(stableStringify(facts)).digest("hex");
+}

--- a/src/lib/insights/summaryPrompt.ts
+++ b/src/lib/insights/summaryPrompt.ts
@@ -1,0 +1,37 @@
+import type { PromptFacts } from "./pseudonymize";
+
+export const PROMPT_VERSION = "summary-v1";
+
+export interface SummaryOptions {
+  perspective: "neutral";
+  tone: "warm";
+  length: "paragraph";
+}
+
+export const DEFAULT_SUMMARY_OPTIONS: SummaryOptions = {
+  perspective: "neutral",
+  tone: "warm",
+  length: "paragraph",
+};
+
+export function buildSummaryPrompt(
+  promptFacts: PromptFacts,
+  _opts: SummaryOptions = DEFAULT_SUMMARY_OPTIONS
+): { system: string; user: string } {
+  const system = [
+    "You are a Dutch Blitz game announcer writing a short, warm, neutral recap of a finished game.",
+    "Scoring: each round a player scores (cards played) minus 2 times (cards left in their Blitz pile); first to the win threshold wins.",
+    "RULES:",
+    "- Only state facts present in the provided JSON. Never invent or infer numbers, names, or events.",
+    '- Neutral broadcaster voice. Do NOT address any player as "you".',
+    "- Refer to players by the names given (e.g. Player A).",
+    "- One warm paragraph, roughly 3 to 5 sentences. No headings, no bullet points, no preamble, no sign-off.",
+  ].join("\n");
+
+  const user =
+    "Game facts (JSON):\n" +
+    JSON.stringify(promptFacts, null, 2) +
+    "\n\nWrite the recap paragraph.";
+
+  return { system, user };
+}

--- a/src/server/__tests__/gameSummaryWiring.test.ts
+++ b/src/server/__tests__/gameSummaryWiring.test.ts
@@ -1,0 +1,133 @@
+// Verifies the post-game summary is scheduled from BOTH finish paths:
+// the direct "Finish" action and an edit that keeps a game finished.
+
+const mockAuth = jest.fn();
+jest.mock("@clerk/nextjs/server", () => ({ auth: () => mockAuth() }));
+
+const mockGameFindUnique = jest.fn();
+const mockGameUpdate = jest.fn();
+const mockUserFindUnique = jest.fn();
+const mockGuestFindUnique = jest.fn();
+const mockScoreUpdateMany = jest.fn();
+const mockTransaction = jest.fn();
+jest.mock("@/server/db/db", () => ({
+  __esModule: true,
+  default: {
+    game: {
+      findUnique: (...a: unknown[]) => mockGameFindUnique(...a),
+      update: (...a: unknown[]) => mockGameUpdate(...a),
+    },
+    user: { findUnique: (...a: unknown[]) => mockUserFindUnique(...a) },
+    guestUser: { findUnique: (...a: unknown[]) => mockGuestFindUnique(...a) },
+    score: { updateMany: (...a: unknown[]) => mockScoreUpdateMany(...a) },
+    $transaction: (...a: unknown[]) => mockTransaction(...a),
+  },
+}));
+
+jest.mock("@/app/posthog", () => ({
+  __esModule: true,
+  default: () => ({ capture: jest.fn() }),
+}));
+
+jest.mock("next/server", () => ({ after: (cb: () => unknown) => cb() }));
+
+const mockSchedule = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/server/ai/summary", () => ({
+  scheduleGameSummary: (...a: unknown[]) => mockSchedule(...a),
+}));
+
+jest.mock("@/server/email", () => ({
+  __esModule: true,
+  sendGameCompleteEmail: jest.fn().mockResolvedValue(undefined),
+  EMAIL_INTER_SEND_DELAY_MS: 0,
+}));
+
+const mockGetGameById = jest.fn();
+jest.mock("@/server/queries/games", () => ({
+  __esModule: true,
+  getGameById: (...a: unknown[]) => mockGetGameById(...a),
+}));
+
+import { updateGameAsFinished, updateRoundScores } from "@/server/mutations";
+
+function finishedGame() {
+  const player = (key: string, username: string) => ({
+    id: `gp_${key}`,
+    gameId: "game_1",
+    userId: key,
+    guestId: null,
+    accentColor: null,
+    user: { id: key, username },
+    guestUser: null,
+  });
+  const score = (key: string, cards: number, blitz: number, ri: number) => ({
+    id: `s_${ri}_${key}`,
+    roundId: `r${ri + 1}`,
+    userId: key,
+    guestId: null,
+    totalCardsPlayed: cards,
+    blitzPileRemaining: blitz,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return {
+    id: "game_1",
+    winThreshold: 30,
+    organizationId: "org_1",
+    isFinished: true,
+    winnerId: "u1", // u1 reaches 34 -> stays the winner
+    createdAt: new Date(),
+    endedAt: new Date(),
+    players: [player("u1", "Mike"), player("u2", "Sarah")],
+    rounds: [
+      { id: "r1", gameId: "game_1", round: 1, createdAt: new Date(), scores: [score("u1", 20, 0, 0), score("u2", 14, 3, 0)] },
+      { id: "r2", gameId: "game_1", round: 2, createdAt: new Date(), scores: [score("u1", 18, 2, 1), score("u2", 10, 0, 1)] },
+    ],
+  };
+}
+
+beforeEach(() => {
+  mockAuth.mockReset().mockReturnValue({ userId: "clerk_1", orgId: "org_1" });
+  mockGameFindUnique.mockReset();
+  mockGameUpdate.mockReset().mockResolvedValue({});
+  mockUserFindUnique.mockReset().mockResolvedValue({ username: "Mike" });
+  mockGuestFindUnique.mockReset();
+  mockScoreUpdateMany.mockReset().mockResolvedValue({ count: 1 });
+  mockTransaction.mockReset().mockImplementation((cb: (tx: unknown) => unknown) =>
+    cb({ score: { updateMany: (...a: unknown[]) => mockScoreUpdateMany(...a) } })
+  );
+  mockSchedule.mockClear();
+  mockGetGameById.mockReset();
+});
+
+describe("post-game summary wiring", () => {
+  it("schedules a summary when a game is finished directly", async () => {
+    mockGameFindUnique.mockResolvedValue({
+      id: "game_1",
+      organizationId: "org_1",
+      isFinished: false,
+      players: [],
+    });
+
+    await updateGameAsFinished("game_1", "u1", false);
+
+    expect(mockSchedule).toHaveBeenCalledWith("game_1");
+  });
+
+  it("schedules a summary when a finished game's scores are edited", async () => {
+    // requireGameInCircle lookup
+    mockGameFindUnique.mockResolvedValue({
+      id: "game_1",
+      organizationId: "org_1",
+    });
+    // sync re-reads the full game via getGameById
+    mockGetGameById.mockResolvedValue(finishedGame());
+
+    await updateRoundScores("game_1", "r2", [
+      { userId: "u1", blitzPileRemaining: 0, totalCardsPlayed: 18 },
+      { userId: "u2", blitzPileRemaining: 5, totalCardsPlayed: 10 },
+    ]);
+
+    expect(mockSchedule).toHaveBeenCalledWith("game_1");
+  });
+});

--- a/src/server/__tests__/gameSummaryWiring.test.ts
+++ b/src/server/__tests__/gameSummaryWiring.test.ts
@@ -130,4 +130,18 @@ describe("post-game summary wiring", () => {
 
     expect(mockSchedule).toHaveBeenCalledWith("game_1");
   });
+
+  it("does not fail the finish when summary scheduling throws", async () => {
+    mockGameFindUnique.mockResolvedValue({
+      id: "game_1",
+      organizationId: "org_1",
+      isFinished: false,
+      players: [],
+    });
+    mockSchedule.mockRejectedValueOnce(new Error("summary boom"));
+
+    await expect(
+      updateGameAsFinished("game_1", "u1", false)
+    ).resolves.toBeUndefined();
+  });
 });

--- a/src/server/__tests__/mutations.test.ts
+++ b/src/server/__tests__/mutations.test.ts
@@ -89,6 +89,12 @@ jest.mock("next/server", () => ({
   after: jest.fn((cb: () => Promise<void>) => void cb()),
 }));
 
+// Post-game summary generation is wired into the finish paths; stub it so
+// finalization tests don't trigger real LLM/DB work.
+jest.mock("@/server/ai/summary", () => ({
+  scheduleGameSummary: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("Game Mutations", () => {
   const mockUserId = "test-user-id";
   const mockGameId = "test-game-id";

--- a/src/server/ai/__tests__/claude.test.ts
+++ b/src/server/ai/__tests__/claude.test.ts
@@ -1,0 +1,58 @@
+jest.mock("@anthropic-ai/sdk", () => ({
+  __esModule: true,
+  default: class {
+    messages = { create: jest.fn() };
+  },
+}));
+
+import claude, {
+  generateSummaryText,
+  CLAUDE_SUMMARY_MODEL,
+} from "@/server/ai/claude";
+
+// The default export is the singleton instance, so its mocked create() is the
+// one generateSummaryText calls.
+const create = claude.messages.create as jest.Mock;
+
+describe("generateSummaryText", () => {
+  beforeEach(() => create.mockReset());
+
+  it("calls Claude with the summary model and sums all billed tokens", async () => {
+    create.mockResolvedValue({
+      stop_reason: "end_turn",
+      content: [
+        { type: "text", text: "A close " },
+        { type: "thinking", thinking: "..." },
+        { type: "text", text: "game." },
+      ],
+      usage: {
+        input_tokens: 30,
+        output_tokens: 12,
+        cache_creation_input_tokens: 5,
+        cache_read_input_tokens: 3,
+      },
+    });
+
+    const result = await generateSummaryText("SYSTEM", "USER");
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0].model).toBe(CLAUDE_SUMMARY_MODEL);
+    expect(CLAUDE_SUMMARY_MODEL).toBe("claude-opus-4-8");
+    expect(result.text).toBe("A close game.");
+    expect(result.tokensUsed).toBe(50);
+  });
+
+  it("throws on a refusal stop reason", async () => {
+    create.mockResolvedValue({ stop_reason: "refusal", content: [], usage: {} });
+    await expect(generateSummaryText("S", "U")).rejects.toThrow(/refus/i);
+  });
+
+  it("throws when the model returns only whitespace", async () => {
+    create.mockResolvedValue({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "   " }],
+      usage: {},
+    });
+    await expect(generateSummaryText("S", "U")).rejects.toThrow(/empty/i);
+  });
+});

--- a/src/server/ai/__tests__/summary.test.ts
+++ b/src/server/ai/__tests__/summary.test.ts
@@ -1,0 +1,216 @@
+const mockFindUnique = jest.fn();
+const mockUpsert = jest.fn();
+const mockUpdate = jest.fn();
+const mockFindMany = jest.fn();
+jest.mock("@/server/db/db", () => ({
+  __esModule: true,
+  default: {
+    gameSummary: {
+      findUnique: (...a: unknown[]) => mockFindUnique(...a),
+      upsert: (...a: unknown[]) => mockUpsert(...a),
+      update: (...a: unknown[]) => mockUpdate(...a),
+      findMany: (...a: unknown[]) => mockFindMany(...a),
+    },
+  },
+}));
+
+const mockGetGameById = jest.fn();
+jest.mock("@/server/queries/games", () => ({
+  __esModule: true,
+  getGameById: (...a: unknown[]) => mockGetGameById(...a),
+}));
+
+const mockGenerate = jest.fn();
+jest.mock("@/server/ai/claude", () => ({
+  __esModule: true,
+  CLAUDE_SUMMARY_MODEL: "claude-opus-4-8",
+  generateSummaryText: (...a: unknown[]) => mockGenerate(...a),
+}));
+
+const mockFlag = jest.fn();
+jest.mock("@/featureFlags", () => ({
+  __esModule: true,
+  isLlmFeaturesEnabled: () => mockFlag(),
+}));
+
+const mockAfter = jest.fn((cb: () => unknown) => cb());
+jest.mock("next/server", () => ({ after: (cb: () => unknown) => mockAfter(cb) }));
+
+import {
+  enqueueGameSummary,
+  runGameSummary,
+  scheduleGameSummary,
+} from "@/server/ai/summary";
+import { buildGameRecap } from "@/lib/insights/gameRecap";
+import { hashRecapFacts } from "@/lib/insights/recapHash";
+import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
+
+type ScoreInput = { key: string; cards: number; blitz: number };
+function makeGame(
+  winThreshold: number,
+  names: Record<string, string>,
+  roundsData: ScoreInput[][]
+): GameWithPlayersAndScores {
+  const players = Object.entries(names).map(([key, username]) => ({
+    id: `gp_${key}`,
+    gameId: "game_1",
+    userId: key,
+    guestId: null,
+    accentColor: null,
+    user: { id: key, username } as never,
+    guestUser: null,
+  }));
+  const rounds = roundsData.map((scores, ri) => ({
+    id: `r${ri + 1}`,
+    gameId: "game_1",
+    round: ri + 1,
+    createdAt: new Date("2026-06-13T00:00:00Z"),
+    scores: scores.map((s) => ({
+      id: `s_${ri}_${s.key}`,
+      roundId: `r${ri + 1}`,
+      userId: s.key,
+      guestId: null,
+      totalCardsPlayed: s.cards,
+      blitzPileRemaining: s.blitz,
+      createdAt: new Date("2026-06-13T00:00:00Z"),
+      updatedAt: new Date("2026-06-13T00:00:00Z"),
+    })),
+  }));
+  return {
+    id: "game_1",
+    winThreshold,
+    organizationId: "org_1",
+    isFinished: true,
+    createdAt: new Date("2026-06-13T00:00:00Z"),
+    endedAt: new Date("2026-06-13T01:00:00Z"),
+    winnerId: null,
+    players,
+    rounds,
+  } as unknown as GameWithPlayersAndScores;
+}
+
+// u1 (Mike) wins 34-18 over u2 (Sarah), threshold 30, 2 rounds.
+const readyGame = () =>
+  makeGame(
+    30,
+    { u1: "Mike", u2: "Sarah" },
+    [
+      [
+        { key: "u1", cards: 20, blitz: 0 },
+        { key: "u2", cards: 14, blitz: 3 },
+      ],
+      [
+        { key: "u1", cards: 18, blitz: 2 },
+        { key: "u2", cards: 10, blitz: 0 },
+      ],
+    ]
+  );
+
+const readyHash = hashRecapFacts(buildGameRecap(readyGame()).facts);
+
+beforeEach(() => {
+  mockFindUnique.mockReset();
+  mockUpsert.mockReset().mockResolvedValue({});
+  mockUpdate.mockReset().mockResolvedValue({});
+  mockFindMany.mockReset();
+  mockGetGameById.mockReset();
+  mockGenerate.mockReset();
+  mockFlag.mockReset();
+  mockAfter.mockClear();
+});
+
+describe("enqueueGameSummary", () => {
+  it("upserts a pending row and reports enqueued for a fresh game", async () => {
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await enqueueGameSummary("game_1");
+
+    expect(result).toEqual({ enqueued: true });
+    const call = mockUpsert.mock.calls.at(-1)![0];
+    expect(call.create.status).toBe("pending");
+    expect(call.create.sourceStatsHash).toBe(readyHash);
+  });
+
+  it("skips when a ready summary already matches the hash", async () => {
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue({
+      status: "ready",
+      sourceStatsHash: readyHash,
+    });
+
+    const result = await enqueueGameSummary("game_1");
+
+    expect(result).toEqual({ enqueued: false });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("marks insufficient_data for a 1-round game", async () => {
+    const g = readyGame();
+    g.rounds = [g.rounds[0]];
+    mockGetGameById.mockResolvedValue(g);
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await enqueueGameSummary("game_1");
+
+    expect(result).toEqual({ enqueued: false });
+    expect(mockUpsert.mock.calls.at(-1)![0].create.status).toBe(
+      "insufficient_data"
+    );
+  });
+});
+
+describe("runGameSummary", () => {
+  it("writes a ready summary with rehydrated real names", async () => {
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue({ status: "pending", sourceStatsHash: readyHash });
+    mockGenerate.mockResolvedValue({
+      text: "Player A edged Player B.",
+      tokensUsed: 42,
+    });
+
+    await runGameSummary("game_1");
+
+    const ready = mockUpsert.mock.calls.find((c) => c[0].update.status === "ready");
+    expect(ready).toBeDefined();
+    expect(ready![0].update.content).toBe("Mike edged Sarah.");
+    expect(ready![0].update.model).toBe("claude-opus-4-8");
+    expect(ready![0].update.tokensUsed).toBe(42);
+  });
+
+  it("records failed status when the LLM throws", async () => {
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue({ status: "pending", sourceStatsHash: readyHash });
+    mockGenerate.mockRejectedValue(new Error("boom"));
+
+    await runGameSummary("game_1");
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "failed", error: "boom" }),
+      })
+    );
+  });
+});
+
+describe("scheduleGameSummary", () => {
+  it("does nothing when the llm-features flag is off", async () => {
+    mockFlag.mockResolvedValue(false);
+
+    await scheduleGameSummary("game_1");
+
+    expect(mockGetGameById).not.toHaveBeenCalled();
+    expect(mockAfter).not.toHaveBeenCalled();
+  });
+
+  it("enqueues and schedules the run when the flag is on", async () => {
+    mockFlag.mockResolvedValue(true);
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue(null);
+    mockGenerate.mockResolvedValue({ text: "Player A wins.", tokensUsed: 5 });
+
+    await scheduleGameSummary("game_1");
+
+    expect(mockAfter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/ai/__tests__/summary.test.ts
+++ b/src/server/ai/__tests__/summary.test.ts
@@ -145,6 +145,19 @@ describe("enqueueGameSummary", () => {
     expect(mockUpsert).not.toHaveBeenCalled();
   });
 
+  it("does not re-schedule when a pending row already matches the hash", async () => {
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue({
+      status: "pending",
+      sourceStatsHash: readyHash,
+    });
+
+    const result = await enqueueGameSummary("game_1");
+
+    expect(result).toEqual({ enqueued: false });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
   it("resets the retry budget when the hash changes", async () => {
     mockGetGameById.mockResolvedValue(readyGame());
     mockFindUnique.mockResolvedValue({
@@ -203,6 +216,8 @@ describe("runGameSummary", () => {
 
     const call = mockUpdateMany.mock.calls.at(-1)![0];
     expect(call.where.sourceStatsHash).toBe(readyHash);
+    // A failed write must never knock a concurrently-succeeded ready row back.
+    expect(call.where.status).toEqual({ not: "ready" });
     expect(call.data.status).toBe("failed");
     expect(call.data.error).toBe("boom");
   });

--- a/src/server/ai/__tests__/summary.test.ts
+++ b/src/server/ai/__tests__/summary.test.ts
@@ -1,6 +1,6 @@
 const mockFindUnique = jest.fn();
 const mockUpsert = jest.fn();
-const mockUpdate = jest.fn();
+const mockUpdateMany = jest.fn();
 const mockFindMany = jest.fn();
 jest.mock("@/server/db/db", () => ({
   __esModule: true,
@@ -8,7 +8,7 @@ jest.mock("@/server/db/db", () => ({
     gameSummary: {
       findUnique: (...a: unknown[]) => mockFindUnique(...a),
       upsert: (...a: unknown[]) => mockUpsert(...a),
-      update: (...a: unknown[]) => mockUpdate(...a),
+      updateMany: (...a: unknown[]) => mockUpdateMany(...a),
       findMany: (...a: unknown[]) => mockFindMany(...a),
     },
   },
@@ -111,7 +111,7 @@ const readyHash = hashRecapFacts(buildGameRecap(readyGame()).facts);
 beforeEach(() => {
   mockFindUnique.mockReset();
   mockUpsert.mockReset().mockResolvedValue({});
-  mockUpdate.mockReset().mockResolvedValue({});
+  mockUpdateMany.mockReset().mockResolvedValue({ count: 1 });
   mockFindMany.mockReset();
   mockGetGameById.mockReset();
   mockGenerate.mockReset();
@@ -145,6 +145,19 @@ describe("enqueueGameSummary", () => {
     expect(mockUpsert).not.toHaveBeenCalled();
   });
 
+  it("resets the retry budget when the hash changes", async () => {
+    mockGetGameById.mockResolvedValue(readyGame());
+    mockFindUnique.mockResolvedValue({
+      status: "failed",
+      sourceStatsHash: "OLD_HASH",
+      retryCount: 5,
+    });
+
+    await enqueueGameSummary("game_1");
+
+    expect(mockUpsert.mock.calls.at(-1)![0].update.retryCount).toBe(0);
+  });
+
   it("marks insufficient_data for a 1-round game", async () => {
     const g = readyGame();
     g.rounds = [g.rounds[0]];
@@ -161,7 +174,7 @@ describe("enqueueGameSummary", () => {
 });
 
 describe("runGameSummary", () => {
-  it("writes a ready summary with rehydrated real names", async () => {
+  it("writes ready via a hash-conditional update with rehydrated names", async () => {
     mockGetGameById.mockResolvedValue(readyGame());
     mockFindUnique.mockResolvedValue({ status: "pending", sourceStatsHash: readyHash });
     mockGenerate.mockResolvedValue({
@@ -171,25 +184,27 @@ describe("runGameSummary", () => {
 
     await runGameSummary("game_1");
 
-    const ready = mockUpsert.mock.calls.find((c) => c[0].update.status === "ready");
-    expect(ready).toBeDefined();
-    expect(ready![0].update.content).toBe("Mike edged Sarah.");
-    expect(ready![0].update.model).toBe("claude-opus-4-8");
-    expect(ready![0].update.tokensUsed).toBe(42);
+    const call = mockUpdateMany.mock.calls.at(-1)![0];
+    // Conditional on the hash this run generated for — guards against a stale
+    // run overwriting newer work.
+    expect(call.where.sourceStatsHash).toBe(readyHash);
+    expect(call.data.status).toBe("ready");
+    expect(call.data.content).toBe("Mike edged Sarah.");
+    expect(call.data.model).toBe("claude-opus-4-8");
+    expect(call.data.tokensUsed).toBe(42);
   });
 
-  it("records failed status when the LLM throws", async () => {
+  it("records failed status (hash-conditional) when the LLM throws", async () => {
     mockGetGameById.mockResolvedValue(readyGame());
     mockFindUnique.mockResolvedValue({ status: "pending", sourceStatsHash: readyHash });
     mockGenerate.mockRejectedValue(new Error("boom"));
 
     await runGameSummary("game_1");
 
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ status: "failed", error: "boom" }),
-      })
-    );
+    const call = mockUpdateMany.mock.calls.at(-1)![0];
+    expect(call.where.sourceStatsHash).toBe(readyHash);
+    expect(call.data.status).toBe("failed");
+    expect(call.data.error).toBe("boom");
   });
 });
 

--- a/src/server/ai/claude.ts
+++ b/src/server/ai/claude.ts
@@ -1,0 +1,64 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+// Mirrors the Prisma singleton pattern in src/server/db/db.ts so hot-reload in
+// dev doesn't open a new client per request.
+const claudeSingleton = () =>
+  new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+declare const globalThis: {
+  claudeGlobal: ReturnType<typeof claudeSingleton>;
+} & typeof global;
+
+const claude = globalThis.claudeGlobal ?? claudeSingleton();
+
+export default claude;
+
+if (process.env.NODE_ENV !== "production") globalThis.claudeGlobal = claude;
+
+export const CLAUDE_SUMMARY_MODEL = "claude-opus-4-8";
+
+export interface GeneratedText {
+  text: string;
+  tokensUsed: number;
+}
+
+// Single, non-streaming Messages call. Adaptive thinking + low effort: the task
+// is short and runs async (latency-insensitive), so we trade a little cost for
+// reliably grounded prose. No sampling params (removed on Opus 4.8). Throws on
+// refusal or empty output so callers never persist an empty "ready" summary.
+export async function generateSummaryText(
+  system: string,
+  user: string
+): Promise<GeneratedText> {
+  const res = await claude.messages.create({
+    model: CLAUDE_SUMMARY_MODEL,
+    max_tokens: 1024,
+    thinking: { type: "adaptive" },
+    output_config: { effort: "low" },
+    system: [{ type: "text", text: system }],
+    messages: [{ role: "user", content: user }],
+  } satisfies Anthropic.MessageCreateParamsNonStreaming);
+
+  if (res.stop_reason === "refusal") {
+    throw new Error("Claude refused to generate the summary");
+  }
+
+  const text = res.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("")
+    .trim();
+
+  if (!text) {
+    throw new Error("Claude returned an empty summary");
+  }
+
+  const u = res.usage;
+  const tokensUsed =
+    (u?.input_tokens ?? 0) +
+    (u?.output_tokens ?? 0) +
+    (u?.cache_creation_input_tokens ?? 0) +
+    (u?.cache_read_input_tokens ?? 0);
+
+  return { text, tokensUsed };
+}

--- a/src/server/ai/summary.ts
+++ b/src/server/ai/summary.ts
@@ -1,0 +1,169 @@
+import prisma from "@/server/db/db";
+import { after } from "next/server";
+import { getGameById } from "@/server/queries/games";
+import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
+import { isLlmFeaturesEnabled } from "@/featureFlags";
+import {
+  buildGameRecap,
+  latestSourceUpdatedAt,
+  MIN_ROUNDS_FOR_SUMMARY,
+  MIN_PLAYERS_FOR_SUMMARY,
+} from "@/lib/insights/gameRecap";
+import { hashRecapFacts } from "@/lib/insights/recapHash";
+import { pseudonymizeRecap, rehydrateNames } from "@/lib/insights/pseudonymize";
+import {
+  buildSummaryPrompt,
+  PROMPT_VERSION,
+  DEFAULT_SUMMARY_OPTIONS,
+} from "@/lib/insights/summaryPrompt";
+import { findUngroundedNumbers } from "@/lib/insights/grounding";
+import { generateSummaryText, CLAUDE_SUMMARY_MODEL } from "./claude";
+
+const MAX_RETRIES = 5;
+
+type SummaryStatus = "pending" | "ready" | "failed" | "insufficient_data";
+
+function whereKey(gameId: string) {
+  return { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } };
+}
+
+type UpsertExtra = {
+  status: SummaryStatus;
+  content?: string;
+  model?: string;
+  tokensUsed?: number;
+};
+
+async function upsertSummary(
+  gameId: string,
+  organizationId: string | null,
+  hash: string,
+  sourceUpdatedAt: Date,
+  extra: UpsertExtra
+): Promise<void> {
+  await prisma.gameSummary.upsert({
+    where: whereKey(gameId),
+    create: {
+      gameId,
+      organizationId,
+      promptVersion: PROMPT_VERSION,
+      sourceStatsHash: hash,
+      sourceUpdatedAt,
+      ...extra,
+    },
+    update: { sourceStatsHash: hash, sourceUpdatedAt, error: null, ...extra },
+  });
+}
+
+// Synchronous, in-request, primary DB. Guarantees a durable row exists before
+// the response returns, so the sweep can always find work. Returns
+// { enqueued: true } only when an LLM run is actually needed.
+export async function enqueueGameSummary(
+  gameId: string
+): Promise<{ enqueued: boolean }> {
+  const game = (await getGameById(gameId)) as GameWithPlayersAndScores | null;
+  if (!game) return { enqueued: false };
+
+  const { facts } = buildGameRecap(game);
+  const hash = hashRecapFacts(facts);
+  const sourceUpdatedAt = latestSourceUpdatedAt(game);
+
+  const existing = await prisma.gameSummary.findUnique({ where: whereKey(gameId) });
+  if (existing?.status === "ready" && existing.sourceStatsHash === hash) {
+    return { enqueued: false };
+  }
+
+  if (
+    facts.roundsPlayed < MIN_ROUNDS_FOR_SUMMARY ||
+    facts.playerCount < MIN_PLAYERS_FOR_SUMMARY
+  ) {
+    await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
+      status: "insufficient_data",
+    });
+    return { enqueued: false };
+  }
+
+  await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
+    status: "pending",
+  });
+  return { enqueued: true };
+}
+
+// The LLM call. Idempotent (re-checks ready + hash before spending tokens) so
+// it is safe to call from both the after() hook and the retry sweep.
+export async function runGameSummary(gameId: string): Promise<void> {
+  const game = (await getGameById(gameId)) as GameWithPlayersAndScores | null;
+  if (!game) return;
+
+  const { facts, playerNames } = buildGameRecap(game);
+  const hash = hashRecapFacts(facts);
+  const sourceUpdatedAt = latestSourceUpdatedAt(game);
+
+  const existing = await prisma.gameSummary.findUnique({ where: whereKey(gameId) });
+  if (existing?.status === "ready" && existing.sourceStatsHash === hash) return;
+
+  if (
+    facts.roundsPlayed < MIN_ROUNDS_FOR_SUMMARY ||
+    facts.playerCount < MIN_PLAYERS_FOR_SUMMARY
+  ) {
+    await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
+      status: "insufficient_data",
+    });
+    return;
+  }
+
+  try {
+    const { promptFacts, nameMap } = pseudonymizeRecap(facts, playerNames);
+    const { system, user } = buildSummaryPrompt(
+      promptFacts,
+      DEFAULT_SUMMARY_OPTIONS
+    );
+    const { text, tokensUsed } = await generateSummaryText(system, user);
+
+    const ungrounded = findUngroundedNumbers(text, promptFacts);
+    if (ungrounded.length) {
+      console.warn(
+        `[insights] ungrounded numbers in summary ${gameId}:`,
+        ungrounded
+      );
+    }
+
+    await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
+      status: "ready",
+      content: rehydrateNames(text, nameMap),
+      model: CLAUDE_SUMMARY_MODEL,
+      tokensUsed,
+    });
+  } catch (err) {
+    await prisma.gameSummary.update({
+      where: whereKey(gameId),
+      data: {
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+        retryCount: { increment: 1 },
+      },
+    });
+  }
+}
+
+// Flag-gated entry point used by the game-finish paths. Writes the durable
+// pending row synchronously, then runs the LLM after the response is sent.
+export async function scheduleGameSummary(gameId: string): Promise<void> {
+  if (!(await isLlmFeaturesEnabled())) return;
+  const { enqueued } = await enqueueGameSummary(gameId);
+  if (enqueued) after(() => runGameSummary(gameId));
+}
+
+// Durability sweep — wire to a cron route. Retries rows that never reached
+// `ready`. Idempotent per game.
+export async function regeneratePendingSummaries(limit = 20): Promise<number> {
+  const stuck = await prisma.gameSummary.findMany({
+    where: {
+      status: { in: ["pending", "failed"] },
+      retryCount: { lt: MAX_RETRIES },
+    },
+    take: limit,
+  });
+  for (const s of stuck) await runGameSummary(s.gameId);
+  return stuck.length;
+}

--- a/src/server/ai/summary.ts
+++ b/src/server/ai/summary.ts
@@ -21,25 +21,20 @@ import { generateSummaryText, CLAUDE_SUMMARY_MODEL } from "./claude";
 
 const MAX_RETRIES = 5;
 
-type SummaryStatus = "pending" | "ready" | "failed" | "insufficient_data";
-
 function whereKey(gameId: string) {
   return { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } };
 }
 
-type UpsertExtra = {
-  status: SummaryStatus;
-  content?: string;
-  model?: string;
-  tokensUsed?: number;
-};
-
-async function upsertSummary(
+// Enqueue (in-request) owns the pending row via upsert. It resets the retry
+// budget whenever the source hash changes, so new work after a score edit is
+// always sweepable even if the previous hash exhausted its retries.
+async function upsertPending(
   gameId: string,
   organizationId: string | null,
   hash: string,
   sourceUpdatedAt: Date,
-  extra: UpsertExtra
+  status: "pending" | "insufficient_data",
+  isNewHash: boolean
 ): Promise<void> {
   await prisma.gameSummary.upsert({
     where: whereKey(gameId),
@@ -49,15 +44,41 @@ async function upsertSummary(
       promptVersion: PROMPT_VERSION,
       sourceStatsHash: hash,
       sourceUpdatedAt,
-      ...extra,
+      status,
     },
-    update: { sourceStatsHash: hash, sourceUpdatedAt, error: null, ...extra },
+    update: {
+      sourceStatsHash: hash,
+      sourceUpdatedAt,
+      status,
+      error: null,
+      ...(isNewHash ? { retryCount: 0 } : {}),
+    },
+  });
+}
+
+type RunData =
+  | { status: "ready"; content: string; model: string; tokensUsed: number; error: null }
+  | { status: "failed"; error: string; retryCount: { increment: number } }
+  | { status: "insufficient_data"; error: null };
+
+// A run only persists its result if the row STILL carries the hash this run
+// generated for. If a newer enqueue (e.g. a mid-generation score edit) changed
+// the hash, this stale result is discarded and the newer pending row survives
+// for its own run / the sweep.
+async function writeRunResult(
+  gameId: string,
+  hash: string,
+  data: RunData
+): Promise<void> {
+  await prisma.gameSummary.updateMany({
+    where: { gameId, promptVersion: PROMPT_VERSION, sourceStatsHash: hash },
+    data,
   });
 }
 
 // Synchronous, in-request, primary DB. Guarantees a durable row exists before
-// the response returns, so the sweep can always find work. Returns
-// { enqueued: true } only when an LLM run is actually needed.
+// the response returns. Returns { enqueued: true } only when an LLM run is
+// actually needed.
 export async function enqueueGameSummary(
   gameId: string
 ): Promise<{ enqueued: boolean }> {
@@ -72,32 +93,43 @@ export async function enqueueGameSummary(
   if (existing?.status === "ready" && existing.sourceStatsHash === hash) {
     return { enqueued: false };
   }
+  const isNewHash = !existing || existing.sourceStatsHash !== hash;
 
   if (
     facts.roundsPlayed < MIN_ROUNDS_FOR_SUMMARY ||
     facts.playerCount < MIN_PLAYERS_FOR_SUMMARY
   ) {
-    await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
-      status: "insufficient_data",
-    });
+    await upsertPending(
+      gameId,
+      facts.organizationId,
+      hash,
+      sourceUpdatedAt,
+      "insufficient_data",
+      isNewHash
+    );
     return { enqueued: false };
   }
 
-  await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
-    status: "pending",
-  });
+  await upsertPending(
+    gameId,
+    facts.organizationId,
+    hash,
+    sourceUpdatedAt,
+    "pending",
+    isNewHash
+  );
   return { enqueued: true };
 }
 
-// The LLM call. Idempotent (re-checks ready + hash before spending tokens) so
-// it is safe to call from both the after() hook and the retry sweep.
+// The LLM call. Idempotent (skips when a ready summary already matches the
+// hash) and race-safe (terminal writes are conditional on the hash). Safe to
+// call from both the after() hook and the retry sweep.
 export async function runGameSummary(gameId: string): Promise<void> {
   const game = (await getGameById(gameId)) as GameWithPlayersAndScores | null;
   if (!game) return;
 
   const { facts, playerNames } = buildGameRecap(game);
   const hash = hashRecapFacts(facts);
-  const sourceUpdatedAt = latestSourceUpdatedAt(game);
 
   const existing = await prisma.gameSummary.findUnique({ where: whereKey(gameId) });
   if (existing?.status === "ready" && existing.sourceStatsHash === hash) return;
@@ -106,8 +138,9 @@ export async function runGameSummary(gameId: string): Promise<void> {
     facts.roundsPlayed < MIN_ROUNDS_FOR_SUMMARY ||
     facts.playerCount < MIN_PLAYERS_FOR_SUMMARY
   ) {
-    await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
+    await writeRunResult(gameId, hash, {
       status: "insufficient_data",
+      error: null,
     });
     return;
   }
@@ -128,20 +161,18 @@ export async function runGameSummary(gameId: string): Promise<void> {
       );
     }
 
-    await upsertSummary(gameId, facts.organizationId, hash, sourceUpdatedAt, {
+    await writeRunResult(gameId, hash, {
       status: "ready",
       content: rehydrateNames(text, nameMap),
       model: CLAUDE_SUMMARY_MODEL,
       tokensUsed,
+      error: null,
     });
   } catch (err) {
-    await prisma.gameSummary.update({
-      where: whereKey(gameId),
-      data: {
-        status: "failed",
-        error: err instanceof Error ? err.message : String(err),
-        retryCount: { increment: 1 },
-      },
+    await writeRunResult(gameId, hash, {
+      status: "failed",
+      error: err instanceof Error ? err.message : String(err),
+      retryCount: { increment: 1 },
     });
   }
 }

--- a/src/server/ai/summary.ts
+++ b/src/server/ai/summary.ts
@@ -25,16 +25,16 @@ function whereKey(gameId: string) {
   return { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } };
 }
 
-// Enqueue (in-request) owns the pending row via upsert. It resets the retry
-// budget whenever the source hash changes, so new work after a score edit is
-// always sweepable even if the previous hash exhausted its retries.
+// Enqueue (in-request) owns the pending row via upsert. It only runs when the
+// source hash is new (see enqueueGameSummary), so the update path always resets
+// the retry budget — new work after a score edit is sweepable even if the
+// previous hash exhausted its retries.
 async function upsertPending(
   gameId: string,
   organizationId: string | null,
   hash: string,
   sourceUpdatedAt: Date,
-  status: "pending" | "insufficient_data",
-  isNewHash: boolean
+  status: "pending" | "insufficient_data"
 ): Promise<void> {
   await prisma.gameSummary.upsert({
     where: whereKey(gameId),
@@ -51,7 +51,7 @@ async function upsertPending(
       sourceUpdatedAt,
       status,
       error: null,
-      ...(isNewHash ? { retryCount: 0 } : {}),
+      retryCount: 0,
     },
   });
 }
@@ -64,14 +64,21 @@ type RunData =
 // A run only persists its result if the row STILL carries the hash this run
 // generated for. If a newer enqueue (e.g. a mid-generation score edit) changed
 // the hash, this stale result is discarded and the newer pending row survives
-// for its own run / the sweep.
+// for its own run / the sweep. A `failed` write additionally never knocks a
+// `ready` row back — a concurrent run for the same hash may already have
+// succeeded.
 async function writeRunResult(
   gameId: string,
   hash: string,
   data: RunData
 ): Promise<void> {
   await prisma.gameSummary.updateMany({
-    where: { gameId, promptVersion: PROMPT_VERSION, sourceStatsHash: hash },
+    where: {
+      gameId,
+      promptVersion: PROMPT_VERSION,
+      sourceStatsHash: hash,
+      ...(data.status === "failed" ? { status: { not: "ready" as const } } : {}),
+    },
     data,
   });
 }
@@ -90,10 +97,13 @@ export async function enqueueGameSummary(
   const sourceUpdatedAt = latestSourceUpdatedAt(game);
 
   const existing = await prisma.gameSummary.findUnique({ where: whereKey(gameId) });
-  if (existing?.status === "ready" && existing.sourceStatsHash === hash) {
+
+  // The row already reflects the current source state — nothing to schedule.
+  // Whatever its status (ready / pending / failed / insufficient), the sweep
+  // retries any non-ready row, so re-triggering here would only duplicate work.
+  if (existing && existing.sourceStatsHash === hash) {
     return { enqueued: false };
   }
-  const isNewHash = !existing || existing.sourceStatsHash !== hash;
 
   if (
     facts.roundsPlayed < MIN_ROUNDS_FOR_SUMMARY ||
@@ -104,8 +114,7 @@ export async function enqueueGameSummary(
       facts.organizationId,
       hash,
       sourceUpdatedAt,
-      "insufficient_data",
-      isNewHash
+      "insufficient_data"
     );
     return { enqueued: false };
   }
@@ -115,8 +124,7 @@ export async function enqueueGameSummary(
     facts.organizationId,
     hash,
     sourceUpdatedAt,
-    "pending",
-    isNewHash
+    "pending"
   );
   return { enqueued: true };
 }

--- a/src/server/db/migrations/20260613000000_add_game_summary/migration.sql
+++ b/src/server/db/migrations/20260613000000_add_game_summary/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "GameSummaryStatus" AS ENUM ('pending', 'ready', 'failed', 'insufficient_data');
+
+-- CreateTable
+CREATE TABLE "GameSummary" (
+    "id" TEXT NOT NULL,
+    "game_id" TEXT NOT NULL,
+    "organization_id" TEXT,
+    "audience_user_id" TEXT,
+    "status" "GameSummaryStatus" NOT NULL DEFAULT 'pending',
+    "content" TEXT,
+    "model" TEXT,
+    "prompt_version" TEXT NOT NULL,
+    "source_stats_hash" TEXT NOT NULL,
+    "source_updated_at" TIMESTAMP(3) NOT NULL,
+    "tokens_used" INTEGER,
+    "error" TEXT,
+    "retry_count" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GameSummary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GameSummary_status_idx" ON "GameSummary"("status");
+
+-- CreateIndex
+CREATE INDEX "GameSummary_game_id_idx" ON "GameSummary"("game_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GameSummary_game_id_prompt_version_key" ON "GameSummary"("game_id", "prompt_version");
+
+-- AddForeignKey
+ALTER TABLE "GameSummary" ADD CONSTRAINT "GameSummary_game_id_fkey" FOREIGN KEY ("game_id") REFERENCES "Game"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/server/db/schema.prisma
+++ b/src/server/db/schema.prisma
@@ -49,6 +49,7 @@ model Game {
   organizationId String?       @map("organization_id")
   players        GamePlayers[]
   rounds         Round[]
+  summaries      GameSummary[]
 
   @@index([organizationId])
 }
@@ -109,5 +110,39 @@ model OrganizationMembership {
   @@unique([organizationId, userId])
   @@index([organizationId])
   @@index([userId])
+}
+
+enum GameSummaryStatus {
+  pending
+  ready
+  failed
+  insufficient_data
+}
+
+// LLM-generated post-game recap. One current row per game per prompt version
+// (audienceUserId is null in MVP — neutral recap). The row is also the durable
+// job unit: status + retryCount drive enqueue/run/sweep. sourceStatsHash is
+// stored (not in the unique key) so score edits after finish are detected.
+model GameSummary {
+  id              String            @id @default(uuid())
+  gameId          String            @map("game_id")
+  organizationId  String?           @map("organization_id")
+  audienceUserId  String?           @map("audience_user_id")
+  status          GameSummaryStatus @default(pending)
+  content         String?
+  model           String?
+  promptVersion   String            @map("prompt_version")
+  sourceStatsHash String            @map("source_stats_hash")
+  sourceUpdatedAt DateTime          @map("source_updated_at")
+  tokensUsed      Int?              @map("tokens_used")
+  error           String?
+  retryCount      Int               @default(0) @map("retry_count")
+  createdAt       DateTime          @default(now()) @map("created_at")
+  updatedAt       DateTime          @updatedAt @map("updated_at")
+  game            Game              @relation(fields: [gameId], references: [id])
+
+  @@unique([gameId, promptVersion])
+  @@index([status])
+  @@index([gameId])
 }
 

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -7,6 +7,7 @@ import { requireAuthContext, assertGameInCircle } from "./common";
 import { getOrgMemberClerkIds } from "../clerkOrgs";
 import { sendGameCompleteEmail, EMAIL_INTER_SEND_DELAY_MS } from "../email";
 import { resolvePlayerColor, assignColorsToPlayers } from "@/lib/scoring/colors";
+import { scheduleGameSummary } from "@/server/ai/summary";
 
 // Create a new game with support for guest players
 export async function createGame(
@@ -200,6 +201,10 @@ export async function updateGameAsFinished(
       isGuestWinner: isGuestWinner,
     },
   });
+
+  // Generate the post-game recap. Flag-gated; writes a durable pending row now
+  // (primary, in-request) and runs the LLM after the response is sent.
+  await scheduleGameSummary(gameId);
 
   // Schedule emails after the response is sent — the platform keeps the
   // runtime alive until the callback resolves (replaces fire-and-forget IIFE).

--- a/src/server/mutations/games.ts
+++ b/src/server/mutations/games.ts
@@ -204,7 +204,12 @@ export async function updateGameAsFinished(
 
   // Generate the post-game recap. Flag-gated; writes a durable pending row now
   // (primary, in-request) and runs the LLM after the response is sent.
-  await scheduleGameSummary(gameId);
+  // Best-effort: a summary failure must never fail the game finish.
+  try {
+    await scheduleGameSummary(gameId);
+  } catch (error) {
+    console.error("[insights] failed to schedule game summary", error);
+  }
 
   // Schedule emails after the response is sent — the platform keeps the
   // runtime alive until the callback resolves (replaces fire-and-forget IIFE).

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -63,7 +63,12 @@ async function syncGameCompletionAfterScoreWrite(
   // Reaching here means the game is finished (no-winner and finalize branches
   // returned earlier). A finished game may have been edited, so refresh the
   // recap — hash-gated, so it's a no-op when the scores are unchanged.
-  await scheduleGameSummary(gameId);
+  // Best-effort: a summary failure must never fail the score edit.
+  try {
+    await scheduleGameSummary(gameId);
+  } catch (error) {
+    console.error("[insights] failed to schedule game summary", error);
+  }
 }
 
 // Create new round with scores

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -10,6 +10,7 @@ import { validateGameRules, ValidationError } from "@/lib/validation/gameRules";
 import { getGameCompletion } from "@/lib/gameLogic";
 import { getGameById } from "@/server/queries/games";
 import { updateGameAsFinished } from "./games";
+import { scheduleGameSummary } from "@/server/ai/summary";
 
 async function syncGameCompletionAfterScoreWrite(
   gameId: string,
@@ -58,6 +59,11 @@ async function syncGameCompletionAfterScoreWrite(
       properties: { game_id: gameId, new_winner_id: completion.winnerId },
     });
   }
+
+  // Reaching here means the game is finished (no-winner and finalize branches
+  // returned earlier). A finished game may have been edited, so refresh the
+  // recap — hash-gated, so it's a no-op when the scores are unchanged.
+  await scheduleGameSummary(gameId);
 }
 
 // Create new round with scores

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -3,6 +3,7 @@ export {
   getGames,
   getGameById,
   getLegacyGames,
+  getGameSummary,
   getDashboardStats,
   getPlayerBattingAverage,
   getHighestAndLowestScore,

--- a/src/server/queries/index.ts
+++ b/src/server/queries/index.ts
@@ -1,4 +1,5 @@
 export { getGames, getGameById, getLegacyGames } from "./games";
+export { getGameSummary } from "./insights";
 export {
   getDashboardStats,
   getPlayerBattingAverage,

--- a/src/server/queries/insights.ts
+++ b/src/server/queries/insights.ts
@@ -1,0 +1,13 @@
+import "server-only";
+
+import prisma from "@/server/db/db";
+import { PROMPT_VERSION } from "@/lib/insights/summaryPrompt";
+
+// Reads from the PRIMARY: this single indexed row is written in-request at game
+// finish, so reading the primary avoids replica lag showing no recap on a
+// just-finished game.
+export async function getGameSummary(gameId: string) {
+  return prisma.gameSummary.findUnique({
+    where: { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } },
+  });
+}


### PR DESCRIPTION
## LLM Insights — Phase 1: post-game summaries (M0a + M1)

First slice of the LLM Insights feature (design spec: `docs/superpowers/specs/2026-06-13-llm-insights-design.md`). After a Dutch Blitz game finishes, Claude writes a short, warm, neutral recap grounded in the real scores. **Ships dark** behind the existing `llm-features` flag.

This is the integration base; later phases (chat, metric-plan DSL, dashboard tiles, RLS substrate) land as their own PRs into `feature/llm-insights`.

### What's in it

**M0a — Claude foundation**
- `@anthropic-ai/sdk` + a singleton client; `generateSummaryText` (Opus 4.8, adaptive thinking, low effort, no sampling params; throws on refusal/empty; sums all billed tokens).
- `GameSummary` model + migration (hand-authored, verified **identical** to Prisma's canonical DDL). The row doubles as the durable job unit (status machine + `retryCount` + `sourceStatsHash`).

**M1 — Post-game summary**
- Deterministic recap pipeline (pure, fully tested): `buildGameRecap` → `recapHash` → `pseudonymize` → `summaryPrompt` → `grounding`. Built entirely in **playerKey space**: real names and internal IDs never reach the model; names are re-substituted server-side after generation.
- **Durable generation**: a synchronous in-request enqueue writes the pending row (primary DB), then the LLM runs via `after()`; a `/api/insights/sweep` cron route (CRON_SECRET-guarded) retries anything stuck. Terminal writes are **hash-conditional** so a stale in-flight run can't clobber newer work.
- Triggered from **both** finish paths — direct finish and edits to already-finished games (`syncGameCompletionAfterScoreWrite`) — hash-gated so unchanged scores are a no-op.
- Renders on the game page (flag-gated) with ready / pending / insufficient states.

### Review

Two Codex review rounds (plan + implementation), all findings addressed:
- **Plan**: durability (write pending synchronously, not inside `after()`), the finished-game-edit trigger, playerKey-keyed pseudonymization, `migrate dev` → hand-authored migration, `satisfies` over `as`, refusal/empty handling, `sourceUpdatedAt` from source data.
- **Implementation**: race-safe hash-conditional terminal writes (blocker), order-independent recap hash, retry-budget reset on new hash, no fake "pending" UI.

### Verification

- `npm test` → **28 suites / 172 tests** pass · `npm run typecheck` clean · `npm run lint` clean.
- No changes to existing gameplay schema or scoring logic; existing mutation tests still pass (summary stubbed).

### 🔴 Needs a human before this does anything in prod

- [ ] Set **`ANTHROPIC_API_KEY`** in the deployment env (+ local `.env` for manual E2E). Documented in `.env.example`.
- [ ] The migration auto-applies on deploy via `prisma migrate deploy` (build script). For local testing, apply it against a dev DB.
- [ ] Enable the **`llm-features`** PostHog flag for the intended users — both generation and rendering are gated on it.
- [ ] Set **`CRON_SECRET`** and add a Vercel cron hitting `GET /api/insights/sweep` (e.g. every 10 min) for retry durability.
- [ ] Manual E2E: finish a game (flag on), confirm the recap renders with the real winner and grounded numbers, no second-person.

### Known limitations (by design, for MVP)

- Games finished while the flag was **off** are never back-filled (summaries are forward-looking from flag enablement). A backfill job can be added later.
- Pseudonymization is correct for duplicate guest names (keyed by playerKey); the broader chat-side scope/RLS substrate is a later phase.
- In an **exact double-tie** (two players with the same cumulative total *and* the same final-round blitz pile), the recap hash can vary by DB score order, because `breakTie` (core scoring) keeps the first DB-order candidate. Impact is only a rare redundant regeneration — within any render the recap agrees with the scoreboard. The underlying core-scoring non-determinism is tracked as a separate follow-up (out of scope here per repo convention: don't change scoring logic in an insights PR).
