### PR TITLE
Add permission-gated prediction history profiles

### DIFF
--- a/src/server/__tests__/predictionProfiles.test.ts
+++ b/src/server/__tests__/predictionProfiles.test.ts
@@ -1,0 +1,286 @@
+import {
+  buildPredictionProfiles,
+  getPredictionProfilesForGame,
+  HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+  RECENT_DELTA_LIMIT,
+} from "../queries/predictionProfiles";
+import prisma from "@/server/db/db";
+import { auth } from "@clerk/nextjs/server";
+
+jest.mock("@/server/db/db", () => {
+  const mockPrisma = {
+    game: {
+      findUnique: jest.fn(),
+    },
+    score: {
+      findMany: jest.fn(),
+    },
+  };
+  return {
+    __esModule: true,
+    default: mockPrisma,
+  };
+});
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+describe("buildPredictionProfiles", () => {
+  it("summarizes score samples by user and guest player id", () => {
+    const profiles = buildPredictionProfiles(["user-1", "guest-1"], [
+      {
+        userId: "user-1",
+        guestId: null,
+        totalCardsPlayed: 20,
+        blitzPileRemaining: 0,
+      },
+      {
+        userId: "user-1",
+        guestId: null,
+        totalCardsPlayed: 10,
+        blitzPileRemaining: 5,
+      },
+      {
+        userId: null,
+        guestId: "guest-1",
+        totalCardsPlayed: 30,
+        blitzPileRemaining: 0,
+      },
+      {
+        userId: "other-user",
+        guestId: null,
+        totalCardsPlayed: 40,
+        blitzPileRemaining: 0,
+      },
+    ]);
+
+    expect(profiles["user-1"]).toMatchObject({
+      playerId: "user-1",
+      roundsPlayed: 2,
+      meanDelta: 10,
+      blitzRate: 0.5,
+      meanCardsPlayed: 15,
+      meanBlitzPileRemaining: 2.5,
+      recentDeltas: [20, 0],
+    });
+    expect(profiles["user-1"].stdDelta).toBeCloseTo(14.142, 3);
+
+    expect(profiles["guest-1"]).toMatchObject({
+      playerId: "guest-1",
+      roundsPlayed: 1,
+      meanDelta: 30,
+      stdDelta: 0,
+      blitzRate: 1,
+      meanCardsPlayed: 30,
+      meanBlitzPileRemaining: 0,
+      recentDeltas: [30],
+    });
+    expect(profiles).not.toHaveProperty("other-user");
+  });
+
+  it("keeps recent deltas capped while retaining aggregate sample counts", () => {
+    const samples = Array.from({ length: RECENT_DELTA_LIMIT + 5 }, (_, index) => ({
+      userId: "user-1",
+      guestId: null,
+      totalCardsPlayed: index,
+      blitzPileRemaining: 0,
+    }));
+
+    const profiles = buildPredictionProfiles(["user-1"], samples);
+
+    expect(profiles["user-1"].roundsPlayed).toBe(RECENT_DELTA_LIMIT + 5);
+    expect(profiles["user-1"].recentDeltas).toHaveLength(RECENT_DELTA_LIMIT);
+    expect(profiles["user-1"].recentDeltas.slice(0, 3)).toEqual([0, 1, 2]);
+    expect(profiles["user-1"].recentDeltas.at(-1)).toBe(RECENT_DELTA_LIMIT - 1);
+  });
+});
+
+describe("getPredictionProfilesForGame", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "clerk-user",
+      orgId: "org-1",
+    });
+  });
+
+  it("does not fetch score history when the viewer is not authenticated", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: null,
+      orgId: null,
+    });
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when no active circle is selected", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "clerk-user",
+      orgId: null,
+    });
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when the game is missing", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history for legacy games without a circle", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: null,
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history for a different active circle", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-2",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when a game has no resolvable players", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: null, guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("fetches prior same-circle score samples for current user and guest players", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [
+        { userId: "user-1", guestId: null },
+        { userId: null, guestId: "guest-1" },
+      ],
+    });
+    (prisma.score.findMany as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          userId: "user-1",
+          guestId: null,
+          totalCardsPlayed: 20,
+          blitzPileRemaining: 0,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          userId: null,
+          guestId: "guest-1",
+          totalCardsPlayed: 25,
+          blitzPileRemaining: 5,
+        },
+      ]);
+
+    const profiles = await getPredictionProfilesForGame("game-1");
+
+    expect(prisma.score.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        userId: "user-1",
+        round: {
+          gameId: { not: "game-1" },
+          game: {
+            organizationId: "org-1",
+            isFinished: true,
+          },
+        },
+      },
+      select: {
+        userId: true,
+        guestId: true,
+        totalCardsPlayed: true,
+        blitzPileRemaining: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+    });
+    expect(prisma.score.findMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        guestId: "guest-1",
+        round: {
+          gameId: { not: "game-1" },
+          game: {
+            organizationId: "org-1",
+            isFinished: true,
+          },
+        },
+      },
+      select: {
+        userId: true,
+        guestId: true,
+        totalCardsPlayed: true,
+        blitzPileRemaining: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+    });
+    expect(profiles["user-1"].recentDeltas).toEqual([20]);
+    expect(profiles["guest-1"].recentDeltas).toEqual([15]);
+  });
+
+  it("supports user-only games without adding a guest query", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+    (prisma.score.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+
+    expect(prisma.score.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.score.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "user-1" }),
+      })
+    );
+  });
+
+  it("supports guest-only games without adding a user query", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: null, guestId: "guest-1" }],
+    });
+    (prisma.score.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+
+    expect(prisma.score.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.score.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ guestId: "guest-1" }),
+      })
+    );
+  });
+});

--- a/src/server/queries/index.ts
+++ b/src/server/queries/index.ts
@@ -6,3 +6,9 @@ export {
   getCumulativeScore,
   getLongestAndShortestGamesByRounds,
 } from "./stats";
+export {
+  buildPredictionProfiles,
+  getPredictionProfilesForGame,
+  type PredictionProfile,
+  type PredictionProfilesByPlayer,
+} from "./predictionProfiles";

--- a/src/server/queries/predictionProfiles.ts
+++ b/src/server/queries/predictionProfiles.ts
@@ -1,0 +1,187 @@
+import "server-only";
+
+import { auth } from "@clerk/nextjs/server";
+import { type Prisma } from "@/generated/prisma/client";
+import prisma from "@/server/db/db";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+
+export const HISTORY_SAMPLE_LIMIT_PER_PLAYER = 120;
+export const RECENT_DELTA_LIMIT = 40;
+
+export interface PredictionScoreSample {
+  userId: string | null;
+  guestId: string | null;
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
+}
+
+export interface PredictionProfile {
+  playerId: string;
+  roundsPlayed: number;
+  meanDelta: number;
+  stdDelta: number;
+  blitzRate: number;
+  meanCardsPlayed: number;
+  meanBlitzPileRemaining: number;
+  recentDeltas: number[];
+}
+
+export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function stddev(values: number[], avg: number): number {
+  if (values.length < 2) return 0;
+  const variance =
+    values.reduce((sum, value) => sum + (value - avg) ** 2, 0) /
+    (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+function getSamplePlayerId(sample: PredictionScoreSample): string | null {
+  return sample.userId ?? sample.guestId ?? null;
+}
+
+export function buildPredictionProfiles(
+  playerIds: string[],
+  samples: PredictionScoreSample[]
+): PredictionProfilesByPlayer {
+  const samplesByPlayer = new Map<string, PredictionScoreSample[]>();
+
+  for (const playerId of playerIds) {
+    samplesByPlayer.set(playerId, []);
+  }
+
+  for (const sample of samples) {
+    const playerId = getSamplePlayerId(sample);
+    if (!playerId || !samplesByPlayer.has(playerId)) continue;
+    samplesByPlayer.get(playerId)?.push(sample);
+  }
+
+  return Object.fromEntries(
+    [...samplesByPlayer.entries()]
+      .filter(([, playerSamples]) => playerSamples.length > 0)
+      .map(([playerId, playerSamples]) => {
+        const deltas = playerSamples.map(calculateRoundScore);
+        const deltaMean = mean(deltas);
+
+        return [
+          playerId,
+          {
+            playerId,
+            roundsPlayed: playerSamples.length,
+            meanDelta: deltaMean,
+            stdDelta: stddev(deltas, deltaMean),
+            blitzRate:
+              playerSamples.filter((sample) => sample.blitzPileRemaining === 0)
+                .length / playerSamples.length,
+            meanCardsPlayed: mean(
+              playerSamples.map((sample) => sample.totalCardsPlayed)
+            ),
+            meanBlitzPileRemaining: mean(
+              playerSamples.map((sample) => sample.blitzPileRemaining)
+            ),
+            recentDeltas: deltas.slice(0, RECENT_DELTA_LIMIT),
+          },
+        ];
+      })
+  );
+}
+
+export async function getPredictionProfilesForGame(
+  gameId: string
+): Promise<PredictionProfilesByPlayer> {
+  const [session, game] = await Promise.all([
+    auth(),
+    prisma.game.findUnique({
+      where: { id: gameId },
+      select: {
+        id: true,
+        organizationId: true,
+        players: {
+          select: {
+            userId: true,
+            guestId: true,
+          },
+        },
+      },
+    }),
+  ]);
+
+  // Forecast history is optional enrichment: return no profiles instead of
+  // throwing so public/spectator game pages can keep rendering safely.
+  if (!session.userId || !session.orgId || !game?.organizationId) {
+    return {};
+  }
+
+  if (game.organizationId !== session.orgId) {
+    return {};
+  }
+
+  const userIds = game.players
+    .map((player) => player.userId)
+    .filter((id): id is string => Boolean(id));
+  const guestIds = game.players
+    .map((player) => player.guestId)
+    .filter((id): id is string => Boolean(id));
+  const playerIds = [...userIds, ...guestIds];
+
+  if (playerIds.length === 0) {
+    return {};
+  }
+
+  const historyScope = {
+    round: {
+      // Deliberately exclude this game; live in-game rounds are supplied by
+      // the scoring UI and will be blended separately by the forecast model.
+      gameId: { not: gameId },
+      game: {
+        organizationId: game.organizationId,
+        isFinished: true,
+      },
+    },
+  };
+
+  const scoreSelect = {
+    userId: true,
+    guestId: true,
+    totalCardsPlayed: true,
+    blitzPileRemaining: true,
+  } as const;
+  const scoreOrder: Prisma.ScoreOrderByWithRelationInput[] = [
+    { createdAt: "desc" },
+    { id: "desc" },
+  ];
+
+  const samplesByPlayer = await Promise.all([
+    ...userIds.map((userId) =>
+      prisma.score.findMany({
+        where: {
+          userId,
+          ...historyScope,
+        },
+        select: scoreSelect,
+        orderBy: scoreOrder,
+        take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+      })
+    ),
+    ...guestIds.map((guestId) =>
+      prisma.score.findMany({
+        where: {
+          guestId,
+          ...historyScope,
+        },
+        select: scoreSelect,
+        orderBy: scoreOrder,
+        take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+      })
+    ),
+  ]);
+
+  const samples = samplesByPlayer.flat();
+
+  return buildPredictionProfiles(playerIds, samples);
+}


### PR DESCRIPTION
## Summary
- Add a server-only prediction profile query for current game players, covering registered users and recurring guests
- Gate historical score access to authenticated viewers whose active Clerk org matches the game circle
- Read only prior finished games in the same circle, exclude the current game, and cap each player to 120 recent score samples
- Expose aggregate prediction inputs: mean delta, standard deviation, blitz rate, cards played, blitz pile remaining, and 40 recent deltas

## Claude review
- Claude reviewed the plan before implementation and reviewed this PR2a diff after implementation
- Its privacy review found no blocking issues; I addressed the main design note by limiting history to finished games only
- Added/kept tests around the empty-profile gates, same-circle scoping, per-player query cap, users vs guests, and profile math

## Verification
- `npm run lint`
- `npm test`
- `RESEND_API_KEY=re_dummy npx next build`

## Notes
This is intentionally groundwork only. The forecast still needs a follow-up PR to blend these profiles into the Monte Carlo model and UI.

---
Integration/testing PR: #270 contains the full stack for end-to-end testing.