### PR TITLE
Improve current-game race outlook forecast

### DIFF
--- a/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
+++ b/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { WinProbabilityCard } from "../../scoring/graphs/WinProbabilityCard";
+import { type PlayerWithScore } from "../../scoring/types";
+
+const players: PlayerWithScore[] = [
+  {
+    id: "close",
+    name: "Alice",
+    color: "#ff0000",
+    isGuest: false,
+    userId: "close",
+    score: 70,
+  },
+  {
+    id: "far",
+    name: "Bob",
+    color: "#0000ff",
+    isGuest: false,
+    userId: "far",
+    score: 30,
+  },
+];
+
+describe("WinProbabilityCard", () => {
+  it("shows an unavailable state before enough current-game rounds", () => {
+    render(
+      <WinProbabilityCard
+        players={players}
+        roundsPlayed={2}
+        winThreshold={75}
+      />
+    );
+
+    expect(screen.getByText("Available after 3 rounds")).toBeInTheDocument();
+  });
+
+  it("renders the race outlook instead of the old projected finish section", () => {
+    render(
+      <WinProbabilityCard
+        players={players}
+        roundsPlayed={5}
+        winThreshold={75}
+        deltasByPlayer={{
+          close: [12, 14, 16, 14, 14],
+          far: [4, 8, 6, 6, 6],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Race Outlook")).toBeInTheDocument();
+    expect(screen.getByText("Likely ending")).toBeInTheDocument();
+    expect(screen.getByText("Next-round danger")).toBeInTheDocument();
+    expect(screen.getByText(/Can close now/)).toBeInTheDocument();
+    expect(screen.queryByText("Projected finish")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import { type PlayerWithScore } from "../types";
 import {
-  calcWinProbabilities,
-  calcProjectedFinishRound,
+  calcRaceForecast,
+  type ForecastRange,
+  type PlayerForecast,
+  type RaceForecast,
 } from "@/lib/scoring/probability";
 
 interface WinProbabilityCardProps {
@@ -18,9 +20,9 @@ export function WinProbabilityCard({
   winThreshold,
   deltasByPlayer,
 }: WinProbabilityCardProps) {
-  const probabilities = useMemo(
+  const forecast = useMemo(
     () =>
-      calcWinProbabilities(
+      calcRaceForecast(
         players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
         winThreshold,
         deltasByPlayer
@@ -30,16 +32,17 @@ export function WinProbabilityCard({
 
   const sorted = useMemo(
     () =>
-      probabilities
+      forecast
         ? [...players].sort(
             (a, b) =>
-              (probabilities[b.id] ?? 0) - (probabilities[a.id] ?? 0)
+              (forecast.players[b.id]?.winProbability ?? 0) -
+              (forecast.players[a.id]?.winProbability ?? 0)
           )
         : players,
-    [players, probabilities]
+    [players, forecast]
   );
 
-  if (!probabilities) {
+  if (!forecast) {
     return (
       <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
         <div className="text-base md:text-sm font-bold text-[#290806] mb-0.5">
@@ -52,78 +55,164 @@ export function WinProbabilityCard({
     );
   }
 
+  const topPlayerId = sorted[0]?.id;
+  const topNextThreat = getTopNextThreat(sorted, forecast);
+
   return (
     <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
       <div className="text-base md:text-sm font-bold text-[#290806] mb-0.5">
         Win Probability
       </div>
       <div className="text-[13px] md:text-xs text-[#8b5e3c] mb-3">
-        Simulated over {roundsPlayed} rounds of data
+        {getSubtitle(roundsPlayed, forecast)}
       </div>
 
       <div className="space-y-2">
         {sorted.map((player) => {
-          const pct = probabilities[player.id] ?? 0;
+          const playerForecast = forecast.players[player.id];
+          const pct = playerForecast?.winProbability ?? 0;
           return (
-            <div key={player.id} className="flex items-center gap-2">
-              <div
-                className="w-14 md:w-10 text-[13px] md:text-[11px] font-semibold text-right flex-shrink-0 truncate leading-tight"
-                style={{ color: player.color }}
-              >
-                {player.name}
-              </div>
-              <div className="flex-1 h-7 md:h-6 bg-[#f0e6d2] rounded-full overflow-hidden">
+            <div key={player.id} className="space-y-1">
+              <div className="flex items-center gap-2">
                 <div
-                  className="h-full rounded-full flex items-center justify-end pr-2 text-[13px] md:text-[11px] font-bold text-white min-w-[34px] md:min-w-[28px] tabular-nums"
-                  style={{
-                    width: `${Math.max(pct, 8)}%`,
-                    backgroundColor: player.color,
-                  }}
+                  className="w-14 md:w-10 text-[13px] md:text-[11px] font-semibold text-right flex-shrink-0 truncate leading-tight"
+                  style={{ color: player.color }}
                 >
-                  {pct}%
+                  {player.name}
                 </div>
+                <div className="flex-1 h-7 md:h-6 bg-[#f0e6d2] rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full flex items-center justify-end pr-2 text-[13px] md:text-[11px] font-bold text-white min-w-[34px] md:min-w-[28px] tabular-nums"
+                    style={{
+                      width: `${Math.max(pct, 8)}%`,
+                      backgroundColor: player.color,
+                    }}
+                  >
+                    {pct}%
+                  </div>
+                </div>
+              </div>
+              <div className="ml-16 md:ml-12 text-[12px] md:text-[11px] text-[#8b5e3c] truncate">
+                {getPlayerLabel(playerForecast, player.id === topPlayerId)} ·{" "}
+                {getWinningRoundText(playerForecast)}
               </div>
             </div>
           );
         })}
       </div>
 
-      {/* Projected finish */}
       <div className="mt-3 pt-3 border-t border-[#f0e6d2]">
         <div className="text-xs md:text-[11px] font-semibold text-[#8b5e3c] mb-2">
-          Projected finish
+          Race Outlook
         </div>
-        <div className="flex flex-wrap gap-x-4 gap-y-2 md:gap-3">
-          {sorted
-            .filter((p) => (probabilities[p.id] ?? 0) > 0)
-            .map((player) => {
-              const round = calcProjectedFinishRound(
-                player.score,
-                roundsPlayed,
-                winThreshold
-              );
-              return (
-                <div key={player.id} className="text-center">
-                  <div
-                    className="text-xl md:text-lg font-extrabold"
-                    style={{ color: player.color }}
-                  >
-                    ~R{round === Infinity ? "∞" : round}
-                  </div>
-                  <div
-                    className="text-[13px] md:text-[11px] text-[#8b5e3c] max-w-16 truncate"
-                  >
-                    {player.name}
-                  </div>
-                </div>
-              );
-            })}
+        <div className="grid grid-cols-2 gap-2">
+          <OutlookStat
+            label="Likely ending"
+            value={formatRoundRange(forecast.gameEndRound) ?? "Wide open"}
+          />
+          <OutlookStat
+            label="Next-round danger"
+            value={topNextThreat ? `${topNextThreat.pct}%` : "None"}
+            detail={topNextThreat?.player.name}
+            color={topNextThreat?.player.color}
+          />
         </div>
+        {forecast.unresolvedProbability > 0 && (
+          <div className="mt-2 text-[12px] md:text-[11px] text-[#8b5e3c]">
+            {forecast.unresolvedProbability}% still open after the forecast window
+          </div>
+        )}
       </div>
 
       <div className="text-xs md:text-[11px] text-[#8b5e3c] text-center mt-2 italic">
         Monte Carlo simulation · accounts for pace &amp; variance
       </div>
+    </div>
+  );
+}
+
+function formatRoundRange(range: ForecastRange | null): string | null {
+  if (!range) return null;
+  if (range.p25 === range.p75) return `R${range.median}`;
+  return `R${range.p25}-R${range.p75}`;
+}
+
+function getWinningRoundText(playerForecast?: PlayerForecast): string {
+  if (
+    playerForecast &&
+    playerForecast.winProbability === 0 &&
+    playerForecast.winningRound
+  ) {
+    return "tail path under 1%";
+  }
+  const roundText = formatRoundRange(playerForecast?.winningRound ?? null);
+  return roundText ? `wins around ${roundText}` : "needs a long path";
+}
+
+function getPlayerLabel(
+  playerForecast: PlayerForecast | undefined,
+  isTopPlayer: boolean
+): string {
+  if (!playerForecast || playerForecast.winProbability === 0) return "Long shot";
+  if (playerForecast.nextRoundWinProbability >= 25) return "Can close now";
+  if (playerForecast.nextRoundWinProbability >= 10) return "Next-round threat";
+  if (isTopPlayer && playerForecast.winProbability >= 45) return "Steady favorite";
+  if (playerForecast.winProbability >= 25) return "In the mix";
+  if (playerForecast.winProbability >= 10) return "Needs a swing round";
+  return "Chaos path";
+}
+
+function getSubtitle(roundsPlayed: number, forecast: RaceForecast): string {
+  const confidence =
+    forecast.confidence === "high"
+      ? "high confidence"
+      : forecast.confidence === "medium"
+        ? "medium confidence"
+        : "low confidence";
+  return `Simulated from ${roundsPlayed} rounds tonight · ${confidence}`;
+}
+
+function getTopNextThreat(
+  players: PlayerWithScore[],
+  forecast: RaceForecast
+): { player: PlayerWithScore; pct: number } | null {
+  let top: { player: PlayerWithScore; pct: number } | null = null;
+  for (const player of players) {
+    const pct = forecast.players[player.id]?.nextRoundWinProbability ?? 0;
+    if (pct > (top?.pct ?? 0)) {
+      top = { player, pct };
+    }
+  }
+  return top && top.pct > 0 ? top : null;
+}
+
+function OutlookStat({
+  label,
+  value,
+  detail,
+  color,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  color?: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[12px] md:text-[11px] text-[#8b5e3c] truncate">
+        {label}
+      </div>
+      <div
+        className="text-lg md:text-base font-extrabold tabular-nums truncate"
+        style={{ color: color ?? "#290806" }}
+      >
+        {value}
+      </div>
+      {detail && (
+        <div className="text-[12px] md:text-[11px] text-[#8b5e3c] truncate">
+          {detail}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -1,21 +1,45 @@
 import {
+  allocateOutcomePercents,
   calcWinProbabilities,
-  calcProjectedFinishRound,
+  calcRaceForecast,
+  clampRoundScore,
 } from "../scoring/probability";
 
-describe("calcProjectedFinishRound", () => {
-  it("projects finish round based on average pace", () => {
-    // 50 points in 5 rounds = 10/round, need 75, so ~7.5 → round 8
-    expect(calcProjectedFinishRound(50, 5, 75)).toBe(8);
-  });
+function forecastSum(forecast: NonNullable<ReturnType<typeof calcRaceForecast>>) {
+  return (
+    Object.values(forecast.players).reduce(
+      (sum, player) => sum + player.winProbability,
+      0
+    ) + forecast.unresolvedProbability
+  );
+}
 
-  it("returns Infinity for zero or negative pace", () => {
-    expect(calcProjectedFinishRound(-10, 5, 75)).toBe(Infinity);
-    expect(calcProjectedFinishRound(0, 5, 75)).toBe(Infinity);
+describe("clampRoundScore", () => {
+  it("keeps simulated round scores inside Dutch Blitz scoring bounds", () => {
+    expect(clampRoundScore(-100)).toBe(-20);
+    expect(clampRoundScore(100)).toBe(40);
+    expect(clampRoundScore(4.6)).toBe(5);
   });
+});
 
-  it("returns current round if already past threshold", () => {
-    expect(calcProjectedFinishRound(80, 5, 75)).toBe(5);
+describe("allocateOutcomePercents", () => {
+  it("uses a stable tie-break when rounded percentages need a remainder bump", () => {
+    const counts: [string, number][] = [
+      ["b", 2250],
+      ["a", 4350],
+      ["__unresolved", 3400],
+    ];
+
+    expect(allocateOutcomePercents(counts, 10_000)).toEqual({
+      a: 44,
+      b: 22,
+      __unresolved: 34,
+    });
+    expect(allocateOutcomePercents([...counts].reverse(), 10_000)).toEqual({
+      a: 44,
+      b: 22,
+      __unresolved: 34,
+    });
   });
 });
 
@@ -42,8 +66,6 @@ describe("calcWinProbabilities", () => {
     );
     expect(result).not.toBeNull();
     expect(result!["1"]).toBeGreaterThan(result!["2"]);
-    const sum = Object.values(result!).reduce((a, b) => a + b, 0);
-    expect(sum).toBe(100);
   });
 
   it("gives 0% to players with negative pace (no deltas)", () => {
@@ -84,6 +106,20 @@ describe("calcWinProbabilities", () => {
     const r1 = calcWinProbabilities(players, 75, deltas);
     const r2 = calcWinProbabilities(players, 75, deltas);
     expect(r1).toEqual(r2);
+  });
+
+  it("is deterministic for the same players in a different order", () => {
+    const players = [
+      { id: "b", score: 35, roundsPlayed: 5 },
+      { id: "a", score: 40, roundsPlayed: 5 },
+    ];
+    const deltas = {
+      a: [10, 8, 7, 9, 6],
+      b: [5, 12, 3, 8, 7],
+    };
+    const original = calcWinProbabilities(players, 75, deltas);
+    const reordered = calcWinProbabilities([...players].reverse(), 75, deltas);
+    expect(original).toEqual(reordered);
   });
 
   describe("with per-round deltas (Monte Carlo)", () => {
@@ -137,5 +173,74 @@ describe("calcWinProbabilities", () => {
       const sum = Object.values(result!).reduce((a, b) => a + b, 0);
       expect(sum).toBe(100);
     });
+  });
+});
+
+describe("calcRaceForecast", () => {
+  it("returns null when fewer than 3 rounds have been played", () => {
+    expect(
+      calcRaceForecast([{ id: "1", score: 10, roundsPlayed: 2 }], 75)
+    ).toBeNull();
+  });
+
+  it("keeps unresolved simulations explicit instead of crediting the leader", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "leader", score: 3, roundsPlayed: 3 },
+        { id: "trailing", score: 0, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        leader: [1, 1, 1],
+        trailing: [0, 0, 0],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.leader.winProbability).toBe(0);
+    expect(forecast!.unresolvedProbability).toBe(100);
+    expect(forecast!.gameEndRound).toBeNull();
+    expect(forecastSum(forecast!)).toBe(100);
+  });
+
+  it("derives next-round threat and winning-round range from the same pass", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "close", score: 70, roundsPlayed: 5 },
+        { id: "far", score: 30, roundsPlayed: 5 },
+      ],
+      75,
+      {
+        close: [12, 14, 16, 14, 14],
+        far: [4, 8, 6, 6, 6],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.close.nextRoundWinProbability).toBeGreaterThan(90);
+    expect(forecast!.players.close.nextRoundWinProbability).toBeLessThanOrEqual(
+      forecast!.players.close.winProbability
+    );
+    expect(forecast!.players.close.winningRound?.median).toBe(6);
+    expect(forecast!.gameEndRound?.median).toBe(6);
+  });
+
+  it("returns player outcomes plus unresolved outcomes that sum to 100", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "1", score: 30, roundsPlayed: 4 },
+        { id: "2", score: 25, roundsPlayed: 4 },
+        { id: "3", score: 20, roundsPlayed: 4 },
+      ],
+      75,
+      {
+        "1": [8, 7, 9, 6],
+        "2": [5, 8, 6, 6],
+        "3": [4, 5, 6, 5],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecastSum(forecast!)).toBe(100);
   });
 });

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -23,6 +23,21 @@ describe("clampRoundScore", () => {
 });
 
 describe("allocateOutcomePercents", () => {
+  it("returns zero percentages when there are no outcomes to allocate", () => {
+    expect(
+      allocateOutcomePercents(
+        [
+          ["a", 0],
+          ["b", 0],
+        ],
+        0
+      )
+    ).toEqual({
+      a: 0,
+      b: 0,
+    });
+  });
+
   it("uses a stable tie-break when rounded percentages need a remainder bump", () => {
     const counts: [string, number][] = [
       ["b", 2250],
@@ -200,6 +215,43 @@ describe("calcRaceForecast", () => {
     expect(forecast!.players.leader.winProbability).toBe(0);
     expect(forecast!.unresolvedProbability).toBe(100);
     expect(forecast!.gameEndRound).toBeNull();
+    expect(forecastSum(forecast!)).toBe(100);
+  });
+
+  it("keeps simulating volatile players even when their average delta is not positive", () => {
+    const forecast = calcRaceForecast(
+      [{ id: "volatile", score: 74, roundsPlayed: 3 }],
+      75,
+      {
+        volatile: [-20, 20, 0],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.volatile.winProbability).toBeGreaterThan(0);
+    expect(
+      forecast!.players.volatile.nextRoundWinProbability
+    ).toBeGreaterThan(0);
+  });
+
+  it("splits exact same-round winning-score ties between tied players", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "b", score: 30, roundsPlayed: 3 },
+        { id: "a", score: 30, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        a: [15, 15, 15],
+        b: [15, 15, 15],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.a.winProbability).toBe(50);
+    expect(forecast!.players.b.winProbability).toBe(50);
+    expect(forecast!.players.a.winningRound?.median).toBe(6);
+    expect(forecast!.players.b.winningRound?.median).toBe(6);
     expect(forecastSum(forecast!)).toBe(100);
   });
 

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,16 +1,8 @@
-export function calcProjectedFinishRound(
-  currentScore: number,
-  roundsPlayed: number,
-  winThreshold: number
-): number {
-  if (currentScore >= winThreshold) return roundsPlayed;
-  const pace = roundsPlayed > 0 ? currentScore / roundsPlayed : 0;
-  if (pace <= 0) return Infinity;
-  return Math.ceil(winThreshold / pace);
-}
-
 const SIMULATION_COUNT = 10_000;
 const MAX_FUTURE_ROUNDS = 50;
+const UNRESOLVED_OUTCOME_ID = "__unresolved";
+export const MIN_SIMULATED_ROUND_SCORE = -20;
+export const MAX_SIMULATED_ROUND_SCORE = 40;
 
 // Seeded PRNG (xoshiro128**) for deterministic Monte Carlo results.
 // Ensures identical inputs always produce identical probabilities,
@@ -43,6 +35,13 @@ function normalSample(mean: number, std: number, rng: () => number): number {
   return mean + std * z;
 }
 
+export function clampRoundScore(score: number): number {
+  return Math.max(
+    MIN_SIMULATED_ROUND_SCORE,
+    Math.min(MAX_SIMULATED_ROUND_SCORE, Math.round(score))
+  );
+}
+
 function mean(values: number[]): number {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
@@ -61,29 +60,143 @@ interface PlayerStats {
   std: number;
 }
 
+export interface ForecastRange {
+  p25: number;
+  median: number;
+  p75: number;
+}
+
+export type ForecastConfidence = "low" | "medium" | "high";
+
+export interface PlayerForecast {
+  id: string;
+  winProbability: number;
+  nextRoundWinProbability: number;
+  winningRound: ForecastRange | null;
+}
+
+export interface RaceForecast {
+  players: Record<string, PlayerForecast>;
+  gameEndRound: ForecastRange | null;
+  unresolvedProbability: number;
+  confidence: ForecastConfidence;
+  simulationCount: number;
+}
+
+function percentile(sortedValues: number[], percentileValue: number): number {
+  if (sortedValues.length === 0) return Infinity;
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.floor((sortedValues.length - 1) * percentileValue))
+  );
+  return sortedValues[index];
+}
+
+function buildRange(values: number[]): ForecastRange | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p25: percentile(sorted, 0.25),
+    median: percentile(sorted, 0.5),
+    p75: percentile(sorted, 0.75),
+  };
+}
+
+function toPercent(count: number, total: number): number {
+  return Math.round((count / total) * 100);
+}
+
+function outcomeSortKey(id: string): string {
+  return id === UNRESOLVED_OUTCOME_ID ? "\uffff" : id;
+}
+
+export function allocateOutcomePercents(
+  counts: [string, number][],
+  total: number
+): Record<string, number> {
+  const exact = counts.map(([id, count]) => ({
+    id,
+    value: total === 0 ? 0 : (count / total) * 100,
+  }));
+  const result = Object.fromEntries(
+    exact.map(({ id, value }) => [id, Math.floor(value)])
+  );
+  let remainder =
+    100 - Object.values(result).reduce((sum, value) => sum + value, 0);
+
+  for (const { id } of exact
+    .map((entry) => ({
+      ...entry,
+      fraction: entry.value - Math.floor(entry.value),
+    }))
+    .sort(
+      (a, b) =>
+        b.fraction - a.fraction ||
+        outcomeSortKey(a.id).localeCompare(outcomeSortKey(b.id))
+    )) {
+    if (remainder <= 0) break;
+    result[id]++;
+    remainder--;
+  }
+
+  return result;
+}
+
+function calcConfidence(
+  roundsPlayed: number,
+  unresolvedProbability: number
+): ForecastConfidence {
+  if (roundsPlayed < 5 || unresolvedProbability >= 25) return "low";
+  if (roundsPlayed < 8 || unresolvedProbability >= 10) return "medium";
+  return "high";
+}
+
+function buildSeed(
+  players: { id: string; score: number; roundsPlayed: number }[],
+  winThreshold: number,
+  deltasByPlayer?: Record<string, number[]>
+): number {
+  const seedText = players
+    .map((p) => {
+      const deltas = deltasByPlayer?.[p.id] ?? [];
+      return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(",")}`;
+    })
+    .sort()
+    .join("|");
+
+  let seed = winThreshold >>> 0;
+  for (let i = 0; i < seedText.length; i++) {
+    seed = Math.imul(seed ^ seedText.charCodeAt(i), 16777619) >>> 0;
+  }
+  return seed || 1;
+}
+
 /**
- * Monte Carlo win-probability estimation.
+ * Monte Carlo race forecast.
  *
  * For each simulation we sample future round scores from a normal distribution
- * fitted to each player's historical per-round deltas, then check who crosses
- * the win threshold first. The fraction of simulations won gives the probability.
+ * fitted to each player's current-game per-round deltas, then check who crosses
+ * the win threshold first. All returned forecast facts come from the same
+ * simulation pass so the percentages and round ranges stay coherent.
  *
  * When per-round deltas are available the model captures both scoring pace *and*
  * variance, which the old pace-ratio approach ignored entirely.
  *
- * Falls back to the simpler pace-ratio heuristic when deltas are unavailable
- * (e.g. when only aggregate score + roundsPlayed are known).
+ * Falls back to aggregate score + roundsPlayed when deltas are unavailable.
  */
-export function calcWinProbabilities(
+export function calcRaceForecast(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
   deltasByPlayer?: Record<string, number[]>
-): Record<string, number> | null {
+): RaceForecast | null {
   if (players.length === 0) return null;
-  if (players[0].roundsPlayed < 3) return null;
+  const roundsPlayed = players[0].roundsPlayed;
+  if (roundsPlayed < 3) return null;
+
+  const orderedPlayers = [...players].sort((a, b) => a.id.localeCompare(b.id));
 
   // Build per-player stats from deltas when available
-  const stats: PlayerStats[] = players.map((p) => {
+  const stats: PlayerStats[] = orderedPlayers.map((p) => {
     const deltas = deltasByPlayer?.[p.id];
     if (deltas && deltas.length >= 2) {
       const m = mean(deltas);
@@ -97,24 +210,46 @@ export function calcWinProbabilities(
 
   // If every player has non-positive mean, no one is progressing
   if (stats.every((s) => s.mean <= 0)) {
-    return Object.fromEntries(players.map((p) => [p.id, 0]));
+    return {
+      players: Object.fromEntries(
+        players.map((p) => [
+          p.id,
+          {
+            id: p.id,
+            winProbability: 0,
+            nextRoundWinProbability: 0,
+            winningRound: null,
+          },
+        ])
+      ),
+      gameEndRound: null,
+      unresolvedProbability: 100,
+      confidence: "low",
+      simulationCount: SIMULATION_COUNT,
+    };
   }
 
-  // Deterministic seed from current game state
-  const seed =
-    players.reduce((h, p) => h * 31 + Math.round(p.score * 100), 7) >>> 0;
-  const rng = makeRng(seed);
+  const rng = makeRng(buildSeed(players, winThreshold, deltasByPlayer));
 
   const wins: Record<string, number> = {};
+  const nextRoundWins: Record<string, number> = {};
+  const winningRounds: Record<string, number[]> = {};
   for (const p of players) wins[p.id] = 0;
+  for (const p of players) nextRoundWins[p.id] = 0;
+  for (const p of players) winningRounds[p.id] = [];
+  const gameEndRounds: number[] = [];
+  let unresolvedCount = 0;
 
   for (let sim = 0; sim < SIMULATION_COUNT; sim++) {
     const scores = stats.map((s) => s.currentScore);
     let winnerId: string | null = null;
+    let winningRound: number | null = null;
 
     for (let r = 0; r < MAX_FUTURE_ROUNDS; r++) {
       for (let i = 0; i < stats.length; i++) {
-        scores[i] += normalSample(stats[i].mean, stats[i].std, rng);
+        scores[i] += clampRoundScore(
+          normalSample(stats[i].mean, stats[i].std, rng)
+        );
       }
       // Check if any player crossed the threshold this round
       let bestScore = -Infinity;
@@ -122,28 +257,67 @@ export function calcWinProbabilities(
         if (scores[i] >= winThreshold && scores[i] > bestScore) {
           bestScore = scores[i];
           winnerId = stats[i].id;
+          winningRound = roundsPlayed + r + 1;
         }
       }
       if (winnerId) break;
     }
 
-    if (winnerId) wins[winnerId]++;
+    if (winnerId && winningRound !== null) {
+      wins[winnerId]++;
+      winningRounds[winnerId].push(winningRound);
+      gameEndRounds.push(winningRound);
+      if (winningRound === roundsPlayed + 1) {
+        nextRoundWins[winnerId]++;
+      }
+    } else {
+      unresolvedCount++;
+    }
   }
 
-  // Convert counts to integer percentages
-  const result: Record<string, number> = {};
+  const outcomePercents = allocateOutcomePercents(
+    [
+      ...players.map((p) => [p.id, wins[p.id]] as [string, number]),
+      [UNRESOLVED_OUTCOME_ID, unresolvedCount],
+    ],
+    SIMULATION_COUNT
+  );
+  const unresolvedProbability = outcomePercents[UNRESOLVED_OUTCOME_ID] ?? 0;
+  const forecastPlayers: Record<string, PlayerForecast> = {};
+
   for (const p of players) {
-    result[p.id] = Math.round((wins[p.id] / SIMULATION_COUNT) * 100);
+    const winProbability = outcomePercents[p.id] ?? 0;
+    forecastPlayers[p.id] = {
+      id: p.id,
+      winProbability,
+      nextRoundWinProbability: Math.min(
+        toPercent(nextRoundWins[p.id], SIMULATION_COUNT),
+        winProbability
+      ),
+      winningRound: buildRange(winningRounds[p.id]),
+    };
   }
 
-  // Fix rounding to sum to exactly 100
-  const sum = Object.values(result).reduce((a, b) => a + b, 0);
-  if (sum !== 100 && sum > 0) {
-    const maxId = Object.entries(result).reduce((a, b) =>
-      b[1] > a[1] ? b : a
-    )[0];
-    result[maxId] += 100 - sum;
-  }
+  return {
+    players: forecastPlayers,
+    gameEndRound: buildRange(gameEndRounds),
+    unresolvedProbability,
+    confidence: calcConfidence(roundsPlayed, unresolvedProbability),
+    simulationCount: SIMULATION_COUNT,
+  };
+}
 
-  return result;
+export function calcWinProbabilities(
+  players: { id: string; score: number; roundsPlayed: number }[],
+  winThreshold: number,
+  deltasByPlayer?: Record<string, number[]>
+): Record<string, number> | null {
+  const forecast = calcRaceForecast(players, winThreshold, deltasByPlayer);
+  if (!forecast) return null;
+  return Object.fromEntries(
+    Object.values(forecast.players).map((player) => [
+      player.id,
+      player.winProbability,
+    ])
+  );
 }

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -114,9 +114,13 @@ export function allocateOutcomePercents(
   counts: [string, number][],
   total: number
 ): Record<string, number> {
+  if (total <= 0) {
+    return Object.fromEntries(counts.map(([id]) => [id, 0]));
+  }
+
   const exact = counts.map(([id, count]) => ({
     id,
-    value: total === 0 ? 0 : (count / total) * 100,
+    value: (count / total) * 100,
   }));
   const result = Object.fromEntries(
     exact.map(({ id, value }) => [id, Math.floor(value)])
@@ -208,27 +212,6 @@ export function calcRaceForecast(
     return { id: p.id, currentScore: p.score, mean: m, std: Math.abs(m) * 0.5 };
   });
 
-  // If every player has non-positive mean, no one is progressing
-  if (stats.every((s) => s.mean <= 0)) {
-    return {
-      players: Object.fromEntries(
-        players.map((p) => [
-          p.id,
-          {
-            id: p.id,
-            winProbability: 0,
-            nextRoundWinProbability: 0,
-            winningRound: null,
-          },
-        ])
-      ),
-      gameEndRound: null,
-      unresolvedProbability: 100,
-      confidence: "low",
-      simulationCount: SIMULATION_COUNT,
-    };
-  }
-
   const rng = makeRng(buildSeed(players, winThreshold, deltasByPlayer));
 
   const wins: Record<string, number> = {};
@@ -242,7 +225,7 @@ export function calcRaceForecast(
 
   for (let sim = 0; sim < SIMULATION_COUNT; sim++) {
     const scores = stats.map((s) => s.currentScore);
-    let winnerId: string | null = null;
+    let winnerIndexes: number[] = [];
     let winningRound: number | null = null;
 
     for (let r = 0; r < MAX_FUTURE_ROUNDS; r++) {
@@ -253,23 +236,37 @@ export function calcRaceForecast(
       }
       // Check if any player crossed the threshold this round
       let bestScore = -Infinity;
+      const crossingIndexes: number[] = [];
       for (let i = 0; i < stats.length; i++) {
-        if (scores[i] >= winThreshold && scores[i] > bestScore) {
+        if (scores[i] < winThreshold) continue;
+        if (scores[i] > bestScore) {
           bestScore = scores[i];
-          winnerId = stats[i].id;
-          winningRound = roundsPlayed + r + 1;
+          crossingIndexes.length = 0;
+          crossingIndexes.push(i);
+        } else if (scores[i] === bestScore) {
+          crossingIndexes.push(i);
         }
       }
-      if (winnerId) break;
+      if (crossingIndexes.length > 0) {
+        winnerIndexes = crossingIndexes;
+        winningRound = roundsPlayed + r + 1;
+        break;
+      }
     }
 
-    if (winnerId && winningRound !== null) {
-      wins[winnerId]++;
-      winningRounds[winnerId].push(winningRound);
-      gameEndRounds.push(winningRound);
-      if (winningRound === roundsPlayed + 1) {
-        nextRoundWins[winnerId]++;
+    if (winnerIndexes.length > 0 && winningRound !== null) {
+      const splitWeight = 1 / winnerIndexes.length;
+
+      for (const winnerIndex of winnerIndexes) {
+        const winnerId = stats[winnerIndex].id;
+        wins[winnerId] += splitWeight;
+        winningRounds[winnerId].push(winningRound);
+        if (winningRound === roundsPlayed + 1) {
+          nextRoundWins[winnerId] += splitWeight;
+        }
       }
+
+      gameEndRounds.push(winningRound);
     } else {
       unresolvedCount++;
     }


### PR DESCRIPTION
## Summary
- replace the pace-only projected finish with a richer current-game Race Outlook forecast
- return win odds, next-round close odds, likely ending ranges, player winning-round ranges, confidence, and explicit unresolved outcomes from one deterministic simulation pass
- clamp simulated round deltas to Dutch Blitz scoring bounds and make forecast rounding/order stable
- add model and component tests for unresolved outcomes, next-round coherence, reorder determinism, clamping, and the new Race Outlook UI

## Claude review
- reviewed the implementation plan before coding
- reviewed the completed diff before push
- addressed concrete findings around largest-remainder ordering, rounded next-round odds exceeding total win odds, and rounded-zero tail outcome text

## Testing
- `npm run lint`
- `npm test`
- `RESEND_API_KEY=re_dummy npx next build`

Note: `npm run build` is not runnable in this local env because it starts with `prisma migrate deploy` against the placeholder local database before Next compiles.

---
Integration/testing PR: #270 contains the full stack for end-to-end testing.