### PR TITLE
feat(insights): LLM-driven Insights (integration / umbrella) [WIP]

### DIFF
--- a/docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md
+++ b/docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md
@@ -1484,3 +1484,48 @@ Plan complete and saved to `docs/superpowers/plans/2026-06-13-llm-insights-phase
 2. **Inline Execution** — execute tasks in this session with batch checkpoints.
 
 Which approach?
+
+---
+
+## Codex Review Revisions (applied 2026-06-13)
+
+Codex reviewed this plan against the codebase: 3 blockers + 9 should-fix + 2 nice-to-have, all accepted. The changes below **override the task bodies above where they conflict** — the implementation follows these.
+
+### Durability & triggers (blockers #1, #2, #3)
+
+`after()` is post-response best-effort, not a queue, and the original plan created the `GameSummary` row *inside* the async callback — so a dropped `after()` left nothing for the sweep to retry. Also, this app lets users **edit finished games** (`src/server/mutations/rounds.ts:167`), and that path never called the trigger.
+
+- **Split generation into a synchronous enqueue + an async run** in `src/server/ai/summary.ts`:
+  - `enqueueGameSummary(gameId): Promise<{ enqueued: boolean }>` — runs **in-request** (primary DB). Loads the game via `getGameById` (primary), builds facts, hashes. Writes nothing and returns `{enqueued:false}` if there's no game or an existing `ready` row already matches the hash; upserts `insufficient_data` (returns false) for `<2` rounds / `<2` players; otherwise upserts a `pending` row with the new hash and returns `{enqueued:true}`. A durable row therefore exists before the response returns.
+  - `runGameSummary(gameId): Promise<void>` — the LLM call; idempotent (re-checks `ready`+hash); writes `ready` or `failed` (+`retryCount`).
+  - `scheduleGameSummary(gameId): Promise<void>` — `if (!(await isLlmFeaturesEnabled())) return; const { enqueued } = await enqueueGameSummary(gameId); if (enqueued) after(() => runGameSummary(gameId));`
+  - `regeneratePendingSummaries(limit=20)` — sweeps `pending`/`failed` (retryCount<5) → `runGameSummary`.
+- **Trigger from both finish paths:** `updateGameAsFinished` calls `await scheduleGameSummary(gameId)` (covers the direct "Finish" button and the finalize-via-score-write branch, which routes through `updateGameAsFinished`). ADD a trailing `await scheduleGameSummary(gameId)` at the end of `syncGameCompletionAfterScoreWrite` in `rounds.ts` so edits that keep a game finished regenerate when the hash changes (hash-gating ⇒ no-op when nothing changed; a reopened game falls out because the page renders only when finished). This replaces Task 9's single `after(() => generateGameSummary(...))`.
+- **Sweep route:** add `src/app/api/insights/sweep/route.ts` (GET, guarded by a `CRON_SECRET` request header) calling `regeneratePendingSummaries()`. Vercel cron schedule + `CRON_SECRET` env = human step.
+- **Read status from primary:** `getGameSummary` reads from `@/server/db/db` (primary; one indexed row) to dodge replica lag on a just-finished game, and the page renders the pending state when `isFinished && !summary`.
+- **Flag-gated:** `scheduleGameSummary` early-returns unless `isLlmFeaturesEnabled()`; the page only renders the card when the flag is on. Phase 1 ships dark.
+
+### Recap correctness (#5, #6, #7, #8) — build in pseudonym-ready, playerKey space
+
+`buildGameRecap(game)` now returns `{ facts: GameRecapFacts; playerNames: Record<playerKey, realName> }`:
+- Feeds `calcGameStats` an **identity** name map (`{key: key}`) so `biggestRound`/`worstRound` carry the **playerKey**, not a display name.
+- `GameRecapFacts` identifiers are all `playerKey`; it contains **no real names and no raw score arrays** — only aggregates — so the hash is order-stable.
+- `standings` sorted by **(isWinner first, total desc, playerKey asc)** ⇒ `standings[0]` is the real winner even under the final-round blitz-pile tiebreak; `rank` follows that order. `winnerKey` replaces `winnerName`.
+- `blitzLeader` ties broken by lowest `playerKey` (deterministic).
+- `pseudonymizeRecap(facts, playerNames)` assigns `keyToPseudo` ("Player A/B"…) by standings order, replaces every `playerKey` in the facts with its pseudonym, and returns `{ promptFacts, nameMap: { "Player A": realName } }`. Real names never enter `calcGameStats` or the prompt; internal UUIDs never reach the LLM; duplicate guest names no longer collapse (keyed by playerKey). `rehydrateNames(text, nameMap)` maps pseudonym→real for storage.
+- `hashRecapFacts` hashes `facts` (no timestamps). `sourceUpdatedAt` is computed separately (below), not hashed.
+
+### Claude client (#9, #10, #11)
+
+- Use `satisfies Anthropic.MessageCreateParamsNonStreaming` (Codex confirmed the installed SDK 0.104.x types support `claude-opus-4-8`, `thinking:{type:"adaptive"}`, `output_config.effort`); fall back to a typed cast only if `tsc` rejects it.
+- `generateSummaryText` **throws** when the text is empty or `res.stop_reason === "refusal"` ⇒ the row becomes `failed`, never `ready` with empty content.
+- `tokensUsed = input_tokens + output_tokens + (cache_creation_input_tokens ?? 0) + (cache_read_input_tokens ?? 0)`.
+- `sourceUpdatedAt` = `max(score.updatedAt across loaded rounds)`, falling back to `game.endedAt ?? new Date()` — computed in the orchestration from the loaded game, **not** `new Date()`.
+
+### Tests (#12)
+
+- Add `jest.mock("@/server/ai/summary", () => ({ scheduleGameSummary: jest.fn() }))` to `src/server/__tests__/mutations.test.ts` so existing finalization tests don't run real summary work. The Task 9 wiring test asserts `scheduleGameSummary` was called.
+
+### Kept as-is (#13)
+
+- `@updatedAt` on `GameSummary` is intentional (status-machine timing); it knowingly diverges from the repo's manual `updated_at` convention.

--- a/docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md
+++ b/docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md
@@ -1,0 +1,1486 @@
+# LLM Insights — Phase 1 (M0a Claude foundation + M1 Post-game summary) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a Dutch Blitz game finishes, generate a warm, neutral, fact-grounded narrative recap with Claude and show it on the game page — built on the official `@anthropic-ai/sdk`.
+
+**Architecture:** Pure functions build a deterministic `GameRecapFacts` payload from the already-loaded game (reusing `transformGameData` + `calcGameStats`), hash it for idempotency, pseudonymize player names, prompt Claude (Opus 4.8) for prose, then rehydrate real names. A durable `GameSummary` row (status: `pending`/`ready`/`failed`/`insufficient_data`) is the unit of work — written from the **primary** DB at game-finish (no replica lag), generated asynchronously via Next's `after()`, retryable via a sweep. Reads use the replica.
+
+**Tech Stack:** Next.js 16 (App Router/RSC), TypeScript, Prisma 7 (`@prisma/adapter-pg`, Postgres/Neon), `@anthropic-ai/sdk`, Jest + Testing Library.
+
+**Scope note:** Phase 1 deliberately uses the `GameSummary` row itself as the durable job unit (status + `retryCount`), not the generic `InsightJob` table from the spec — that table is only justified once tiles add a second job kind (later phase). Pseudonymization is name-keyed here; the playerKey-keyed version lands with the chat phase (M2). Both are noted in the spec's open items.
+
+---
+
+### Task 0: Create the Phase-1 branch off the integration branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch from the integration branch**
+
+```bash
+git checkout feature/llm-insights
+git pull --ff-only 2>/dev/null || true
+git checkout -b feature/llm-insights-p1-summary
+```
+
+- [ ] **Step 2: Confirm the branch + clean tree (spec present)**
+
+Run: `git status --short && git branch --show-current`
+Expected: branch is `feature/llm-insights-p1-summary`; `docs/superpowers/specs/2026-06-13-llm-insights-design.md` already tracked; no other staged changes.
+
+---
+
+## M0a — Claude foundation
+
+### Task 1: Add the Anthropic SDK + Claude client singleton
+
+**Files:**
+- Modify: `package.json` (add dependency)
+- Create: `src/server/ai/claude.ts`
+- Create: `src/server/ai/__tests__/claude.test.ts`
+- Env: `.env` (add `ANTHROPIC_API_KEY`), `.env.example` if it exists
+
+- [ ] **Step 1: Install the SDK**
+
+Run: `npm install @anthropic-ai/sdk`
+Expected: `@anthropic-ai/sdk` appears in `package.json` dependencies; install succeeds.
+
+- [ ] **Step 2: Add the API key to env**
+
+Add to `.env` (do NOT commit a real key):
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+If `.env.example` exists, add a placeholder line `ANTHROPIC_API_KEY=` there too.
+
+- [ ] **Step 3: Write the failing test**
+
+Create `src/server/ai/__tests__/claude.test.ts`:
+
+```ts
+const create = jest.fn();
+
+jest.mock("@anthropic-ai/sdk", () => ({
+  __esModule: true,
+  default: class {
+    messages = { create };
+  },
+}));
+
+import { generateSummaryText, CLAUDE_SUMMARY_MODEL } from "@/server/ai/claude";
+
+describe("generateSummaryText", () => {
+  beforeEach(() => create.mockReset());
+
+  it("calls Claude with the summary model and returns concatenated text + token total", async () => {
+    create.mockResolvedValue({
+      content: [
+        { type: "text", text: "A close " },
+        { type: "text", text: "game." },
+      ],
+      usage: { input_tokens: 30, output_tokens: 12 },
+    });
+
+    const result = await generateSummaryText("SYSTEM", "USER");
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0].model).toBe(CLAUDE_SUMMARY_MODEL);
+    expect(CLAUDE_SUMMARY_MODEL).toBe("claude-opus-4-8");
+    expect(result.text).toBe("A close game.");
+    expect(result.tokensUsed).toBe(42);
+  });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `npm test -- src/server/ai/__tests__/claude.test.ts`
+Expected: FAIL — cannot find module `@/server/ai/claude`.
+
+- [ ] **Step 5: Write the implementation**
+
+Create `src/server/ai/claude.ts`:
+
+```ts
+import Anthropic from "@anthropic-ai/sdk";
+
+// Mirrors the Prisma singleton pattern in src/server/db/db.ts so hot-reload in
+// dev doesn't open a new client per request.
+const claudeSingleton = () =>
+  new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+declare const globalThis: {
+  claudeGlobal: ReturnType<typeof claudeSingleton>;
+} & typeof global;
+
+const claude = globalThis.claudeGlobal ?? claudeSingleton();
+
+export default claude;
+
+if (process.env.NODE_ENV !== "production") globalThis.claudeGlobal = claude;
+
+export const CLAUDE_SUMMARY_MODEL = "claude-opus-4-8";
+
+export interface GeneratedText {
+  text: string;
+  tokensUsed: number;
+}
+
+// Single, non-streaming Messages call. Adaptive thinking + low effort: the task
+// is short and runs async (latency-insensitive), so we trade a little cost for
+// reliably grounded prose. No sampling params (removed on Opus 4.8).
+export async function generateSummaryText(
+  system: string,
+  user: string
+): Promise<GeneratedText> {
+  const res = await claude.messages.create({
+    model: CLAUDE_SUMMARY_MODEL,
+    max_tokens: 1024,
+    thinking: { type: "adaptive" },
+    output_config: { effort: "low" },
+    system: [{ type: "text", text: system }],
+    messages: [{ role: "user", content: user }],
+  } as Anthropic.MessageCreateParamsNonStreaming);
+
+  const text = res.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("")
+    .trim();
+
+  const tokensUsed =
+    (res.usage?.input_tokens ?? 0) + (res.usage?.output_tokens ?? 0);
+
+  return { text, tokensUsed };
+}
+```
+
+> If TypeScript rejects `thinking` / `output_config` (installed SDK types lag the API), keep the `as Anthropic.MessageCreateParamsNonStreaming` cast — the wire fields are correct per the Claude API.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npm test -- src/server/ai/__tests__/claude.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json src/server/ai/claude.ts src/server/ai/__tests__/claude.test.ts
+git commit -m "feat(insights): add Anthropic SDK + Claude summary client"
+```
+
+---
+
+### Task 2: Add the `GameSummary` model + migration
+
+**Files:**
+- Modify: `src/server/db/schema.prisma`
+
+- [ ] **Step 1: Add the enum, model, and back-relation**
+
+In `src/server/db/schema.prisma`, add a back-relation field to `Game` (inside the `Game` model, alongside `rounds`):
+
+```prisma
+  summaries      GameSummary[]
+```
+
+Then append at the end of the file:
+
+```prisma
+enum GameSummaryStatus {
+  pending
+  ready
+  failed
+  insufficient_data
+}
+
+model GameSummary {
+  id              String            @id @default(uuid())
+  gameId          String            @map("game_id")
+  organizationId  String?           @map("organization_id")
+  audienceUserId  String?           @map("audience_user_id")
+  status          GameSummaryStatus @default(pending)
+  content         String?
+  model           String?
+  promptVersion   String            @map("prompt_version")
+  sourceStatsHash String            @map("source_stats_hash")
+  sourceUpdatedAt DateTime          @map("source_updated_at")
+  tokensUsed      Int?              @map("tokens_used")
+  error           String?
+  retryCount      Int               @default(0) @map("retry_count")
+  createdAt       DateTime          @default(now()) @map("created_at")
+  updatedAt       DateTime          @updatedAt @map("updated_at")
+
+  game            Game              @relation(fields: [gameId], references: [id])
+
+  @@unique([gameId, promptVersion])
+  @@index([status])
+  @@index([gameId])
+}
+```
+
+> `audienceUserId` is always null in MVP (neutral recap); the unique key is `(gameId, promptVersion)` so there is exactly one current summary per game per prompt version, and `upsert` has a clean target. `sourceStatsHash` is stored (not in the unique key) so we can detect score changes after finish and regenerate.
+
+- [ ] **Step 2: Create + apply the migration (regenerates the client)**
+
+Run: `npx prisma migrate dev --name add_game_summary`
+Expected: a new migration under `src/server/db/migrations/`, applied to the dev DB; Prisma client regenerated (so `prisma.gameSummary` exists).
+
+- [ ] **Step 3: Verify the client type compiles**
+
+Run: `npm run typecheck`
+Expected: PASS (no errors). Confirms `prisma.gameSummary` and `GameSummaryStatus` are generated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/db/schema.prisma src/server/db/migrations
+git commit -m "feat(insights): add GameSummary model + migration"
+```
+
+---
+
+## M1 — Post-game summary
+
+### Task 3: `buildGameRecap` — deterministic fact builder (pure)
+
+**Files:**
+- Create: `src/lib/insights/gameRecap.ts`
+- Create: `src/lib/insights/__tests__/gameRecap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/insights/__tests__/gameRecap.test.ts`:
+
+```ts
+import { buildGameRecap } from "@/lib/insights/gameRecap";
+import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
+
+// Minimal fixture: 2 players, 2 rounds. Player "u1" (Mike) wins.
+// Round score = totalCardsPlayed - 2*blitzPileRemaining.
+function fixture(): GameWithPlayersAndScores {
+  const base = {
+    createdAt: new Date(),
+    endedAt: null,
+    winnerId: null,
+    organizationId: "org_1",
+    isFinished: true,
+  };
+  return {
+    id: "game_1",
+    winThreshold: 30,
+    ...base,
+    players: [
+      { id: "gp1", gameId: "game_1", userId: "u1", guestId: null, accentColor: null,
+        user: { id: "u1", username: "Mike" } as never, guestUser: null },
+      { id: "gp2", gameId: "game_1", userId: "u2", guestId: null, accentColor: null,
+        user: { id: "u2", username: "Sarah" } as never, guestUser: null },
+    ],
+    rounds: [
+      { id: "r1", gameId: "game_1", round: 1, createdAt: new Date(),
+        scores: [
+          { id: "s1", roundId: "r1", userId: "u1", guestId: null, totalCardsPlayed: 20, blitzPileRemaining: 0, createdAt: new Date(), updatedAt: new Date() },
+          { id: "s2", roundId: "r1", userId: "u2", guestId: null, totalCardsPlayed: 14, blitzPileRemaining: 3, createdAt: new Date(), updatedAt: new Date() },
+        ] },
+      { id: "r2", gameId: "game_1", round: 2, createdAt: new Date(),
+        scores: [
+          { id: "s3", roundId: "r2", userId: "u1", guestId: null, totalCardsPlayed: 18, blitzPileRemaining: 2, createdAt: new Date(), updatedAt: new Date() },
+          { id: "s4", roundId: "r2", userId: "u2", guestId: null, totalCardsPlayed: 10, blitzPileRemaining: 0, createdAt: new Date(), updatedAt: new Date() },
+        ] },
+    ],
+  } as unknown as GameWithPlayersAndScores;
+}
+
+describe("buildGameRecap", () => {
+  it("computes standings, winner, and round counts", () => {
+    const facts = buildGameRecap(fixture());
+    // u1: round1 = 20-0 = 20, round2 = 18-4 = 14 -> 34 (>= 30 threshold)
+    // u2: round1 = 14-6 = 8,  round2 = 10-0 = 10 -> 18
+    expect(facts.roundsPlayed).toBe(2);
+    expect(facts.playerCount).toBe(2);
+    expect(facts.winnerName).toBe("Mike");
+    expect(facts.standings[0].name).toBe("Mike");
+    expect(facts.standings[0].total).toBe(34);
+    expect(facts.standings[0].rank).toBe(1);
+    expect(facts.standings[1].total).toBe(18);
+  });
+
+  it("identifies the biggest round and the blitz leader", () => {
+    const facts = buildGameRecap(fixture());
+    expect(facts.biggestRound.delta).toBe(20);
+    expect(facts.biggestRound.playerName).toBe("Mike");
+    expect(facts.totalBlitzes).toBe(2); // u1 r1, u2 r2
+    expect(facts.blitzLeader).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/insights/__tests__/gameRecap.test.ts`
+Expected: FAIL — cannot find module `@/lib/insights/gameRecap`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/insights/gameRecap.ts`:
+
+```ts
+import transformGameData, { type GameWithPlayersAndScores } from "@/lib/gameLogic";
+import { calcGameStats, type RoundResult, type GameStats } from "@/lib/scoring/gameStats";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+
+export const MIN_ROUNDS_FOR_SUMMARY = 2;
+export const MIN_PLAYERS_FOR_SUMMARY = 2;
+
+export interface RecapStanding {
+  playerKey: string; // userId or guestId
+  name: string;
+  total: number;
+  isWinner: boolean;
+  rank: number;
+}
+
+export interface GameRecapFacts {
+  gameId: string;
+  organizationId: string | null;
+  winThreshold: number;
+  roundsPlayed: number;
+  playerCount: number;
+  standings: RecapStanding[];
+  winnerName: string | null;
+  tiebreakUsed: boolean;
+  biggestRound: GameStats["biggestRound"];
+  worstRound: GameStats["worstRound"];
+  blitzLeader: { name: string; blitzes: number } | null;
+  totalBlitzes: number;
+  leadChanges: number;
+}
+
+export function buildGameRecap(
+  game: GameWithPlayersAndScores
+): GameRecapFacts {
+  const display = transformGameData(game);
+  const playerNames: Record<string, string> = {};
+  for (const d of display) playerNames[d.id] = d.username;
+
+  // Per-round deltas + blitz counts, keyed by playerKey (userId || guestId)
+  const rounds: RoundResult[] = game.rounds.map((round) => {
+    const deltas: Record<string, number> = {};
+    const blitzCounts: Record<string, number> = {};
+    for (const id of Object.keys(playerNames)) {
+      deltas[id] = 0;
+      blitzCounts[id] = 0;
+    }
+    for (const s of round.scores) {
+      const key = s.userId || s.guestId;
+      if (!key || !(key in playerNames)) continue;
+      deltas[key] = calculateRoundScore({
+        blitzPileRemaining: s.blitzPileRemaining,
+        totalCardsPlayed: s.totalCardsPlayed,
+      });
+      if (s.blitzPileRemaining === 0) blitzCounts[key] += 1;
+    }
+    return { deltas, blitzCounts };
+  });
+
+  const stats = calcGameStats(rounds, playerNames);
+
+  const sorted = [...display].sort((a, b) => b.total - a.total);
+  const standings: RecapStanding[] = sorted.map((d, i) => ({
+    playerKey: d.id,
+    name: d.username,
+    total: d.total,
+    isWinner: !!d.isWinner,
+    rank: i + 1,
+  }));
+
+  const winner = display.find((d) => d.isWinner) ?? null;
+  const topTotal = sorted.length ? sorted[0].total : 0;
+  const reachedTop = display.filter(
+    (d) => d.total >= game.winThreshold && d.total === topTotal
+  );
+  const tiebreakUsed = reachedTop.length > 1;
+
+  let blitzLeader: { name: string; blitzes: number } | null = null;
+  for (const [key, n] of Object.entries(stats.blitzCounts)) {
+    if (n > 0 && (!blitzLeader || n > blitzLeader.blitzes)) {
+      blitzLeader = { name: playerNames[key] ?? key, blitzes: n };
+    }
+  }
+
+  // Lead changes: cumulative leader transitions round over round
+  const cumulative: Record<string, number> = {};
+  for (const id of Object.keys(playerNames)) cumulative[id] = 0;
+  let prevLeader: string | null = null;
+  let leadChanges = 0;
+  for (const r of rounds) {
+    for (const [id, delta] of Object.entries(r.deltas)) cumulative[id] += delta;
+    let leader: string | null = null;
+    let best = -Infinity;
+    for (const [id, total] of Object.entries(cumulative)) {
+      if (total > best) {
+        best = total;
+        leader = id;
+      }
+    }
+    if (leader && prevLeader && leader !== prevLeader) leadChanges++;
+    prevLeader = leader;
+  }
+
+  return {
+    gameId: game.id,
+    organizationId: game.organizationId ?? null,
+    winThreshold: game.winThreshold,
+    roundsPlayed: stats.roundsPlayed,
+    playerCount: display.length,
+    standings,
+    winnerName: winner?.username ?? null,
+    tiebreakUsed,
+    biggestRound: stats.biggestRound,
+    worstRound: stats.worstRound,
+    blitzLeader,
+    totalBlitzes: stats.totalBlitzes,
+    leadChanges,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/insights/__tests__/gameRecap.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/insights/gameRecap.ts src/lib/insights/__tests__/gameRecap.test.ts
+git commit -m "feat(insights): buildGameRecap deterministic fact builder"
+```
+
+---
+
+### Task 4: `hashRecapFacts` — stable hash for idempotency
+
+**Files:**
+- Create: `src/lib/insights/recapHash.ts`
+- Create: `src/lib/insights/__tests__/recapHash.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/insights/__tests__/recapHash.test.ts`:
+
+```ts
+import { hashRecapFacts, stableStringify } from "@/lib/insights/recapHash";
+import type { GameRecapFacts } from "@/lib/insights/gameRecap";
+
+const facts = (overrides: Partial<GameRecapFacts> = {}): GameRecapFacts => ({
+  gameId: "g1",
+  organizationId: "o1",
+  winThreshold: 75,
+  roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { playerKey: "u1", name: "Mike", total: 80, isWinner: true, rank: 1 },
+    { playerKey: "u2", name: "Sarah", total: 40, isWinner: false, rank: 2 },
+  ],
+  winnerName: "Mike",
+  tiebreakUsed: false,
+  biggestRound: { delta: 20, playerName: "Mike", roundNumber: 1 },
+  worstRound: { delta: -4, playerName: "Sarah", roundNumber: 2 },
+  blitzLeader: { name: "Mike", blitzes: 2 },
+  totalBlitzes: 3,
+  leadChanges: 1,
+  ...overrides,
+});
+
+describe("hashRecapFacts", () => {
+  it("is stable for equal facts regardless of key order", () => {
+    expect(hashRecapFacts(facts())).toBe(hashRecapFacts(facts()));
+  });
+
+  it("changes when a number changes", () => {
+    expect(hashRecapFacts(facts())).not.toBe(
+      hashRecapFacts(facts({ totalBlitzes: 4 }))
+    );
+  });
+
+  it("stableStringify orders object keys", () => {
+    expect(stableStringify({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/insights/__tests__/recapHash.test.ts`
+Expected: FAIL — cannot find module `@/lib/insights/recapHash`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/insights/recapHash.ts`:
+
+```ts
+import { createHash } from "crypto";
+import type { GameRecapFacts } from "./gameRecap";
+
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const entries = keys.map(
+    (k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`
+  );
+  return `{${entries.join(",")}}`;
+}
+
+export function hashRecapFacts(facts: GameRecapFacts): string {
+  return createHash("sha256").update(stableStringify(facts)).digest("hex");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/insights/__tests__/recapHash.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/insights/recapHash.ts src/lib/insights/__tests__/recapHash.test.ts
+git commit -m "feat(insights): stable recap fact hashing"
+```
+
+---
+
+### Task 5: `pseudonymizeRecap` / `rehydrateNames` — keep names out of the LLM
+
+**Files:**
+- Create: `src/lib/insights/pseudonymize.ts`
+- Create: `src/lib/insights/__tests__/pseudonymize.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/insights/__tests__/pseudonymize.test.ts`:
+
+```ts
+import { pseudonymizeRecap, rehydrateNames } from "@/lib/insights/pseudonymize";
+import type { GameRecapFacts } from "@/lib/insights/gameRecap";
+
+const facts: GameRecapFacts = {
+  gameId: "g1",
+  organizationId: "o1",
+  winThreshold: 75,
+  roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { playerKey: "u1", name: "Mike", total: 80, isWinner: true, rank: 1 },
+    { playerKey: "u2", name: "Sarah", total: 40, isWinner: false, rank: 2 },
+  ],
+  winnerName: "Mike",
+  tiebreakUsed: false,
+  biggestRound: { delta: 20, playerName: "Mike", roundNumber: 1 },
+  worstRound: { delta: -4, playerName: "Sarah", roundNumber: 2 },
+  blitzLeader: { name: "Mike", blitzes: 2 },
+  totalBlitzes: 3,
+  leadChanges: 1,
+};
+
+describe("pseudonymizeRecap", () => {
+  it("replaces real names with positional pseudonyms", () => {
+    const { facts: px, nameMap } = pseudonymizeRecap(facts);
+    expect(px.winnerName).toBe("Player A");
+    expect(px.standings[0].name).toBe("Player A");
+    expect(px.standings[1].name).toBe("Player B");
+    expect(px.biggestRound.playerName).toBe("Player A");
+    expect(px.blitzLeader?.name).toBe("Player A");
+    expect(nameMap).toEqual({ "Player A": "Mike", "Player B": "Sarah" });
+  });
+
+  it("rehydrates pseudonyms back to real names", () => {
+    const { nameMap } = pseudonymizeRecap(facts);
+    expect(
+      rehydrateNames("Player A edged out Player B.", nameMap)
+    ).toBe("Mike edged out Sarah.");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/insights/__tests__/pseudonymize.test.ts`
+Expected: FAIL — cannot find module `@/lib/insights/pseudonymize`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/insights/pseudonymize.ts`:
+
+```ts
+import type { GameRecapFacts } from "./gameRecap";
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+export interface Pseudonymized {
+  facts: GameRecapFacts;
+  nameMap: Record<string, string>; // pseudonym -> real name
+}
+
+// Names are positional by standings rank, so the mapping is deterministic.
+// NOTE: two players sharing a display name collapse to one pseudonym here; the
+// playerKey-keyed version arrives with the chat phase (M2). Tracked in the spec.
+export function pseudonymizeRecap(facts: GameRecapFacts): Pseudonymized {
+  const realToPseudo: Record<string, string> = {};
+  facts.standings.forEach((s, i) => {
+    if (!(s.name in realToPseudo)) {
+      realToPseudo[s.name] = `Player ${ALPHABET[i] ?? String(i)}`;
+    }
+  });
+
+  const px = (name: string | null): string | null =>
+    name == null ? null : realToPseudo[name] ?? name;
+
+  const pseudoFacts: GameRecapFacts = {
+    ...facts,
+    standings: facts.standings.map((s) => ({
+      ...s,
+      name: realToPseudo[s.name] ?? s.name,
+    })),
+    winnerName: px(facts.winnerName),
+    biggestRound: { ...facts.biggestRound, playerName: px(facts.biggestRound.playerName)! },
+    worstRound: { ...facts.worstRound, playerName: px(facts.worstRound.playerName)! },
+    blitzLeader: facts.blitzLeader
+      ? { ...facts.blitzLeader, name: px(facts.blitzLeader.name)! }
+      : null,
+  };
+
+  const nameMap: Record<string, string> = {};
+  for (const [real, pseudo] of Object.entries(realToPseudo)) nameMap[pseudo] = real;
+
+  return { facts: pseudoFacts, nameMap };
+}
+
+export function rehydrateNames(
+  text: string,
+  nameMap: Record<string, string>
+): string {
+  let out = text;
+  for (const [pseudo, real] of Object.entries(nameMap)) {
+    out = out.split(pseudo).join(real);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/insights/__tests__/pseudonymize.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/insights/pseudonymize.ts src/lib/insights/__tests__/pseudonymize.test.ts
+git commit -m "feat(insights): pseudonymize player names before the LLM"
+```
+
+---
+
+### Task 6: `buildSummaryPrompt` — the prompt contract (pure)
+
+**Files:**
+- Create: `src/lib/insights/summaryPrompt.ts`
+- Create: `src/lib/insights/__tests__/summaryPrompt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/insights/__tests__/summaryPrompt.test.ts`:
+
+```ts
+import {
+  buildSummaryPrompt,
+  PROMPT_VERSION,
+  DEFAULT_SUMMARY_OPTIONS,
+} from "@/lib/insights/summaryPrompt";
+import type { GameRecapFacts } from "@/lib/insights/gameRecap";
+
+const facts: GameRecapFacts = {
+  gameId: "g1", organizationId: "o1", winThreshold: 75, roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { playerKey: "p1", name: "Player A", total: 80, isWinner: true, rank: 1 },
+    { playerKey: "p2", name: "Player B", total: 40, isWinner: false, rank: 2 },
+  ],
+  winnerName: "Player A", tiebreakUsed: false,
+  biggestRound: { delta: 20, playerName: "Player A", roundNumber: 1 },
+  worstRound: { delta: -4, playerName: "Player B", roundNumber: 2 },
+  blitzLeader: { name: "Player A", blitzes: 2 }, totalBlitzes: 3, leadChanges: 1,
+};
+
+describe("buildSummaryPrompt", () => {
+  it("forbids second-person and embeds the facts", () => {
+    const { system, user } = buildSummaryPrompt(facts, DEFAULT_SUMMARY_OPTIONS);
+    expect(system.toLowerCase()).toContain("never invent");
+    expect(system).toMatch(/do not address.*"you"/i);
+    expect(user).toContain("Player A");
+    expect(user).toContain('"winnerName"');
+  });
+
+  it("exposes a stable prompt version", () => {
+    expect(PROMPT_VERSION).toBe("summary-v1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/insights/__tests__/summaryPrompt.test.ts`
+Expected: FAIL — cannot find module `@/lib/insights/summaryPrompt`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/insights/summaryPrompt.ts`:
+
+```ts
+import type { GameRecapFacts } from "./gameRecap";
+
+export const PROMPT_VERSION = "summary-v1";
+
+export interface SummaryOptions {
+  perspective: "neutral";
+  tone: "warm";
+  length: "paragraph";
+}
+
+export const DEFAULT_SUMMARY_OPTIONS: SummaryOptions = {
+  perspective: "neutral",
+  tone: "warm",
+  length: "paragraph",
+};
+
+export function buildSummaryPrompt(
+  facts: GameRecapFacts,
+  _opts: SummaryOptions = DEFAULT_SUMMARY_OPTIONS
+): { system: string; user: string } {
+  const system = [
+    "You are a Dutch Blitz game announcer writing a short, warm, neutral recap of a finished game.",
+    "Scoring: each round a player scores (cards played) minus 2 times (cards left in their Blitz pile); first to the win threshold wins.",
+    "RULES:",
+    '- Only state facts present in the provided JSON. Never invent or infer numbers, names, or events.',
+    '- Neutral broadcaster voice. Do NOT address any player as "you".',
+    "- One warm paragraph, roughly 3 to 5 sentences. No headings, no bullet points, no preamble, no sign-off.",
+  ].join("\n");
+
+  const user =
+    "Game facts (JSON):\n" +
+    JSON.stringify(facts, null, 2) +
+    "\n\nWrite the recap paragraph.";
+
+  return { system, user };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/insights/__tests__/summaryPrompt.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/insights/summaryPrompt.ts src/lib/insights/__tests__/summaryPrompt.test.ts
+git commit -m "feat(insights): summary prompt contract + version"
+```
+
+---
+
+### Task 7: `findUngroundedNumbers` — fact-grounding guard (eval seed)
+
+**Files:**
+- Create: `src/lib/insights/grounding.ts`
+- Create: `src/lib/insights/__tests__/grounding.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/insights/__tests__/grounding.test.ts`:
+
+```ts
+import { findUngroundedNumbers, collectFactNumbers } from "@/lib/insights/grounding";
+import type { GameRecapFacts } from "@/lib/insights/gameRecap";
+
+const facts: GameRecapFacts = {
+  gameId: "g1", organizationId: "o1", winThreshold: 75, roundsPlayed: 3,
+  playerCount: 2,
+  standings: [
+    { playerKey: "p1", name: "Player A", total: 80, isWinner: true, rank: 1 },
+    { playerKey: "p2", name: "Player B", total: 40, isWinner: false, rank: 2 },
+  ],
+  winnerName: "Player A", tiebreakUsed: false,
+  biggestRound: { delta: 20, playerName: "Player A", roundNumber: 1 },
+  worstRound: { delta: -4, playerName: "Player B", roundNumber: 2 },
+  blitzLeader: { name: "Player A", blitzes: 2 }, totalBlitzes: 3, leadChanges: 1,
+};
+
+describe("findUngroundedNumbers", () => {
+  it("returns nothing when every number is grounded", () => {
+    const text = "Player A reached 80 over 3 rounds, beating 40.";
+    expect(findUngroundedNumbers(text, facts)).toEqual([]);
+  });
+
+  it("flags a fabricated number", () => {
+    const text = "Player A scored a record 999 points.";
+    expect(findUngroundedNumbers(text, facts)).toContain("999");
+  });
+
+  it("collects fact numbers as strings", () => {
+    expect(collectFactNumbers(facts).has("80")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/insights/__tests__/grounding.test.ts`
+Expected: FAIL — cannot find module `@/lib/insights/grounding`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/insights/grounding.ts`:
+
+```ts
+import type { GameRecapFacts } from "./gameRecap";
+
+export function collectFactNumbers(facts: GameRecapFacts): Set<string> {
+  const nums = new Set<string>();
+  const walk = (v: unknown): void => {
+    if (typeof v === "number") nums.add(String(v));
+    else if (Array.isArray(v)) v.forEach(walk);
+    else if (v && typeof v === "object") Object.values(v).forEach(walk);
+  };
+  walk(facts);
+  return nums;
+}
+
+// Soft guard: any integer in the prose that is not present in the facts is a
+// candidate hallucination. Used both as a runtime warning and as the seed of
+// the fact-based eval. Ordinals like ranks 1..N are already in the facts.
+export function findUngroundedNumbers(
+  text: string,
+  facts: GameRecapFacts
+): string[] {
+  const allowed = collectFactNumbers(facts);
+  const inText = text.match(/-?\d+/g) ?? [];
+  return inText.filter((n) => !allowed.has(n));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/insights/__tests__/grounding.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/insights/grounding.ts src/lib/insights/__tests__/grounding.test.ts
+git commit -m "feat(insights): fact-grounding guard for summaries"
+```
+
+---
+
+### Task 8: `generateGameSummary` orchestration + retry sweep
+
+**Files:**
+- Create: `src/server/ai/summary.ts`
+- Create: `src/server/ai/__tests__/summary.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/ai/__tests__/summary.test.ts`:
+
+```ts
+const findUnique = jest.fn();
+const upsert = jest.fn();
+const update = jest.fn();
+
+jest.mock("@/server/db/db", () => ({
+  __esModule: true,
+  default: { gameSummary: { findUnique, upsert, update } },
+}));
+
+const getGameById = jest.fn();
+jest.mock("@/server/queries/games", () => ({
+  __esModule: true,
+  getGameById: (...a: unknown[]) => getGameById(...a),
+}));
+
+const generateSummaryText = jest.fn();
+jest.mock("@/server/ai/claude", () => ({
+  __esModule: true,
+  CLAUDE_SUMMARY_MODEL: "claude-opus-4-8",
+  generateSummaryText: (...a: unknown[]) => generateSummaryText(...a),
+}));
+
+import { generateGameSummary } from "@/server/ai/summary";
+import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
+
+function readyGame(): GameWithPlayersAndScores {
+  return {
+    id: "game_1", winThreshold: 30, organizationId: "org_1", isFinished: true,
+    createdAt: new Date(), endedAt: null, winnerId: null,
+    players: [
+      { id: "gp1", gameId: "game_1", userId: "u1", guestId: null, accentColor: null, user: { id: "u1", username: "Mike" } as never, guestUser: null },
+      { id: "gp2", gameId: "game_1", userId: "u2", guestId: null, accentColor: null, user: { id: "u2", username: "Sarah" } as never, guestUser: null },
+    ],
+    rounds: [
+      { id: "r1", gameId: "game_1", round: 1, createdAt: new Date(), scores: [
+        { id: "s1", roundId: "r1", userId: "u1", guestId: null, totalCardsPlayed: 20, blitzPileRemaining: 0, createdAt: new Date(), updatedAt: new Date() },
+        { id: "s2", roundId: "r1", userId: "u2", guestId: null, totalCardsPlayed: 14, blitzPileRemaining: 3, createdAt: new Date(), updatedAt: new Date() },
+      ] },
+      { id: "r2", gameId: "game_1", round: 2, createdAt: new Date(), scores: [
+        { id: "s3", roundId: "r2", userId: "u1", guestId: null, totalCardsPlayed: 18, blitzPileRemaining: 2, createdAt: new Date(), updatedAt: new Date() },
+        { id: "s4", roundId: "r2", userId: "u2", guestId: null, totalCardsPlayed: 10, blitzPileRemaining: 0, createdAt: new Date(), updatedAt: new Date() },
+      ] },
+    ],
+  } as unknown as GameWithPlayersAndScores;
+}
+
+beforeEach(() => {
+  findUnique.mockReset(); upsert.mockReset(); update.mockReset();
+  getGameById.mockReset(); generateSummaryText.mockReset();
+  upsert.mockResolvedValue({}); update.mockResolvedValue({});
+});
+
+describe("generateGameSummary", () => {
+  it("writes a ready summary with rehydrated names", async () => {
+    getGameById.mockResolvedValue(readyGame());
+    findUnique.mockResolvedValue(null);
+    generateSummaryText.mockResolvedValue({ text: "Player A edged Player B.", tokensUsed: 42 });
+
+    await generateGameSummary("game_1");
+
+    const ready = upsert.mock.calls.find((c) => c[0].update.status === "ready");
+    expect(ready).toBeDefined();
+    expect(ready![0].update.content).toBe("Mike edged Sarah.");
+    expect(ready![0].update.model).toBe("claude-opus-4-8");
+    expect(ready![0].update.tokensUsed).toBe(42);
+    expect(generateSummaryText).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks insufficient_data and skips the LLM for a 1-round game", async () => {
+    const g = readyGame();
+    g.rounds = [g.rounds[0]];
+    getGameById.mockResolvedValue(g);
+    findUnique.mockResolvedValue(null);
+
+    await generateGameSummary("game_1");
+
+    expect(generateSummaryText).not.toHaveBeenCalled();
+    const call = upsert.mock.calls.at(-1)!;
+    expect(call[0].update.status).toBe("insufficient_data");
+  });
+
+  it("records failed status when the LLM call throws", async () => {
+    getGameById.mockResolvedValue(readyGame());
+    findUnique.mockResolvedValue(null);
+    generateSummaryText.mockRejectedValue(new Error("boom"));
+
+    await generateGameSummary("game_1");
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "failed", error: "boom" }),
+      })
+    );
+  });
+
+  it("is idempotent when a ready summary already matches the hash", async () => {
+    getGameById.mockResolvedValue(readyGame());
+    // First compute the hash the way the code will, by letting it run once.
+    findUnique.mockResolvedValueOnce(null);
+    generateSummaryText.mockResolvedValue({ text: "Player A wins.", tokensUsed: 5 });
+    await generateGameSummary("game_1");
+    const storedHash = upsert.mock.calls.at(-1)![0].create.sourceStatsHash as string;
+
+    upsert.mockClear(); generateSummaryText.mockClear();
+    findUnique.mockResolvedValue({ status: "ready", sourceStatsHash: storedHash });
+
+    await generateGameSummary("game_1");
+    expect(generateSummaryText).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/server/ai/__tests__/summary.test.ts`
+Expected: FAIL — cannot find module `@/server/ai/summary`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/server/ai/summary.ts`:
+
+```ts
+import prisma from "@/server/db/db";
+import { getGameById } from "@/server/queries/games";
+import type { GameWithPlayersAndScores } from "@/lib/gameLogic";
+import {
+  buildGameRecap,
+  MIN_ROUNDS_FOR_SUMMARY,
+  MIN_PLAYERS_FOR_SUMMARY,
+  type GameRecapFacts,
+} from "@/lib/insights/gameRecap";
+import { hashRecapFacts } from "@/lib/insights/recapHash";
+import { pseudonymizeRecap, rehydrateNames } from "@/lib/insights/pseudonymize";
+import {
+  buildSummaryPrompt,
+  PROMPT_VERSION,
+  DEFAULT_SUMMARY_OPTIONS,
+} from "@/lib/insights/summaryPrompt";
+import { findUngroundedNumbers } from "@/lib/insights/grounding";
+import { generateSummaryText, CLAUDE_SUMMARY_MODEL } from "./claude";
+
+type Extra = {
+  status: "pending" | "ready" | "failed" | "insufficient_data";
+  content?: string;
+  model?: string;
+  tokensUsed?: number;
+};
+
+async function writeSummary(
+  facts: GameRecapFacts,
+  hash: string,
+  sourceUpdatedAt: Date,
+  extra: Extra
+): Promise<void> {
+  await prisma.gameSummary.upsert({
+    where: {
+      gameId_promptVersion: {
+        gameId: facts.gameId,
+        promptVersion: PROMPT_VERSION,
+      },
+    },
+    create: {
+      gameId: facts.gameId,
+      organizationId: facts.organizationId,
+      promptVersion: PROMPT_VERSION,
+      sourceStatsHash: hash,
+      sourceUpdatedAt,
+      ...extra,
+    },
+    update: { sourceStatsHash: hash, sourceUpdatedAt, error: null, ...extra },
+  });
+}
+
+// Loads the game from the PRIMARY (getGameById uses the primary client) so the
+// recap can't miss the final round to replica lag. The LLM call does no DB read.
+export async function generateGameSummary(gameId: string): Promise<void> {
+  const game = (await getGameById(gameId)) as GameWithPlayersAndScores | null;
+  if (!game) return;
+
+  const facts = buildGameRecap(game);
+  const hash = hashRecapFacts(facts);
+  const sourceUpdatedAt = new Date();
+
+  const existing = await prisma.gameSummary.findUnique({
+    where: { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } },
+  });
+  if (existing?.status === "ready" && existing.sourceStatsHash === hash) return;
+
+  if (
+    facts.roundsPlayed < MIN_ROUNDS_FOR_SUMMARY ||
+    facts.playerCount < MIN_PLAYERS_FOR_SUMMARY
+  ) {
+    await writeSummary(facts, hash, sourceUpdatedAt, { status: "insufficient_data" });
+    return;
+  }
+
+  await writeSummary(facts, hash, sourceUpdatedAt, { status: "pending" });
+
+  try {
+    const { facts: pseudo, nameMap } = pseudonymizeRecap(facts);
+    const { system, user } = buildSummaryPrompt(pseudo, DEFAULT_SUMMARY_OPTIONS);
+    const { text, tokensUsed } = await generateSummaryText(system, user);
+
+    const ungrounded = findUngroundedNumbers(text, pseudo);
+    if (ungrounded.length) {
+      console.warn(
+        `[insights] ungrounded numbers in summary ${gameId}:`,
+        ungrounded
+      );
+    }
+
+    await writeSummary(facts, hash, sourceUpdatedAt, {
+      status: "ready",
+      content: rehydrateNames(text, nameMap),
+      model: CLAUDE_SUMMARY_MODEL,
+      tokensUsed,
+    });
+  } catch (err) {
+    await prisma.gameSummary.update({
+      where: { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } },
+      data: {
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+        retryCount: { increment: 1 },
+      },
+    });
+  }
+}
+
+// Durability: re-attempt summaries that never reached `ready`. Wire to a cron
+// route in a later step; safe to call repeatedly (idempotent per game).
+export async function regeneratePendingSummaries(limit = 20): Promise<number> {
+  const stuck = await prisma.gameSummary.findMany({
+    where: { status: { in: ["pending", "failed"] }, retryCount: { lt: 5 } },
+    take: limit,
+  });
+  for (const s of stuck) await generateGameSummary(s.gameId);
+  return stuck.length;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/server/ai/__tests__/summary.test.ts`
+Expected: PASS (all four cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/ai/summary.ts src/server/ai/__tests__/summary.test.ts
+git commit -m "feat(insights): durable game-summary generation orchestration"
+```
+
+---
+
+### Task 9: Trigger generation when a game finishes
+
+**Files:**
+- Modify: `src/server/mutations/games.ts` (`updateGameAsFinished`)
+- Create: `src/server/__tests__/gameSummaryWiring.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/__tests__/gameSummaryWiring.test.ts`:
+
+```ts
+const authMock = jest.fn();
+jest.mock("@clerk/nextjs/server", () => ({ auth: () => authMock() }));
+
+const gameFindUnique = jest.fn();
+const gameUpdate = jest.fn();
+const userFindUnique = jest.fn();
+jest.mock("@/server/db/db", () => ({
+  __esModule: true,
+  default: {
+    game: { findUnique: (...a: unknown[]) => gameFindUnique(...a), update: (...a: unknown[]) => gameUpdate(...a) },
+    user: { findUnique: (...a: unknown[]) => userFindUnique(...a) },
+  },
+}));
+
+jest.mock("@/app/posthog", () => ({ __esModule: true, default: () => ({ capture: jest.fn() }) }));
+
+// after() runs its callback immediately in the test
+jest.mock("next/server", () => ({ after: (cb: () => unknown) => cb() }));
+
+const generateGameSummary = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/server/ai/summary", () => ({
+  __esModule: true,
+  generateGameSummary: (...a: unknown[]) => generateGameSummary(...a),
+}));
+
+// Email side effects are not under test
+jest.mock("@/server/email", () => ({
+  __esModule: true,
+  sendGameCompleteEmail: jest.fn().mockResolvedValue(undefined),
+  EMAIL_INTER_SEND_DELAY_MS: 0,
+}));
+
+import { updateGameAsFinished } from "@/server/mutations/games";
+
+beforeEach(() => {
+  authMock.mockReset(); gameFindUnique.mockReset(); gameUpdate.mockReset();
+  userFindUnique.mockReset(); generateGameSummary.mockReset();
+  authMock.mockReturnValue({ userId: "clerk_1", orgId: "org_1" });
+  gameFindUnique.mockResolvedValue({
+    id: "game_1", organizationId: "org_1", isFinished: false, players: [],
+  });
+  gameUpdate.mockResolvedValue({});
+  userFindUnique.mockResolvedValue({ username: "Mike" });
+  generateGameSummary.mockResolvedValue(undefined);
+});
+
+it("schedules summary generation for the finished game", async () => {
+  await updateGameAsFinished("game_1", "u1", false);
+  expect(generateGameSummary).toHaveBeenCalledWith("game_1");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/server/__tests__/gameSummaryWiring.test.ts`
+Expected: FAIL — `generateGameSummary` not called (wiring not added yet).
+
+- [ ] **Step 3: Add the trigger**
+
+In `src/server/mutations/games.ts`, add the import near the top (with the other imports):
+
+```ts
+import { generateGameSummary } from "@/server/ai/summary";
+```
+
+Then in `updateGameAsFinished`, immediately after the existing
+`posthog.capture({ ... event: "update_game_as_finished" ... })` call and
+**before** the existing `const registeredPlayers = ...` line, add an independent
+durable trigger:
+
+```ts
+  // Generate the post-game recap durably after the response is sent. Reads the
+  // game from the primary inside generateGameSummary, so no replica-lag risk.
+  after(() => generateGameSummary(gameId));
+```
+
+(`after` is already imported from `next/server` in this file.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/server/__tests__/gameSummaryWiring.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/mutations/games.ts src/server/__tests__/gameSummaryWiring.test.ts
+git commit -m "feat(insights): generate recap when a game finishes"
+```
+
+---
+
+### Task 10: Read query + render the recap on the game page
+
+**Files:**
+- Create: `src/server/queries/insights.ts`
+- Modify: `src/server/queries/index.ts` (re-export)
+- Create: `src/components/insights/GameSummaryCard.tsx`
+- Create: `src/components/__tests__/insights/GameSummaryCard.test.tsx`
+- Modify: `src/app/games/[id]/page.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `src/components/__tests__/insights/GameSummaryCard.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { GameSummaryCard } from "@/components/insights/GameSummaryCard";
+
+describe("GameSummaryCard", () => {
+  it("renders the recap content when ready", () => {
+    render(<GameSummaryCard status="ready" content="Mike edged Sarah." />);
+    expect(screen.getByText("Mike edged Sarah.")).toBeInTheDocument();
+  });
+
+  it("shows a pending message while generating", () => {
+    render(<GameSummaryCard status="pending" content={null} />);
+    expect(screen.getByText(/being written/i)).toBeInTheDocument();
+  });
+
+  it("shows the insufficient-data message", () => {
+    render(<GameSummaryCard status="insufficient_data" content={null} />);
+    expect(screen.getByText(/not enough rounds/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing on failure", () => {
+    const { container } = render(
+      <GameSummaryCard status="failed" content={null} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/components/__tests__/insights/GameSummaryCard.test.tsx`
+Expected: FAIL — cannot find module `@/components/insights/GameSummaryCard`.
+
+- [ ] **Step 3: Write the component**
+
+Create `src/components/insights/GameSummaryCard.tsx`:
+
+```tsx
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function GameSummaryCard({
+  status,
+  content,
+}: {
+  status: string;
+  content: string | null;
+}) {
+  if (status === "failed") return null;
+
+  return (
+    <Card className="max-w-2xl mx-auto mt-4">
+      <CardHeader>
+        <CardTitle>Game Recap</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {status === "ready" && content ? (
+          <p>{content}</p>
+        ) : status === "insufficient_data" ? (
+          <p className="text-muted-foreground">
+            Not enough rounds for a recap.
+          </p>
+        ) : (
+          <p className="text-muted-foreground">Your recap is being written…</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Run component test to verify it passes**
+
+Run: `npm test -- src/components/__tests__/insights/GameSummaryCard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Add the read query**
+
+Create `src/server/queries/insights.ts`:
+
+```ts
+import "server-only";
+
+import prismaReadonly from "@/server/db/db-readonly";
+import { PROMPT_VERSION } from "@/lib/insights/summaryPrompt";
+
+// Reads from the replica — the summary row is a cache; if it hasn't replicated
+// yet the page shows the pending state and the user can refresh.
+export async function getGameSummary(gameId: string) {
+  return prismaReadonly.gameSummary.findUnique({
+    where: { gameId_promptVersion: { gameId, promptVersion: PROMPT_VERSION } },
+  });
+}
+```
+
+- [ ] **Step 6: Re-export from the queries barrel**
+
+In `src/server/queries/index.ts`, add:
+
+```ts
+export { getGameSummary } from "./insights";
+```
+
+- [ ] **Step 7: Mount the card on the game page**
+
+In `src/app/games/[id]/page.tsx`:
+
+Add imports at the top:
+
+```ts
+import { getGameSummary } from "@/server/queries/insights";
+import { GameSummaryCard } from "@/components/insights/GameSummaryCard";
+```
+
+Change the parallel load to also fetch the summary:
+
+```ts
+  const [gameData, { userId, orgId }, summary] = await Promise.all([
+    getGameById(params.id),
+    auth(),
+    getGameSummary(params.id),
+  ]);
+```
+
+Then, inside the returned JSX, render the card after `</ScoringShell>` but before
+`</section>`, only when the game is finished:
+
+```tsx
+      {isFinished && summary && (
+        <GameSummaryCard status={summary.status} content={summary.content} />
+      )}
+```
+
+- [ ] **Step 8: Typecheck + full test run**
+
+Run: `npm run typecheck && npm test`
+Expected: typecheck PASS; all tests green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/server/queries/insights.ts src/server/queries/index.ts \
+  src/components/insights/GameSummaryCard.tsx \
+  src/components/__tests__/insights/GameSummaryCard.test.tsx \
+  src/app/games/[id]/page.tsx
+git commit -m "feat(insights): show game recap on the game page"
+```
+
+---
+
+### Task 11: End-to-end manual verification
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Confirm the env key is set**
+
+Ensure `ANTHROPIC_API_KEY` is present in `.env`.
+
+- [ ] **Step 2: Run the app and finish a game**
+
+Run: `npm run dev`
+Then: create a game with 2 players, play ≥2 rounds to the threshold, and finish it.
+Expected: the game page shows "Game Recap" — first the pending state, then (after refresh) a warm neutral paragraph naming the real winner with grounded numbers, no "you".
+
+- [ ] **Step 3: Confirm the row + idempotency**
+
+Run: `npx prisma studio`
+Expected: a `GameSummary` row for that game with `status = ready`, populated `content`, `model = claude-opus-4-8`, a non-null `sourceStatsHash`. Finishing the same game again does not duplicate the row.
+
+- [ ] **Step 4: Merge the phase branch into the integration branch**
+
+```bash
+git checkout feature/llm-insights
+git merge --no-ff feature/llm-insights-p1-summary -m "Merge Phase 1: post-game summary (M0a + M1)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase-1 slice of `docs/superpowers/specs/2026-06-13-llm-insights-design.md`):**
+- M0a Claude foundation → Tasks 1–2 (SDK + client + `GameSummary` table). The generic `InsightJob` table is intentionally deferred (scope note in header); durability is met via `GameSummary` status + `regeneratePendingSummaries`.
+- Fact snapshot from primary (spec §8, rev #3) → Task 8 loads via `getGameById` (primary).
+- Durable, not fire-and-forget (rev #4) → Task 8 status machine + Task 9 `after()` + sweep.
+- Status + invalidation fields (rev #5) → Task 2 model (`status`, `error`, `retryCount`, `sourceStatsHash`, `sourceUpdatedAt`).
+- Neutral, no-audience MVP (rev #6) → Task 6 prompt forbids "you"; `audienceUserId` null.
+- Pseudonymized names (rev #21) → Task 5 + Task 8.
+- Fact-grounding / eval seed (rev #22) → Task 7.
+- Failure UX (rev #23) → Task 10 card states (pending/failed/insufficient).
+- Single formula source (rev #16) → recap reuses `calculateRoundScore` / `calcGameStats`, no re-inlined formula.
+- Pinned Claude params (rev #19) → Task 1 (`thinking: adaptive`, `effort: low`, no sampling params).
+- Not in this phase (correctly deferred to M0b/M2/M3/M4): RLS, `getInsightScope`, views, chat, metric-plan DSL, tiles.
+
+**Placeholder scan:** none — every code step contains complete code; no TBD/TODO.
+
+**Type consistency:** `GameRecapFacts`, `RecapStanding`, `Pseudonymized`, `SummaryOptions`, `PROMPT_VERSION`, `CLAUDE_SUMMARY_MODEL`, `generateSummaryText`, `generateGameSummary`, `getGameSummary`, and the `gameId_promptVersion` unique selector are used identically across tasks. `buildGameRecap`/`generateGameSummary` both take `GameWithPlayersAndScores`. The card props (`status`, `content`) match `getGameSummary`'s row shape.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session with batch checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-06-13-llm-insights-design.md
+++ b/docs/superpowers/specs/2026-06-13-llm-insights-design.md
@@ -1,0 +1,331 @@
+# Design: LLM-Driven Insights for Blitzer
+
+**Date:** 2026-06-13
+**Status:** Draft for review
+**Author:** Product/data design session (Claude Code)
+
+Companion-app feature that lets Dutch Blitz players ask natural-language questions
+about their gameplay, get auto-generated dashboard stat tiles, and receive a
+tailored narrative recap after each game — all grounded in real Postgres data,
+never hallucinated numbers.
+
+This spec incorporates an external design review (Codex, gpt-5.5) that checked
+live Neon / PgBouncer / Postgres-RLS / Anthropic docs; the load-bearing
+corrections from that review are folded in below and flagged `[rev]`.
+
+---
+
+## Locked decisions
+
+| Area | Decision |
+|---|---|
+| Engine | **Claude API + tool use** — official `@anthropic-ai/sdk`, Messages API tool runner, `claude-opus-4-8`, streamed from the Next.js backend. Not the Claude Agent SDK / Managed Agents (containers) — overkill for read-only Postgres Q&A. |
+| Reuse stance | **Re-platform, not rewrite** — keep the data/query layer + tool implementations + scoring helpers; replace only the OpenAI/Vercel-AI-SDK orchestration and the `useChat` transport. |
+| MVP wedge | **Post-game narrative summary first.** |
+| Query engine | **Curated typed tools + a structured metric-plan DSL** for the nuanced long tail. Raw LLM-written SQL stays behind a separate flag + security suite, post-MVP. `[rev]` |
+| Data scope | **Circle-scoped** — a user may query any player they've shared games with, across their circles, plus their own legacy (null-org) games. |
+| Tiles | **Deterministic first**, LLM blurbs layered on later (on-demand, stale-while-revalidate per viewer). `[rev]` |
+
+---
+
+## 1. Objectives & success criteria
+
+**Objective.** A player can (a) ask how they and their circle play, (b) see
+auto-generated stat tiles, and (c) read a narrative recap after each game —
+grounded in Postgres, with every cited number traceable to a tool/DSL result.
+
+**Success criteria (measurable):**
+
+- **Accuracy** — ≥95% on a labeled, **fact-based** eval set (~40 questions). The grader checks that *every numeric claim maps to a tool/DSL result*, not prose similarity. `[rev #22]`
+- **Isolation** — 0 cross-circle leakage across an adversarial security suite (revoked membership, cross-circle probes, SQL/prompt injection).
+- **Summary coverage** — recap reaches a terminal state (`ready`/`failed`) for ≥95% of finished games; p95 generation < ~30s end-to-end (durable job, not request-bound). `[rev #4]`
+- **Latency** — chat **first SSE status event** < 1s; **first NL token** target p50 < 6s (re-baselined for adaptive thinking + ≥1 DB tool call). `[rev #18]`
+- **Dashboard** — TTFB unchanged: tiles render from deterministic queries; LLM blurbs hydrate async and never block paint. `[rev #24]`
+- **Cost** — within a per-interaction budget (track `cache_read_input_tokens` / `cache_creation_input_tokens` per call). `[rev #19]`
+- **Engagement** — PostHog: insights opened, questions/session, summary views, tile interactions.
+
+## 2. Scope, MVP & reuse verdict
+
+In scope: **post-game summary** (wedge), **chat**, **dashboard tiles**. Out of
+scope for MVP: persistent multi-session chat memory, raw LLM-written SQL,
+cross-circle/global leaderboards, voice, push.
+
+**Reuse verdict (re-platform).**
+*Keep* — the read-only query layer (`src/server/queries/stats.ts`,
+`src/server/db/db-readonly.ts`), the canonical `ROUND_SCORE_SQL`, the 6 tool
+*implementations* (`src/server/ai/tools.ts`), the scoring helpers
+(`src/lib/scoring/gameStats.ts`, `probability.ts`), the `llm-features` flag,
+`src/proxy.ts` route protection, the `BasicStatBlock` UI.
+*Replace* — the OpenAI/Vercel-AI-SDK orchestration in `src/app/api/chat/route.ts`
+and the `useChat` client transport in `src/app/insights/ModernChatUI.tsx`.
+Rationale: the data layer and tool bodies are already clean, provider-agnostic
+and tested; only the LLM glue (weak model, OpenAI, chat-only) is dated.
+
+## 3. Architecture & data flow
+
+```
+                        ┌─────────────────────────── Next.js backend ───────────────────────────┐
+Browser                 │                                                                          │
+ ├─ Dashboard (RSC) ─────┼─▶ deterministic tile queries (replica) ──▶ paint immediately            │
+ │   BasicStatBlock      │        └▶ InsightTile cache (primary)  ◀── on-demand SWR blurb job        │
+ │                       │                                            (Claude/Haiku, per viewer)     │
+ ├─ Game detail (RSC) ───┼─▶ getGameSummary(gameId) ─▶ GameSummary (primary) ◀─ durable summary job ─┤
+ │                       │        recap FACTS snapshotted from PRIMARY at game finish ───────────────┤
+ └─ /insights chat ─SSE──┼─▶ /api/insights/chat ─▶ Claude tool loop (Opus 4.8, streaming)            │
+                         │        ├─ curated typed tools ─┐                                          │
+                         │        └─ metric_plan tool ────┤ server compiles → safe SQL               │
+                         │                                ▼                                          │
+                         │   getInsightScope(userId) → AuthorizedScope ─▶ READ REPLICA (analytical)  │
+                         │                                  ▲ RLS + read-only role + llm_views schema │
+                         └──────────────────────────────────┴───────────────────────────────────────┘
+   Reads → replica.  Writes (GameSummary, InsightTile, jobs) → primary.  [rev #2]
+```
+
+Key correction `[rev #2]`: analytical **reads** use the replica; cache/job/summary
+**writes** use the primary. The earlier "all DB access via replica" was wrong.
+
+## 4. Scope & identity model `[rev #7,#8,#9]`
+
+**`getInsightScope(userId) → AuthorizedScope`** returns an explicit object, not
+just org ids:
+
+```ts
+type PlayerKey = { kind: "user" | "guest"; id: string }   // never merge guests by name
+type AuthorizedScope = {
+  callerPlayerKeys: PlayerKey[]      // the caller's own user + any guest identities
+  orgIds: string[]                    // circles the caller is a member of (OrganizationMembership)
+  legacyGameIds: string[]             // null-org games the caller PARTICIPATED in (separate auth path)
+  scopeHash: string                   // stable hash of sorted (orgIds ∪ legacyGameIds) — for cache keys
+}
+```
+
+- **Circle games**: visibility follows the existing app model — any member of a
+  circle can already see all of that circle's games (`getGames` filters by
+  `auth().orgId`). So org membership legitimately grants circle-wide visibility.
+- **Legacy null-org games** are a *separate* authorization path `[rev #8]`:
+  `organizationId IS NULL` can't be expressed as an org filter, and you may only
+  see legacy games you personally played in — never another player's null-org
+  history just because their `userId` appears in a query.
+- **Player identity** is a typed `PlayerKey` everywhere (tools, views, DSL).
+  Guests are never merged by display name. Tools that can return guest stats are
+  named player-oriented (`getPlayerOverview`, not `getUserOverview`). `[rev #9]`
+
+## 5. Data model
+
+Three additive tables; **no change to the gameplay schema**.
+
+**`GameSummary`** `[rev #5,#6]`
+
+| field | notes |
+|---|---|
+| `id`, `gameId`, `organizationId` | |
+| `audienceUserId` | **null for MVP** (neutral recap); set only for future personalized recaps `[rev #6]` |
+| `status` | `pending` \| `ready` \| `failed` \| `insufficient_data` |
+| `content`, `model`, `promptVersion` | |
+| `sourceStatsHash`, `sourceUpdatedAt` | invalidation: regenerate/mark stale if scores change post-finish |
+| `tokensUsed`, `error`, `retryCount`, `createdAt`, `updatedAt` | |
+
+Unique index on `(gameId, audienceUserId, promptVersion, sourceStatsHash)` →
+idempotent generation. For the neutral MVP, `audienceUserId` is null and
+"you-centric" language is forbidden in the prompt so one player's recap can't
+leak personal framing to another. `[rev #6]`
+
+**`InsightTile`** `[rev #10]`
+
+| field | notes |
+|---|---|
+| `scopeType` (`user`\|`org`), `scopeSubjectId`, `scopeHash` | from sorted authorized ids — not a weak `userId\|orgId` string |
+| `tileKey`, `tileVersion`, `promptVersion` | |
+| `statPayload` jsonb (deterministic), `blurb` (LLM, nullable), `computedAt`, `expiresAt` | |
+
+**Authorization is re-checked on *read*** so a tile cached under a prior
+membership can't leak after the viewer is removed from a circle. `[rev #10]`
+
+**`InsightJob`** (durable async) `[rev #4]` — `{id, kind, refId, idempotencyKey,
+status, attempts, lastError, runAfter}`. Idempotency key e.g.
+`game_summary:{gameId}:{promptVersion}:{sourceHash}`.
+
+**`InsightMessage`** — optional, post-MVP (chat history).
+
+**Single source for the score formula** `[rev #16]`: curated tools, the
+read-only views, and the DSL compiler all derive the round score from one place
+(`ROUND_SCORE_SQL`). A parity test asserts the SQL view formula equals the
+TypeScript helper formula so they can't drift.
+
+**Read-only views** live in a dedicated `llm_views` schema, e.g.
+`v_player_round_scores(player_kind, player_id, player_name, organization_id,
+game_id, round_no, score, blitz_pile_remaining, total_cards_played, played_at)`
+and `v_game_results(...)`. Both curated tools and the DSL compile against these
+views — not raw tables. `[rev #16]`
+
+**Indexing** `[rev #17]`: existing indexes (`Score.userId/guestId/roundId`,
+`Round.gameId`, `Game.organizationId`) cover curated aggregations. The new hot
+path is cross-player-per-circle aggregation (`Score → Round → Game.organizationId
+→ player`). Capture `EXPLAIN ANALYZE` fixtures on representative data **before
+launching chat**; be ready to add a composite covering index or a
+`player_round_scores` materialized/read model keyed by
+`(organizationId, gameId, playerKind, playerId, playedAt)`.
+
+## 6. Query engine — curated tools + metric-plan DSL
+
+**Tier 1 — curated typed tools** (port existing 6 + circle-scope):
+`getPlayerOverview`, `getRecentGames`, `getExtremes`, `getCumulativeScore`,
+`getTrends`, `getHeadToHead` (generalize `getOpponentStats`),
+`getCircleLeaderboard`. Zod tools via the SDK tool runner; each returns exact
+numbers. Tool descriptions are **prescriptive about *when* to call** (Opus 4.8
+under-reaches for tools by default).
+
+**Tier 2 — `metric_plan` tool (the nuanced long tail)** `[rev #15]`. Instead of
+the LLM writing SQL, it emits a **structured plan** the server compiles into
+safe, parameterized SQL:
+
+```ts
+type MetricPlan = {
+  subject: PlayerKey | { allInScope: true }
+  metric: "round_score" | "blitz_rate" | "win_rate" | "cards_played" | ...
+  filters?: { gameLengthRounds?: Range; dateRange?: Range; opponent?: PlayerKey; ... }
+  groupBy?: ("player" | "game" | "week" | "month")[]
+  orderBy?: ...; limit?: number
+}
+```
+
+The compiler validates against an allow-list of metrics/dimensions, always
+applies scope, and produces a single parameterized `SELECT`. This is far smaller
+an attack surface than free SQL and is unit-testable. **Raw LLM-written SQL is
+deferred** behind its own flag + the full hardening below, only if the DSL proves
+too limiting. `[rev #15]`
+
+**Isolation & execution (applies to DSL-compiled and any future raw SQL)** —
+defense in depth:
+
+1. **Postgres RLS as the real boundary** `[rev #11]`. Policies on the base tables
+   (or `security_invoker`/`security_barrier` views in `llm_views`). The read role
+   is a **dedicated, non-owner, non-`BYPASSRLS`** role; `FORCE ROW LEVEL SECURITY`
+   on base tables; grants only on `llm_views`. Table owners and `BYPASSRLS` would
+   otherwise silently bypass policies.
+2. **Scope set inside one explicit transaction** `[rev #12]`. Neon's pooled
+   endpoint is PgBouncer **transaction-pooled**, so session state doesn't persist.
+   Per request: `prisma.$transaction(tx => { tx.$executeRaw(select set_config('app.org_ids_json', $1, true)); ...query... })` on the **same** connection, then commit/rollback. Never a bare session `SET`.
+3. **Parameterized scope** `[rev #13]`. Pass scope as a JSON param to
+   `set_config(...)`; a stable DB function parses it with **default-deny** when
+   unset. No hand-built `'{...}'` array literals.
+4. **Statement hardening** `[rev #14]` (for the raw-SQL path; mostly N/A to the
+   compiled DSL): AST parse; single `SELECT`; ban `WITH RECURSIVE`, `FOR UPDATE`,
+   `pg_sleep`, comments/semicolons, system schemas, volatile/unknown functions,
+   excessive joins. Enforce `statement_timeout`, row limit, byte limit, max
+   tool-calls per turn; log every rejection with a reason.
+5. **Replica only** — never the primary.
+
+## 7. Prompting
+
+- **System prompt split for prompt caching** `[rev #19]`: Block 1 (stable,
+  `cache_control: {type:"ephemeral"}`) = Dutch Blitz rules + scoring formula +
+  tool/DSL catalog + data dictionary + output guardrails ("only cite numbers
+  returned by tools; never invent stats"). Block 2 (volatile, after the
+  breakpoint) = caller scope, a small stat snapshot, the question. Verify the
+  stable prefix clears the model's minimum-cacheable threshold and stays
+  byte-identical; track cache token usage per call.
+- **Pseudonymize player names before the LLM sees them** `[rev #21]`. Send
+  `Player A / Player B` + structured stats; substitute real display names
+  server-side *after* generation. This neutralizes name-based prompt injection
+  *and* keeps display names (potential PII) out of the provider + out of
+  PostHog/Sentry traces. Chat resolves a user-typed name → `PlayerKey` server-side
+  first, then pseudonymizes tool outputs.
+- **Model/params** `[rev #19]`: `claude-opus-4-8`; `thinking: {type:"adaptive"}`;
+  explicit `output_config: {effort:"medium"}` (sweep later); streaming; **no**
+  sampling params (`temperature`/`top_p`/`top_k` 400 on Opus 4.8). Consider
+  `claude-haiku-4-5` and/or Message Batches for high-volume cheap copy (tile
+  blurbs) `[rev #20]`.
+
+## 8. Post-game summary (MVP wedge)
+
+- **Fact snapshot at finish, from the primary** `[rev #3]`. On
+  `updateGameAsFinished`, synchronously build a `GameRecapFacts` payload from the
+  primary (we already hold the data in the write path) via a pure
+  `buildGameRecap(game)` over existing helpers: `{finalStandings, winner,
+  tiebreakUsed, perRoundDeltas, blitzCounts, roundWinners, biggestRound,
+  worstRound, leadChanges}`. Persist the facts. The LLM call then formats facts
+  with **no DB read** — sidestepping replica lag entirely.
+- **Durable generation** `[rev #4]`. Enqueue an `InsightJob` (not a
+  fire-and-forget Promise, which serverless can kill). A retryable worker/cron
+  drains it; idempotency key prevents dupes; `status` transitions
+  `pending → ready|failed|insufficient_data`.
+- **Tunable parameters** (system-prompt vars, for later personalization):
+  perspective (neutral / you-centric), tone (hype / dry / wholesome), length
+  (one-liner / paragraph / play-by-play), spotlight (winner / most-improved /
+  biggest-blunder). **MVP ships one neutral, warm, ~paragraph default**; no
+  `audienceUserId`, no "you" framing. `[rev #6]`
+
+## 9. Dashboard tiles — deterministic first `[rev #24,#20]`
+
+- **Phase A — deterministic tiles.** Reuse `BasicStatBlock`. Compute the number
+  from the query layer; render immediately. Tiles: blitz-rate trend, nemesis,
+  signature round, consistency. No LLM in the paint path.
+- **Phase B — LLM blurbs (later).** Layer a one-line read onto each tile. The
+  **number stays computed; the LLM only writes prose** (can't hallucinate a
+  stat). Generation is **on-demand, stale-while-revalidate per viewer** — serve
+  the cached blurb (or none) immediately, revalidate in the background on first
+  view after `expiresAt`. No daily batch for every active user (most never open
+  the dashboard). `[rev #20]` Plus a "coach's tip" tile in Phase B.
+
+## 10. Privacy, safety & failure UX `[rev #23]`
+
+- **Failure UX.** Game detail tolerates `summary pending` (skeleton),
+  `summary failed` (quiet retry/hide), `insufficient_data` (friendly note). Chat
+  handles Anthropic errors, timeout, abort, "no visible games," and partial tool
+  failure — never leaking stack traces, raw prompts, or other circles' data.
+- **PostHog/Sentry**: no PII in event properties (per CLAUDE.md); `@posthog/ai`
+  Anthropic tracing in redaction/privacy mode; pseudonymized names mean traces
+  carry `Player A/B`, not real names.
+- **Rate limiting**: per-user limits on chat + the metric_plan tool; cap tool
+  calls per turn.
+
+## 11. Milestones
+
+- **M0a — Claude foundation** `[rev #1]`: add `@anthropic-ai/sdk` +
+  `ANTHROPIC_API_KEY`, a `claudeClient`, `GameSummary` + `InsightJob` tables, the
+  durable-job worker, the fact-based eval harness skeleton. *Gate:* a Claude call
+  round-trips; eval harness runs.
+- **M0b — Data substrate**: `getInsightScope` (explicit `AuthorizedScope` incl.
+  legacy path), `llm_views` schema + views, dedicated read-only role + RLS +
+  `set_config` scope function, `EXPLAIN ANALYZE` fixtures. *Gate:* RLS isolation
+  test passes (a wrong scope returns 0 rows); leaderboard plan is acceptable.
+- **M1 — Post-game summary (wedge)**: `buildGameRecap` (pure, unit-tested) →
+  fact snapshot at finish → durable job → single Claude format call →
+  `GameSummary` → game-detail render with pending/failed/insufficient states.
+  *Gate:* ≥95% reach terminal state; reads well on a labeled set; idempotent.
+- **M2 — Chat on Claude**: new `/api/insights/chat` (tool runner, streaming) +
+  port the curated tools with circle-scope + new SSE client transport replacing
+  `useChat`; behind `llm-features`. *Gate:* fact-based eval accuracy; first-status
+  <1s and first-token latency target; security suite = no leakage.
+- **M3 — Metric-plan DSL**: `metric_plan` tool + server compiler + RLS-backed
+  execution; added to chat. *Gate:* answers nuanced eval questions the curated
+  tools miss; isolation + timeout/limit tests pass. (Raw guarded SQL: separate
+  later flag, only if needed.)
+- **M4a — Deterministic tiles**; **M4b — LLM blurbs (SWR)**. *Gate:* dashboard
+  TTFB unchanged; blurbs match computed stats; cost within budget.
+
+**Order:** M0a → M0b → M1 → M2 → M3; M4a can start after M0b; M4b after M2.
+Cross-cutting throughout: PostHog tracing, rate limits, cost dashboard, eval set.
+
+## 12. Trade-offs & risks
+
+| Risk | Mitigation |
+|---|---|
+| Hallucinated numbers | Tools/DSL return exact values; tiles compute the number, LLM writes only prose; system rule forbids inventing stats; fact-based eval enforces it |
+| Cross-tenant read | RLS (non-owner role, FORCE RLS) + per-txn parameterized scope + DSL allow-list + replica-only (`[rev #11–14]`) |
+| Replica lag corrupting recaps | Snapshot facts from primary at finish; LLM call does no DB read (`[rev #3]`) |
+| Lost async generation | Durable `InsightJob` + retries + idempotency, not fire-and-forget (`[rev #4]`) |
+| Stale tile leaks after removal | Re-check authorization on tile read; `scopeHash` keying (`[rev #10]`) |
+| Cost/latency | Prompt caching, fact-snapshot (no tool loop for summaries), SWR tiles, Haiku/Batches for cheap copy |
+| Guest / dual identity | Typed `PlayerKey`; never merge guests by name (`[rev #9]`) |
+| Legacy null-org games | Separate participation-based auth path (`[rev #8]`) |
+| Formula drift | Single `ROUND_SCORE_SQL` source + view↔helper parity test (`[rev #16]`) |
+| PII / name injection | Pseudonymize before the LLM; substitute server-side (`[rev #21]`) |
+
+## 13. Open questions
+
+1. **Summary delivery** — game-detail page only for MVP, or also a finish-time toast/notification? (Assumed: game-detail only.)
+2. **Cost ceiling** — target $/summary and $/chat, to tune model choice (Opus vs Haiku) and caching aggressiveness?
+3. **Tile TTL** — what `expiresAt` window for the SWR blurbs (e.g. 24h)?
+4. **Eval ownership** — who curates/labels the ~40-question eval set and the adversarial isolation cases?


### PR DESCRIPTION
## 🧵 LLM-driven Insights — integration / umbrella PR

**Draft, do not merge yet.** This is the tracking PR for the whole LLM Insights feature. `feature/llm-insights` is the long-lived integration branch; each phase lands as its own PR **into this branch**, and this PR merges to `main` once the phases are assembled.

The diff here grows as phase PRs merge into the integration branch. Right now it contains the design spec + Phase-1 plan; Phase-1 code arrives when #262 merges in.

### Design
- Spec: `docs/superpowers/specs/2026-06-13-llm-insights-design.md`
- Phase-1 plan: `docs/superpowers/plans/2026-06-13-llm-insights-phase1-summary.md`

Feature in one line: let players ask about their Dutch Blitz performance, get auto-generated dashboard stat tiles, and receive a tailored post-game recap — grounded in Postgres, never hallucinated. Engine: Claude API + tool use (`@anthropic-ai/sdk`, Opus 4.8). Shipped dark behind the `llm-features` flag.

### Phase roadmap

| Phase | Scope | Status |
|---|---|---|
| **M0a + M1** | Claude foundation + post-game summary | 🟢 PR #262 (into this branch) |
| M0b | Insight scope + `llm_views` + read-only role/RLS | ⬜ not started |
| M2 | Chat on Claude (tool runner, streaming, circle-scope) | ⬜ not started |
| M3 | Metric-plan DSL (structured query → safe SQL) | ⬜ not started |
| M4a / M4b | Deterministic dashboard tiles → LLM blurbs (SWR) | ⬜ not started |

### Review process
Each phase goes through: plan → Codex review → implement (TDD) → Codex review → fix → PR. Phase 1's full Codex trail is in #262.

### 🔴 Operational setup (before any of this is live)
- `ANTHROPIC_API_KEY` in the deployment env.
- Enable the `llm-features` PostHog flag.
- `CRON_SECRET` + a Vercel cron → `GET /api/insights/sweep` (Phase 1 durability).
- Migrations auto-apply on deploy (`prisma migrate deploy`).

### Tracking
- [x] M0a + M1 (post-game summary) — #262
- [ ] M0b — data substrate (scope, views, RLS)
- [ ] M2 — chat
- [ ] M3 — metric-plan DSL
- [ ] M4a / M4b — dashboard tiles
- [ ] Operational setup verified in prod
- [ ] Final review of the assembled feature → merge to `main`
