### PR TITLE
Blend player history into Race Outlook

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { ScoringShell } from "@/components/scoring/ScoringShell";
-import { getGameById } from "@/server/queries";
+import { getGameById, getPredictionProfilesForGame } from "@/server/queries";
 import { notFound } from "next/navigation";
 import transformGameData, { GameWithPlayersAndScores } from "@/lib/gameLogic";
 import {
@@ -67,6 +67,9 @@ export default async function GameView(props: {
   // read-only spectator view of the same scoring UI.
   const isCircleMember =
     !!userId && !!game.organizationId && game.organizationId === orgId;
+  const predictionProfiles = isCircleMember
+    ? await getPredictionProfilesForGame(params.id)
+    : {};
 
   return (
     <section className="py-6">
@@ -84,6 +87,7 @@ export default async function GameView(props: {
         winnerId={displayScores.find((s) => s.isWinner)?.id}
         endedAt={game.endedAt?.toISOString()}
         canEdit={isCircleMember}
+        predictionProfiles={predictionProfiles}
         rounds={game.rounds.map((r) => ({
           id: r.id,
           scores: r.scores.map((s) => ({

--- a/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
+++ b/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
@@ -40,17 +40,42 @@ describe("WinProbabilityCard", () => {
         players={players}
         roundsPlayed={5}
         winThreshold={75}
-        deltasByPlayer={{
-          close: [12, 14, 16, 14, 14],
-          far: [4, 8, 6, 6, 6],
-        }}
-      />
-    );
+          deltasByPlayer={{
+            close: [12, 14, 16, 14, 14],
+            far: [4, 8, 6, 6, 6],
+          }}
+          predictionProfiles={{
+            close: {
+              playerId: "close",
+              roundsPlayed: 12,
+              meanDelta: 14,
+              stdDelta: 2,
+              blitzRate: 0.5,
+              meanCardsPlayed: 24,
+              meanBlitzPileRemaining: 5,
+              recentDeltas: [12, 14, 16],
+            },
+            far: {
+              playerId: "far",
+              roundsPlayed: 12,
+              meanDelta: 6,
+              stdDelta: 2,
+              blitzRate: 0.2,
+              meanCardsPlayed: 18,
+              meanBlitzPileRemaining: 6,
+              recentDeltas: [4, 8, 6],
+            },
+          }}
+        />
+      );
 
     expect(screen.getByText("Race Outlook")).toBeInTheDocument();
     expect(screen.getByText("Likely ending")).toBeInTheDocument();
     expect(screen.getByText("Next-round danger")).toBeInTheDocument();
     expect(screen.getByText(/Can close now/)).toBeInTheDocument();
+    expect(
+      screen.getByText("History-backed from 24 prior player scores")
+    ).toBeInTheDocument();
     expect(screen.queryByText("Projected finish")).not.toBeInTheDocument();
   });
 });

--- a/src/components/scoring/BetweenRoundsView.tsx
+++ b/src/components/scoring/BetweenRoundsView.tsx
@@ -15,6 +15,7 @@ import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { useRoundEditing } from "./useRoundEditing";
 import { findPlayerScore } from "./utils";
 import { type PlayerWithScore, type RoundData } from "./types";
+import { type PredictionProfilesByPlayer } from "@/lib/scoring/probability";
 
 interface BetweenRoundsViewProps {
   gameId: string;
@@ -25,6 +26,7 @@ interface BetweenRoundsViewProps {
   onEnterScores: () => void;
   /** When false, render as a read-only spectator view (no entry/edit actions) */
   canEdit?: boolean;
+  predictionProfiles?: PredictionProfilesByPlayer;
 }
 
 export function BetweenRoundsView({
@@ -35,6 +37,7 @@ export function BetweenRoundsView({
   nextRoundNumber,
   onEnterScores,
   canEdit = true,
+  predictionProfiles,
 }: BetweenRoundsViewProps) {
   const posthog = usePostHog();
   const { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit } =
@@ -87,6 +90,7 @@ export function BetweenRoundsView({
           roundsPlayed={rounds.length}
           winThreshold={winThreshold}
           deltasByPlayer={deltasByRound}
+          predictionProfiles={predictionProfiles}
         />
       </GraphCarousel>
 

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -12,6 +12,7 @@ import { findPlayerScore } from "./utils";
 import { useRoundEditing } from "./useRoundEditing";
 import { type PlayerWithScore, type RoundData, type RoundScoreData } from "./types";
 import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
+import { type PredictionProfilesByPlayer } from "@/lib/scoring/probability";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { cloneGame } from "@/server/mutations/games";
 
@@ -26,6 +27,7 @@ interface ScoringShellProps {
   winnerId?: string;
   endedAt?: string;
   rounds: RoundData[];
+  predictionProfiles?: PredictionProfilesByPlayer;
   /**
    * When false, render as a read-only spectator view — for people viewing a
    * game outside their circle, or via a public shared link. No score entry,
@@ -43,6 +45,7 @@ export function ScoringShell({
   winnerId,
   endedAt,
   rounds,
+  predictionProfiles,
   canEdit = true,
 }: ScoringShellProps) {
   const router = useRouter();
@@ -226,6 +229,7 @@ export function ScoringShell({
         nextRoundNumber={optimisticRound ? currentRoundNumber + 1 : currentRoundNumber}
         onEnterScores={() => setShowEntry(true)}
         canEdit={canEdit}
+        predictionProfiles={predictionProfiles}
       />
     );
   }

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -5,6 +5,7 @@ import {
   type ForecastRange,
   type PlayerForecast,
   type RaceForecast,
+  type PredictionProfilesByPlayer,
 } from "@/lib/scoring/probability";
 
 interface WinProbabilityCardProps {
@@ -12,6 +13,7 @@ interface WinProbabilityCardProps {
   roundsPlayed: number;
   winThreshold: number;
   deltasByPlayer?: Record<string, number[]>;
+  predictionProfiles?: PredictionProfilesByPlayer;
 }
 
 export function WinProbabilityCard({
@@ -19,15 +21,17 @@ export function WinProbabilityCard({
   roundsPlayed,
   winThreshold,
   deltasByPlayer,
+  predictionProfiles,
 }: WinProbabilityCardProps) {
   const forecast = useMemo(
     () =>
       calcRaceForecast(
         players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
         winThreshold,
-        deltasByPlayer
+        deltasByPlayer,
+        { predictionProfiles }
       ),
-    [players, roundsPlayed, winThreshold, deltasByPlayer]
+    [players, roundsPlayed, winThreshold, deltasByPlayer, predictionProfiles]
   );
 
   const sorted = useMemo(
@@ -122,10 +126,15 @@ export function WinProbabilityCard({
             {forecast.unresolvedProbability}% still open after the forecast window
           </div>
         )}
+        {forecast.usesHistoricalData && (
+          <div className="mt-2 text-[12px] md:text-[11px] text-[#8b5e3c]">
+            History-backed from {forecast.historicalSampleCount} prior player scores
+          </div>
+        )}
       </div>
 
       <div className="text-xs md:text-[11px] text-[#8b5e3c] text-center mt-2 italic">
-        Monte Carlo simulation · accounts for pace &amp; variance
+        Monte Carlo simulation · {getModelNote(forecast)}
       </div>
     </div>
   );
@@ -169,7 +178,22 @@ function getSubtitle(roundsPlayed: number, forecast: RaceForecast): string {
       : forecast.confidence === "medium"
         ? "medium confidence"
         : "low confidence";
-  return `Simulated from ${roundsPlayed} rounds tonight · ${confidence}`;
+  const source = forecast.usesHistoricalData
+    ? roundsPlayed > 0
+      ? `${formatRoundCount(roundsPlayed)} tonight + history`
+      : "player history"
+    : `${formatRoundCount(roundsPlayed)} tonight`;
+  return `Simulated from ${source} · ${confidence}`;
+}
+
+function getModelNote(forecast: RaceForecast): string {
+  return forecast.usesHistoricalData
+    ? "blends pace, variance & player history"
+    : "accounts for pace & variance";
+}
+
+function formatRoundCount(roundsPlayed: number): string {
+  return `${roundsPlayed} ${roundsPlayed === 1 ? "round" : "rounds"}`;
 }
 
 function getTopNextThreat(

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -198,6 +198,121 @@ describe("calcRaceForecast", () => {
     ).toBeNull();
   });
 
+  it("can use historical profiles for an early low-confidence forecast", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "fast", score: 10, roundsPlayed: 1 },
+        { id: "steady", score: 10, roundsPlayed: 1 },
+      ],
+      75,
+      {
+        fast: [10],
+        steady: [10],
+      },
+      {
+        predictionProfiles: {
+          fast: {
+            playerId: "fast",
+            roundsPlayed: 20,
+            meanDelta: 18,
+            stdDelta: 4,
+            blitzRate: 0.6,
+            meanCardsPlayed: 24,
+            meanBlitzPileRemaining: 3,
+            recentDeltas: [20, 18, 16],
+          },
+          steady: {
+            playerId: "steady",
+            roundsPlayed: 20,
+            meanDelta: 8,
+            stdDelta: 3,
+            blitzRate: 0.2,
+            meanCardsPlayed: 18,
+            meanBlitzPileRemaining: 5,
+            recentDeltas: [8, 9, 7],
+          },
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.usesHistoricalData).toBe(true);
+    expect(forecast!.historicalSampleCount).toBe(40);
+    expect(forecast!.confidence).toBe("low");
+    expect(forecast!.players.fast.winProbability).toBeGreaterThan(
+      forecast!.players.steady.winProbability
+    );
+  });
+
+  it("ignores profiles without enough history for an early forecast", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "fast", score: 10, roundsPlayed: 1 },
+        { id: "steady", score: 10, roundsPlayed: 1 },
+      ],
+      75,
+      {
+        fast: [10],
+        steady: [10],
+      },
+      {
+        predictionProfiles: {
+          fast: {
+            playerId: "fast",
+            roundsPlayed: 4,
+            meanDelta: 18,
+            stdDelta: 4,
+            blitzRate: 0.6,
+            meanCardsPlayed: 24,
+            meanBlitzPileRemaining: 3,
+            recentDeltas: [20, 18, 16],
+          },
+        },
+      }
+    );
+
+    expect(forecast).toBeNull();
+  });
+
+  it("does not mark shallow per-player history as high confidence", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "a", score: 50, roundsPlayed: 5 },
+        { id: "b", score: 45, roundsPlayed: 5 },
+        { id: "c", score: 40, roundsPlayed: 5 },
+        { id: "d", score: 35, roundsPlayed: 5 },
+      ],
+      75,
+      {
+        a: [10, 10, 10, 10, 10],
+        b: [9, 9, 9, 9, 9],
+        c: [8, 8, 8, 8, 8],
+        d: [7, 7, 7, 7, 7],
+      },
+      {
+        predictionProfiles: Object.fromEntries(
+          ["a", "b", "c", "d"].map((id, index) => [
+            id,
+            {
+              playerId: id,
+              roundsPlayed: 5,
+              meanDelta: 10 - index,
+              stdDelta: 1,
+              blitzRate: 0.4,
+              meanCardsPlayed: 20,
+              meanBlitzPileRemaining: 4,
+              recentDeltas: [10 - index],
+            },
+          ])
+        ),
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.historicalSampleCount).toBe(20);
+    expect(forecast!.confidence).not.toBe("high");
+  });
+
   it("keeps unresolved simulations explicit instead of crediting the leader", () => {
     const forecast = calcRaceForecast(
       [

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,6 +1,8 @@
 const SIMULATION_COUNT = 10_000;
 const MAX_FUTURE_ROUNDS = 50;
 const UNRESOLVED_OUTCOME_ID = "__unresolved";
+const MIN_HISTORICAL_ROUNDS = 5;
+const HISTORY_BLEND_ROUND_CAP = 8;
 export const MIN_SIMULATED_ROUND_SCORE = -20;
 export const MAX_SIMULATED_ROUND_SCORE = 40;
 
@@ -58,7 +60,21 @@ interface PlayerStats {
   currentScore: number;
   mean: number;
   std: number;
+  historicalSampleCount: number;
 }
+
+export interface PredictionProfile {
+  playerId: string;
+  roundsPlayed: number;
+  meanDelta: number;
+  stdDelta: number;
+  blitzRate: number;
+  meanCardsPlayed: number;
+  meanBlitzPileRemaining: number;
+  recentDeltas: number[];
+}
+
+export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
 
 export interface ForecastRange {
   p25: number;
@@ -81,6 +97,12 @@ export interface RaceForecast {
   unresolvedProbability: number;
   confidence: ForecastConfidence;
   simulationCount: number;
+  usesHistoricalData: boolean;
+  historicalSampleCount: number;
+}
+
+interface RaceForecastOptions {
+  predictionProfiles?: PredictionProfilesByPlayer;
 }
 
 function percentile(sortedValues: number[], percentileValue: number): number {
@@ -148,22 +170,130 @@ export function allocateOutcomePercents(
 
 function calcConfidence(
   roundsPlayed: number,
-  unresolvedProbability: number
+  unresolvedProbability: number,
+  minimumHistoricalDepth: number
 ): ForecastConfidence {
   if (roundsPlayed < 5 || unresolvedProbability >= 25) return "low";
+  if (minimumHistoricalDepth >= 12 && unresolvedProbability < 10) return "high";
   if (roundsPlayed < 8 || unresolvedProbability >= 10) return "medium";
   return "high";
+}
+
+function hasUsableHistory(
+  profile: PredictionProfile | undefined
+): profile is PredictionProfile {
+  return Boolean(profile && profile.roundsPlayed >= MIN_HISTORICAL_ROUNDS);
+}
+
+function calcCurrentWeight(
+  currentRounds: number,
+  historicalSampleCount: number
+): number {
+  if (currentRounds <= 0) return 0;
+  const cappedHistoryRounds = Math.min(
+    historicalSampleCount,
+    HISTORY_BLEND_ROUND_CAP
+  );
+  const raw = currentRounds / (currentRounds + cappedHistoryRounds);
+  return Math.min(0.85, Math.max(0.35, raw));
+}
+
+function blendStd(
+  currentMean: number,
+  currentStd: number,
+  historicalMean: number,
+  historicalStd: number,
+  currentWeight: number
+): number {
+  const blendedMean =
+    currentMean * currentWeight + historicalMean * (1 - currentWeight);
+  const variance =
+    currentWeight * (currentStd ** 2 + (currentMean - blendedMean) ** 2) +
+    (1 - currentWeight) *
+      (historicalStd ** 2 + (historicalMean - blendedMean) ** 2);
+  return Math.sqrt(variance);
+}
+
+function buildPlayerStats(
+  player: { id: string; score: number; roundsPlayed: number },
+  deltas: number[] | undefined,
+  profile: PredictionProfile | undefined
+): PlayerStats {
+  const currentDeltas = deltas ?? [];
+  const currentMean =
+    currentDeltas.length > 0
+      ? mean(currentDeltas)
+      : player.roundsPlayed > 0
+        ? player.score / player.roundsPlayed
+        : 0;
+  const currentStd =
+    currentDeltas.length >= 2
+      ? stddev(currentDeltas, currentMean)
+      : Math.abs(currentMean) * 0.5;
+
+  if (hasUsableHistory(profile)) {
+    const currentWeight = calcCurrentWeight(
+      currentDeltas.length,
+      profile.roundsPlayed
+    );
+    const blendedMean =
+      currentMean * currentWeight + profile.meanDelta * (1 - currentWeight);
+    const blendedStd = blendStd(
+      currentMean,
+      currentStd,
+      profile.meanDelta,
+      profile.stdDelta,
+      currentWeight
+    );
+
+    return {
+      id: player.id,
+      currentScore: player.score,
+      mean: blendedMean,
+      std: blendedStd,
+      historicalSampleCount: profile.roundsPlayed,
+    };
+  }
+
+  if (currentDeltas.length >= 2) {
+    return {
+      id: player.id,
+      currentScore: player.score,
+      mean: currentMean,
+      std: currentStd,
+      historicalSampleCount: 0,
+    };
+  }
+
+  return {
+    id: player.id,
+    currentScore: player.score,
+    mean: currentMean,
+    std: Math.abs(currentMean) * 0.5,
+    historicalSampleCount: 0,
+  };
 }
 
 function buildSeed(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
-  deltasByPlayer?: Record<string, number[]>
+  deltasByPlayer?: Record<string, number[]>,
+  predictionProfiles?: PredictionProfilesByPlayer
 ): number {
   const seedText = players
     .map((p) => {
       const deltas = deltasByPlayer?.[p.id] ?? [];
-      return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(",")}`;
+      const profile = predictionProfiles?.[p.id];
+      const profileText = profile
+        ? `${profile.roundsPlayed}:${profile.meanDelta.toFixed(
+            3
+          )}:${profile.stdDelta.toFixed(3)}:${profile.recentDeltas
+            .slice(0, 10)
+            .join(",")}`
+        : "";
+      return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(
+        ","
+      )}:${profileText}`;
     })
     .sort()
     .join("|");
@@ -191,28 +321,35 @@ function buildSeed(
 export function calcRaceForecast(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
-  deltasByPlayer?: Record<string, number[]>
+  deltasByPlayer?: Record<string, number[]>,
+  options: RaceForecastOptions = {}
 ): RaceForecast | null {
   if (players.length === 0) return null;
   const roundsPlayed = players[0].roundsPlayed;
-  if (roundsPlayed < 3) return null;
+  const hasHistoricalEvidence = players.some((p) =>
+    hasUsableHistory(options.predictionProfiles?.[p.id])
+  );
+  if (roundsPlayed < 3 && !hasHistoricalEvidence) return null;
 
   const orderedPlayers = [...players].sort((a, b) => a.id.localeCompare(b.id));
 
-  // Build per-player stats from deltas when available
-  const stats: PlayerStats[] = orderedPlayers.map((p) => {
-    const deltas = deltasByPlayer?.[p.id];
-    if (deltas && deltas.length >= 2) {
-      const m = mean(deltas);
-      const s = stddev(deltas, m);
-      return { id: p.id, currentScore: p.score, mean: m, std: s };
-    }
-    // Fallback: infer mean from aggregate, assume moderate variance
-    const m = p.roundsPlayed > 0 ? p.score / p.roundsPlayed : 0;
-    return { id: p.id, currentScore: p.score, mean: m, std: Math.abs(m) * 0.5 };
-  });
+  const stats: PlayerStats[] = orderedPlayers.map((p) =>
+    buildPlayerStats(p, deltasByPlayer?.[p.id], options.predictionProfiles?.[p.id])
+  );
+  const historicalSampleCount = stats.reduce(
+    (sum, stat) => sum + stat.historicalSampleCount,
+    0
+  );
+  const usesHistoricalData = historicalSampleCount > 0;
+  const historicalDepths = stats
+    .map((stat) => stat.historicalSampleCount)
+    .filter((count) => count > 0);
+  const minimumHistoricalDepth =
+    historicalDepths.length === stats.length ? Math.min(...historicalDepths) : 0;
 
-  const rng = makeRng(buildSeed(players, winThreshold, deltasByPlayer));
+  const rng = makeRng(
+    buildSeed(players, winThreshold, deltasByPlayer, options.predictionProfiles)
+  );
 
   const wins: Record<string, number> = {};
   const nextRoundWins: Record<string, number> = {};
@@ -299,17 +436,29 @@ export function calcRaceForecast(
     players: forecastPlayers,
     gameEndRound: buildRange(gameEndRounds),
     unresolvedProbability,
-    confidence: calcConfidence(roundsPlayed, unresolvedProbability),
+    confidence: calcConfidence(
+      roundsPlayed,
+      unresolvedProbability,
+      minimumHistoricalDepth
+    ),
     simulationCount: SIMULATION_COUNT,
+    usesHistoricalData,
+    historicalSampleCount,
   };
 }
 
 export function calcWinProbabilities(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
-  deltasByPlayer?: Record<string, number[]>
+  deltasByPlayer?: Record<string, number[]>,
+  options: RaceForecastOptions = {}
 ): Record<string, number> | null {
-  const forecast = calcRaceForecast(players, winThreshold, deltasByPlayer);
+  const forecast = calcRaceForecast(
+    players,
+    winThreshold,
+    deltasByPlayer,
+    options
+  );
   if (!forecast) return null;
   return Object.fromEntries(
     Object.values(forecast.players).map((player) => [

--- a/src/server/__tests__/predictionProfiles.test.ts
+++ b/src/server/__tests__/predictionProfiles.test.ts
@@ -1,0 +1,286 @@
+import {
+  buildPredictionProfiles,
+  getPredictionProfilesForGame,
+  HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+  RECENT_DELTA_LIMIT,
+} from "../queries/predictionProfiles";
+import prisma from "@/server/db/db";
+import { auth } from "@clerk/nextjs/server";
+
+jest.mock("@/server/db/db", () => {
+  const mockPrisma = {
+    game: {
+      findUnique: jest.fn(),
+    },
+    score: {
+      findMany: jest.fn(),
+    },
+  };
+  return {
+    __esModule: true,
+    default: mockPrisma,
+  };
+});
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+describe("buildPredictionProfiles", () => {
+  it("summarizes score samples by user and guest player id", () => {
+    const profiles = buildPredictionProfiles(["user-1", "guest-1"], [
+      {
+        userId: "user-1",
+        guestId: null,
+        totalCardsPlayed: 20,
+        blitzPileRemaining: 0,
+      },
+      {
+        userId: "user-1",
+        guestId: null,
+        totalCardsPlayed: 10,
+        blitzPileRemaining: 5,
+      },
+      {
+        userId: null,
+        guestId: "guest-1",
+        totalCardsPlayed: 30,
+        blitzPileRemaining: 0,
+      },
+      {
+        userId: "other-user",
+        guestId: null,
+        totalCardsPlayed: 40,
+        blitzPileRemaining: 0,
+      },
+    ]);
+
+    expect(profiles["user-1"]).toMatchObject({
+      playerId: "user-1",
+      roundsPlayed: 2,
+      meanDelta: 10,
+      blitzRate: 0.5,
+      meanCardsPlayed: 15,
+      meanBlitzPileRemaining: 2.5,
+      recentDeltas: [20, 0],
+    });
+    expect(profiles["user-1"].stdDelta).toBeCloseTo(14.142, 3);
+
+    expect(profiles["guest-1"]).toMatchObject({
+      playerId: "guest-1",
+      roundsPlayed: 1,
+      meanDelta: 30,
+      stdDelta: 0,
+      blitzRate: 1,
+      meanCardsPlayed: 30,
+      meanBlitzPileRemaining: 0,
+      recentDeltas: [30],
+    });
+    expect(profiles).not.toHaveProperty("other-user");
+  });
+
+  it("keeps recent deltas capped while retaining aggregate sample counts", () => {
+    const samples = Array.from({ length: RECENT_DELTA_LIMIT + 5 }, (_, index) => ({
+      userId: "user-1",
+      guestId: null,
+      totalCardsPlayed: index,
+      blitzPileRemaining: 0,
+    }));
+
+    const profiles = buildPredictionProfiles(["user-1"], samples);
+
+    expect(profiles["user-1"].roundsPlayed).toBe(RECENT_DELTA_LIMIT + 5);
+    expect(profiles["user-1"].recentDeltas).toHaveLength(RECENT_DELTA_LIMIT);
+    expect(profiles["user-1"].recentDeltas.slice(0, 3)).toEqual([0, 1, 2]);
+    expect(profiles["user-1"].recentDeltas.at(-1)).toBe(RECENT_DELTA_LIMIT - 1);
+  });
+});
+
+describe("getPredictionProfilesForGame", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "clerk-user",
+      orgId: "org-1",
+    });
+  });
+
+  it("does not fetch score history when the viewer is not authenticated", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: null,
+      orgId: null,
+    });
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when no active circle is selected", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "clerk-user",
+      orgId: null,
+    });
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when the game is missing", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history for legacy games without a circle", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: null,
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history for a different active circle", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-2",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when a game has no resolvable players", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: null, guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("fetches prior same-circle score samples for current user and guest players", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [
+        { userId: "user-1", guestId: null },
+        { userId: null, guestId: "guest-1" },
+      ],
+    });
+    (prisma.score.findMany as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          userId: "user-1",
+          guestId: null,
+          totalCardsPlayed: 20,
+          blitzPileRemaining: 0,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          userId: null,
+          guestId: "guest-1",
+          totalCardsPlayed: 25,
+          blitzPileRemaining: 5,
+        },
+      ]);
+
+    const profiles = await getPredictionProfilesForGame("game-1");
+
+    expect(prisma.score.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        userId: "user-1",
+        round: {
+          gameId: { not: "game-1" },
+          game: {
+            organizationId: "org-1",
+            isFinished: true,
+          },
+        },
+      },
+      select: {
+        userId: true,
+        guestId: true,
+        totalCardsPlayed: true,
+        blitzPileRemaining: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+    });
+    expect(prisma.score.findMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        guestId: "guest-1",
+        round: {
+          gameId: { not: "game-1" },
+          game: {
+            organizationId: "org-1",
+            isFinished: true,
+          },
+        },
+      },
+      select: {
+        userId: true,
+        guestId: true,
+        totalCardsPlayed: true,
+        blitzPileRemaining: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+    });
+    expect(profiles["user-1"].recentDeltas).toEqual([20]);
+    expect(profiles["guest-1"].recentDeltas).toEqual([15]);
+  });
+
+  it("supports user-only games without adding a guest query", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+    (prisma.score.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+
+    expect(prisma.score.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.score.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "user-1" }),
+      })
+    );
+  });
+
+  it("supports guest-only games without adding a user query", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: null, guestId: "guest-1" }],
+    });
+    (prisma.score.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+
+    expect(prisma.score.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.score.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ guestId: "guest-1" }),
+      })
+    );
+  });
+});

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -8,4 +8,5 @@ export {
   getHighestAndLowestScore,
   getCumulativeScore,
   getLongestAndShortestGamesByRounds,
+  getPredictionProfilesForGame,
 } from "./queries/index";

--- a/src/server/queries/index.ts
+++ b/src/server/queries/index.ts
@@ -6,3 +6,9 @@ export {
   getCumulativeScore,
   getLongestAndShortestGamesByRounds,
 } from "./stats";
+export {
+  buildPredictionProfiles,
+  getPredictionProfilesForGame,
+  type PredictionProfile,
+  type PredictionProfilesByPlayer,
+} from "./predictionProfiles";

--- a/src/server/queries/predictionProfiles.ts
+++ b/src/server/queries/predictionProfiles.ts
@@ -4,6 +4,12 @@ import { auth } from "@clerk/nextjs/server";
 import { type Prisma } from "@/generated/prisma/client";
 import prisma from "@/server/db/db";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
+import {
+  type PredictionProfile,
+  type PredictionProfilesByPlayer,
+} from "@/lib/scoring/probability";
+
+export type { PredictionProfile, PredictionProfilesByPlayer };
 
 export const HISTORY_SAMPLE_LIMIT_PER_PLAYER = 120;
 export const RECENT_DELTA_LIMIT = 40;
@@ -14,19 +20,6 @@ export interface PredictionScoreSample {
   totalCardsPlayed: number;
   blitzPileRemaining: number;
 }
-
-export interface PredictionProfile {
-  playerId: string;
-  roundsPlayed: number;
-  meanDelta: number;
-  stdDelta: number;
-  blitzRate: number;
-  meanCardsPlayed: number;
-  meanBlitzPileRemaining: number;
-  recentDeltas: number[];
-}
-
-export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
 
 function mean(values: number[]): number {
   if (values.length === 0) return 0;

--- a/src/server/queries/predictionProfiles.ts
+++ b/src/server/queries/predictionProfiles.ts
@@ -1,0 +1,187 @@
+import "server-only";
+
+import { auth } from "@clerk/nextjs/server";
+import { type Prisma } from "@/generated/prisma/client";
+import prisma from "@/server/db/db";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+
+export const HISTORY_SAMPLE_LIMIT_PER_PLAYER = 120;
+export const RECENT_DELTA_LIMIT = 40;
+
+export interface PredictionScoreSample {
+  userId: string | null;
+  guestId: string | null;
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
+}
+
+export interface PredictionProfile {
+  playerId: string;
+  roundsPlayed: number;
+  meanDelta: number;
+  stdDelta: number;
+  blitzRate: number;
+  meanCardsPlayed: number;
+  meanBlitzPileRemaining: number;
+  recentDeltas: number[];
+}
+
+export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function stddev(values: number[], avg: number): number {
+  if (values.length < 2) return 0;
+  const variance =
+    values.reduce((sum, value) => sum + (value - avg) ** 2, 0) /
+    (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+function getSamplePlayerId(sample: PredictionScoreSample): string | null {
+  return sample.userId ?? sample.guestId ?? null;
+}
+
+export function buildPredictionProfiles(
+  playerIds: string[],
+  samples: PredictionScoreSample[]
+): PredictionProfilesByPlayer {
+  const samplesByPlayer = new Map<string, PredictionScoreSample[]>();
+
+  for (const playerId of playerIds) {
+    samplesByPlayer.set(playerId, []);
+  }
+
+  for (const sample of samples) {
+    const playerId = getSamplePlayerId(sample);
+    if (!playerId || !samplesByPlayer.has(playerId)) continue;
+    samplesByPlayer.get(playerId)?.push(sample);
+  }
+
+  return Object.fromEntries(
+    [...samplesByPlayer.entries()]
+      .filter(([, playerSamples]) => playerSamples.length > 0)
+      .map(([playerId, playerSamples]) => {
+        const deltas = playerSamples.map(calculateRoundScore);
+        const deltaMean = mean(deltas);
+
+        return [
+          playerId,
+          {
+            playerId,
+            roundsPlayed: playerSamples.length,
+            meanDelta: deltaMean,
+            stdDelta: stddev(deltas, deltaMean),
+            blitzRate:
+              playerSamples.filter((sample) => sample.blitzPileRemaining === 0)
+                .length / playerSamples.length,
+            meanCardsPlayed: mean(
+              playerSamples.map((sample) => sample.totalCardsPlayed)
+            ),
+            meanBlitzPileRemaining: mean(
+              playerSamples.map((sample) => sample.blitzPileRemaining)
+            ),
+            recentDeltas: deltas.slice(0, RECENT_DELTA_LIMIT),
+          },
+        ];
+      })
+  );
+}
+
+export async function getPredictionProfilesForGame(
+  gameId: string
+): Promise<PredictionProfilesByPlayer> {
+  const [session, game] = await Promise.all([
+    auth(),
+    prisma.game.findUnique({
+      where: { id: gameId },
+      select: {
+        id: true,
+        organizationId: true,
+        players: {
+          select: {
+            userId: true,
+            guestId: true,
+          },
+        },
+      },
+    }),
+  ]);
+
+  // Forecast history is optional enrichment: return no profiles instead of
+  // throwing so public/spectator game pages can keep rendering safely.
+  if (!session.userId || !session.orgId || !game?.organizationId) {
+    return {};
+  }
+
+  if (game.organizationId !== session.orgId) {
+    return {};
+  }
+
+  const userIds = game.players
+    .map((player) => player.userId)
+    .filter((id): id is string => Boolean(id));
+  const guestIds = game.players
+    .map((player) => player.guestId)
+    .filter((id): id is string => Boolean(id));
+  const playerIds = [...userIds, ...guestIds];
+
+  if (playerIds.length === 0) {
+    return {};
+  }
+
+  const historyScope = {
+    round: {
+      // Deliberately exclude this game; live in-game rounds are supplied by
+      // the scoring UI and will be blended separately by the forecast model.
+      gameId: { not: gameId },
+      game: {
+        organizationId: game.organizationId,
+        isFinished: true,
+      },
+    },
+  };
+
+  const scoreSelect = {
+    userId: true,
+    guestId: true,
+    totalCardsPlayed: true,
+    blitzPileRemaining: true,
+  } as const;
+  const scoreOrder: Prisma.ScoreOrderByWithRelationInput[] = [
+    { createdAt: "desc" },
+    { id: "desc" },
+  ];
+
+  const samplesByPlayer = await Promise.all([
+    ...userIds.map((userId) =>
+      prisma.score.findMany({
+        where: {
+          userId,
+          ...historyScope,
+        },
+        select: scoreSelect,
+        orderBy: scoreOrder,
+        take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+      })
+    ),
+    ...guestIds.map((guestId) =>
+      prisma.score.findMany({
+        where: {
+          guestId,
+          ...historyScope,
+        },
+        select: scoreSelect,
+        orderBy: scoreOrder,
+        take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+      })
+    ),
+  ]);
+
+  const samples = samplesByPlayer.flat();
+
+  return buildPredictionProfiles(playerIds, samples);
+}


### PR DESCRIPTION
## Summary
- Pass permission-gated prediction profiles from the game page into the Race Outlook card for active circle members only
- Blend current-game deltas with capped historical player profiles in the Monte Carlo simulation
- Allow low-confidence early forecasts when usable player history exists
- Label history-backed forecasts and report prior player-score sample counts instead of whole-game round counts

## Stack notes
- Stacked on #266 (`mwickett/race-outlook-current-game`)
- Carries the profile-query commit from #267 until that branch is merged/rebased, because the blending layer depends on the query shape

## Claude review
- Claude reviewed the PR2b diff after implementation
- No blocking issues found
- Addressed its medium findings by using per-player history depth for confidence and rewording the UI from prior rounds to prior player scores
- Added tests for early history forecasts, insufficient history, shallow-history confidence, and history-backed UI copy

## Verification
- `npm run lint`
- `npm test`
- `RESEND_API_KEY=re_dummy npx next build`

---
Integration/testing PR: #270 contains the full stack for end-to-end testing.