### PR TITLE
Model Dutch Blitz mechanics in Race Outlook

### DIFF
--- a/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
+++ b/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
@@ -44,6 +44,22 @@ describe("WinProbabilityCard", () => {
             close: [12, 14, 16, 14, 14],
             far: [4, 8, 6, 6, 6],
           }}
+          roundSamplesByPlayer={{
+            close: [
+              { totalCardsPlayed: 22, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 24, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 26, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 24, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 24, blitzPileRemaining: 5 },
+            ],
+            far: [
+              { totalCardsPlayed: 14, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 18, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 16, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 16, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 16, blitzPileRemaining: 5 },
+            ],
+          }}
           predictionProfiles={{
             close: {
               playerId: "close",
@@ -72,7 +88,9 @@ describe("WinProbabilityCard", () => {
     expect(screen.getByText("Race Outlook")).toBeInTheDocument();
     expect(screen.getByText("Likely ending")).toBeInTheDocument();
     expect(screen.getByText("Next-round danger")).toBeInTheDocument();
-    expect(screen.getByText(/Can close now/)).toBeInTheDocument();
+    expect(screen.getByText("Blitz-out path")).toBeInTheDocument();
+    expect(screen.getByText("20+ pt swing")).toBeInTheDocument();
+    expect(screen.getByText(/Blitz-out threat/)).toBeInTheDocument();
     expect(
       screen.getByText("History-backed from 24 prior player scores")
     ).toBeInTheDocument();

--- a/src/components/scoring/BetweenRoundsView.tsx
+++ b/src/components/scoring/BetweenRoundsView.tsx
@@ -15,7 +15,10 @@ import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { useRoundEditing } from "./useRoundEditing";
 import { findPlayerScore } from "./utils";
 import { type PlayerWithScore, type RoundData } from "./types";
-import { type PredictionProfilesByPlayer } from "@/lib/scoring/probability";
+import {
+  type ForecastRoundSample,
+  type PredictionProfilesByPlayer,
+} from "@/lib/scoring/probability";
 
 interface BetweenRoundsViewProps {
   gameId: string;
@@ -49,13 +52,15 @@ export function BetweenRoundsView({
   };
 
   // Compute derived graph data from rounds
-  const { scoresByRound, deltasByRound } = useMemo(() => {
+  const { scoresByRound, deltasByRound, roundSamplesByPlayer } = useMemo(() => {
     const scores: Record<string, number[]> = {};
     const deltas: Record<string, number[]> = {};
+    const samples: Record<string, ForecastRoundSample[]> = {};
 
     for (const player of players) {
       scores[player.id] = [];
       deltas[player.id] = [];
+      samples[player.id] = [];
       let cumulative = 0;
 
       for (const round of rounds) {
@@ -64,10 +69,20 @@ export function BetweenRoundsView({
         cumulative += delta;
         scores[player.id].push(cumulative);
         deltas[player.id].push(delta);
+        if (s) {
+          samples[player.id].push({
+            totalCardsPlayed: s.totalCardsPlayed,
+            blitzPileRemaining: s.blitzPileRemaining,
+          });
+        }
       }
     }
 
-    return { scoresByRound: scores, deltasByRound: deltas };
+    return {
+      scoresByRound: scores,
+      deltasByRound: deltas,
+      roundSamplesByPlayer: samples,
+    };
   }, [players, rounds]);
 
   return (
@@ -91,6 +106,7 @@ export function BetweenRoundsView({
           winThreshold={winThreshold}
           deltasByPlayer={deltasByRound}
           predictionProfiles={predictionProfiles}
+          roundSamplesByPlayer={roundSamplesByPlayer}
         />
       </GraphCarousel>
 

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -5,6 +5,7 @@ import {
   type ForecastRange,
   type PlayerForecast,
   type RaceForecast,
+  type ForecastRoundSample,
   type PredictionProfilesByPlayer,
 } from "@/lib/scoring/probability";
 
@@ -14,6 +15,7 @@ interface WinProbabilityCardProps {
   winThreshold: number;
   deltasByPlayer?: Record<string, number[]>;
   predictionProfiles?: PredictionProfilesByPlayer;
+  roundSamplesByPlayer?: Record<string, ForecastRoundSample[]>;
 }
 
 export function WinProbabilityCard({
@@ -22,6 +24,7 @@ export function WinProbabilityCard({
   winThreshold,
   deltasByPlayer,
   predictionProfiles,
+  roundSamplesByPlayer,
 }: WinProbabilityCardProps) {
   const forecast = useMemo(
     () =>
@@ -29,9 +32,16 @@ export function WinProbabilityCard({
         players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
         winThreshold,
         deltasByPlayer,
-        { predictionProfiles }
+        { predictionProfiles, roundSamplesByPlayer }
       ),
-    [players, roundsPlayed, winThreshold, deltasByPlayer, predictionProfiles]
+    [
+      players,
+      roundsPlayed,
+      winThreshold,
+      deltasByPlayer,
+      predictionProfiles,
+      roundSamplesByPlayer,
+    ]
   );
 
   const sorted = useMemo(
@@ -61,6 +71,8 @@ export function WinProbabilityCard({
 
   const topPlayerId = sorted[0]?.id;
   const topNextThreat = getTopNextThreat(sorted, forecast);
+  const topBlitzThreat = getTopBlitzThreat(sorted, forecast);
+  const topSwingThreat = getTopSwingThreat(sorted, forecast);
 
   return (
     <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
@@ -120,6 +132,18 @@ export function WinProbabilityCard({
             detail={topNextThreat?.player.name}
             color={topNextThreat?.player.color}
           />
+          <OutlookStat
+            label="Blitz-out path"
+            value={topBlitzThreat ? `${topBlitzThreat.pct}%` : "None"}
+            detail={topBlitzThreat?.player.name}
+            color={topBlitzThreat?.player.color}
+          />
+          <OutlookStat
+            label="20+ pt swing"
+            value={topSwingThreat ? `${topSwingThreat.pct}%` : "Quiet"}
+            detail={topSwingThreat?.player.name}
+            color={topSwingThreat?.player.color}
+          />
         </div>
         {forecast.unresolvedProbability > 0 && (
           <div className="mt-2 text-[12px] md:text-[11px] text-[#8b5e3c]">
@@ -163,8 +187,12 @@ function getPlayerLabel(
   isTopPlayer: boolean
 ): string {
   if (!playerForecast || playerForecast.winProbability === 0) return "Long shot";
+  if (playerForecast.nextRoundBlitzWinProbability >= 10) {
+    return "Blitz-out threat";
+  }
   if (playerForecast.nextRoundWinProbability >= 25) return "Can close now";
   if (playerForecast.nextRoundWinProbability >= 10) return "Next-round threat";
+  if (playerForecast.nextRoundSwingProbability >= 35) return "Swing threat";
   if (isTopPlayer && playerForecast.winProbability >= 45) return "Steady favorite";
   if (playerForecast.winProbability >= 25) return "In the mix";
   if (playerForecast.winProbability >= 10) return "Needs a swing round";
@@ -187,6 +215,11 @@ function getSubtitle(roundsPlayed: number, forecast: RaceForecast): string {
 }
 
 function getModelNote(forecast: RaceForecast): string {
+  if (forecast.usesMechanicsModel) {
+    return forecast.usesHistoricalData
+      ? "models cards, blitz pile & player history"
+      : "models cards, blitz pile & variance";
+  }
   return forecast.usesHistoricalData
     ? "blends pace, variance & player history"
     : "accounts for pace & variance";
@@ -203,6 +236,34 @@ function getTopNextThreat(
   let top: { player: PlayerWithScore; pct: number } | null = null;
   for (const player of players) {
     const pct = forecast.players[player.id]?.nextRoundWinProbability ?? 0;
+    if (pct > (top?.pct ?? 0)) {
+      top = { player, pct };
+    }
+  }
+  return top && top.pct > 0 ? top : null;
+}
+
+function getTopBlitzThreat(
+  players: PlayerWithScore[],
+  forecast: RaceForecast
+): { player: PlayerWithScore; pct: number } | null {
+  let top: { player: PlayerWithScore; pct: number } | null = null;
+  for (const player of players) {
+    const pct = forecast.players[player.id]?.nextRoundBlitzWinProbability ?? 0;
+    if (pct > (top?.pct ?? 0)) {
+      top = { player, pct };
+    }
+  }
+  return top && top.pct > 0 ? top : null;
+}
+
+function getTopSwingThreat(
+  players: PlayerWithScore[],
+  forecast: RaceForecast
+): { player: PlayerWithScore; pct: number } | null {
+  let top: { player: PlayerWithScore; pct: number } | null = null;
+  for (const player of players) {
+    const pct = forecast.players[player.id]?.nextRoundSwingProbability ?? 0;
     if (pct > (top?.pct ?? 0)) {
       top = { player, pct };
     }

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -392,6 +392,112 @@ describe("calcRaceForecast", () => {
     expect(forecast!.gameEndRound?.median).toBe(6);
   });
 
+  it("tracks next-round blitz-out wins and swing potential from score mechanics", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "close", score: 55, roundsPlayed: 3 },
+        { id: "steady", score: 30, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        close: [25, 25, 25],
+        steady: [10, 10, 10],
+      },
+      {
+        roundSamplesByPlayer: {
+          close: [
+            { totalCardsPlayed: 25, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 25, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 25, blitzPileRemaining: 0 },
+          ],
+          steady: [
+            { totalCardsPlayed: 20, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 20, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 20, blitzPileRemaining: 5 },
+          ],
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.usesMechanicsModel).toBe(true);
+    expect(forecast!.players.close.nextRoundWinProbability).toBe(100);
+    expect(forecast!.players.close.nextRoundBlitzWinProbability).toBe(100);
+    expect(forecast!.players.close.nextRoundSwingProbability).toBe(100);
+    expect(forecast!.players.steady.nextRoundSwingProbability).toBe(0);
+  });
+
+  it("conditions mechanics-mode future rounds on at least one blitzer", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "a", score: 70, roundsPlayed: 3 },
+        { id: "b", score: 70, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        a: [5, 5, 5],
+        b: [5, 5, 5],
+      },
+      {
+        roundSamplesByPlayer: {
+          a: [
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+          ],
+          b: [
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+          ],
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.usesMechanicsModel).toBe(true);
+    expect(
+      forecast!.players.a.nextRoundWinProbability +
+        forecast!.players.b.nextRoundWinProbability
+    ).toBe(100);
+    expect(
+      forecast!.players.a.nextRoundBlitzWinProbability +
+        forecast!.players.b.nextRoundBlitzWinProbability
+    ).toBe(100);
+  });
+
+  it("keeps swing probability separate from next-round win probability", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "leader", score: 70, roundsPlayed: 3 },
+        { id: "trailer", score: 10, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        leader: [5, 5, 5],
+        trailer: [30, 30, 30],
+      },
+      {
+        roundSamplesByPlayer: {
+          leader: [
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+          ],
+          trailer: [
+            { totalCardsPlayed: 30, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 30, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 30, blitzPileRemaining: 0 },
+          ],
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.trailer.nextRoundWinProbability).toBe(0);
+    expect(forecast!.players.trailer.nextRoundSwingProbability).toBe(100);
+  });
+
   it("returns player outcomes plus unresolved outcomes that sum to 100", () => {
     const forecast = calcRaceForecast(
       [

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,10 +1,17 @@
+import { GAME_RULES } from "@/lib/validation/gameRules";
+
 const SIMULATION_COUNT = 10_000;
 const MAX_FUTURE_ROUNDS = 50;
 const UNRESOLVED_OUTCOME_ID = "__unresolved";
 const MIN_HISTORICAL_ROUNDS = 5;
 const HISTORY_BLEND_ROUND_CAP = 8;
+const SWING_ROUND_SCORE = 20;
 export const MIN_SIMULATED_ROUND_SCORE = -20;
 export const MAX_SIMULATED_ROUND_SCORE = 40;
+export const MIN_SIMULATED_CARDS_PLAYED = 0;
+export const MAX_SIMULATED_CARDS_PLAYED = GAME_RULES.MAX_CARDS_PLAYED;
+export const MIN_SIMULATED_BLITZ_PILE_REMAINING = 1;
+export const MAX_SIMULATED_BLITZ_PILE_REMAINING = GAME_RULES.MAX_BLITZ_PILE;
 
 // Seeded PRNG (xoshiro128**) for deterministic Monte Carlo results.
 // Ensures identical inputs always produce identical probabilities,
@@ -44,6 +51,20 @@ export function clampRoundScore(score: number): number {
   );
 }
 
+function clampCardsPlayed(cardsPlayed: number): number {
+  return Math.max(
+    MIN_SIMULATED_CARDS_PLAYED,
+    Math.min(MAX_SIMULATED_CARDS_PLAYED, Math.round(cardsPlayed))
+  );
+}
+
+function clampActiveBlitzPile(blitzPileRemaining: number): number {
+  return Math.max(
+    MIN_SIMULATED_BLITZ_PILE_REMAINING,
+    Math.min(MAX_SIMULATED_BLITZ_PILE_REMAINING, Math.round(blitzPileRemaining))
+  );
+}
+
 function mean(values: number[]): number {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
@@ -61,6 +82,27 @@ interface PlayerStats {
   mean: number;
   std: number;
   historicalSampleCount: number;
+  mechanics?: PlayerMechanicsStats;
+}
+
+interface PlayerMechanicsStats {
+  blitzRate: number;
+  meanCardsPlayed: number;
+  stdCardsPlayed: number;
+  meanActiveBlitzPileRemaining: number;
+  stdActiveBlitzPileRemaining: number;
+}
+
+interface RoundOutcome {
+  delta: number;
+  blitzed: boolean;
+  cardsPlayed?: number;
+  blitzPileRemaining?: number;
+}
+
+export interface ForecastRoundSample {
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
 }
 
 export interface PredictionProfile {
@@ -88,6 +130,8 @@ export interface PlayerForecast {
   id: string;
   winProbability: number;
   nextRoundWinProbability: number;
+  nextRoundBlitzWinProbability: number;
+  nextRoundSwingProbability: number;
   winningRound: ForecastRange | null;
 }
 
@@ -99,10 +143,12 @@ export interface RaceForecast {
   simulationCount: number;
   usesHistoricalData: boolean;
   historicalSampleCount: number;
+  usesMechanicsModel: boolean;
 }
 
 interface RaceForecastOptions {
   predictionProfiles?: PredictionProfilesByPlayer;
+  roundSamplesByPlayer?: Record<string, ForecastRoundSample[]>;
 }
 
 function percentile(sortedValues: number[], percentileValue: number): number {
@@ -214,10 +260,101 @@ function blendStd(
   return Math.sqrt(variance);
 }
 
+function calcActiveBlitzPileMean(
+  meanBlitzPileRemaining: number,
+  blitzRate: number
+): number {
+  if (blitzRate >= 0.95) return MIN_SIMULATED_BLITZ_PILE_REMAINING;
+  return clampActiveBlitzPile(meanBlitzPileRemaining / (1 - blitzRate));
+}
+
+function buildCurrentMechanics(
+  samples: ForecastRoundSample[] | undefined
+): PlayerMechanicsStats | undefined {
+  if (!samples || samples.length === 0) return undefined;
+
+  const cardsPlayed = samples.map((sample) => sample.totalCardsPlayed);
+  const activeBlitzPiles = samples
+    .map((sample) => sample.blitzPileRemaining)
+    .filter((pile) => pile > 0);
+  const meanCardsPlayed = mean(cardsPlayed);
+  const meanActiveBlitzPileRemaining =
+    activeBlitzPiles.length > 0
+      ? mean(activeBlitzPiles)
+      : MIN_SIMULATED_BLITZ_PILE_REMAINING;
+
+  return {
+    blitzRate:
+      samples.filter((sample) => sample.blitzPileRemaining === 0).length /
+      samples.length,
+    meanCardsPlayed,
+    stdCardsPlayed: stddev(cardsPlayed, meanCardsPlayed),
+    meanActiveBlitzPileRemaining,
+    stdActiveBlitzPileRemaining: stddev(
+      activeBlitzPiles,
+      meanActiveBlitzPileRemaining
+    ),
+  };
+}
+
+function buildHistoricalMechanics(
+  profile: PredictionProfile | undefined
+): PlayerMechanicsStats | undefined {
+  if (!hasUsableHistory(profile)) return undefined;
+
+  return {
+    blitzRate: profile.blitzRate,
+    meanCardsPlayed: profile.meanCardsPlayed,
+    stdCardsPlayed: Math.max(4, profile.stdDelta * 0.7),
+    meanActiveBlitzPileRemaining: calcActiveBlitzPileMean(
+      profile.meanBlitzPileRemaining,
+      profile.blitzRate
+    ),
+    stdActiveBlitzPileRemaining: Math.max(1.5, profile.stdDelta * 0.2),
+  };
+}
+
+function blendMechanics(
+  current: PlayerMechanicsStats | undefined,
+  historical: PlayerMechanicsStats | undefined,
+  currentWeight: number
+): PlayerMechanicsStats | undefined {
+  if (current && !historical) return current;
+  if (!current && historical) return historical;
+  if (!current || !historical) return undefined;
+
+  return {
+    blitzRate:
+      current.blitzRate * currentWeight +
+      historical.blitzRate * (1 - currentWeight),
+    meanCardsPlayed:
+      current.meanCardsPlayed * currentWeight +
+      historical.meanCardsPlayed * (1 - currentWeight),
+    stdCardsPlayed: blendStd(
+      current.meanCardsPlayed,
+      current.stdCardsPlayed,
+      historical.meanCardsPlayed,
+      historical.stdCardsPlayed,
+      currentWeight
+    ),
+    meanActiveBlitzPileRemaining:
+      current.meanActiveBlitzPileRemaining * currentWeight +
+      historical.meanActiveBlitzPileRemaining * (1 - currentWeight),
+    stdActiveBlitzPileRemaining: blendStd(
+      current.meanActiveBlitzPileRemaining,
+      current.stdActiveBlitzPileRemaining,
+      historical.meanActiveBlitzPileRemaining,
+      historical.stdActiveBlitzPileRemaining,
+      currentWeight
+    ),
+  };
+}
+
 function buildPlayerStats(
   player: { id: string; score: number; roundsPlayed: number },
   deltas: number[] | undefined,
-  profile: PredictionProfile | undefined
+  profile: PredictionProfile | undefined,
+  roundSamples: ForecastRoundSample[] | undefined
 ): PlayerStats {
   const currentDeltas = deltas ?? [];
   const currentMean =
@@ -230,19 +367,25 @@ function buildPlayerStats(
     currentDeltas.length >= 2
       ? stddev(currentDeltas, currentMean)
       : Math.abs(currentMean) * 0.5;
+  const historicalProfile = hasUsableHistory(profile) ? profile : undefined;
+  const currentWeight = historicalProfile
+    ? calcCurrentWeight(currentDeltas.length, historicalProfile.roundsPlayed)
+    : 1;
+  const mechanics = blendMechanics(
+    buildCurrentMechanics(roundSamples),
+    buildHistoricalMechanics(historicalProfile),
+    currentWeight
+  );
 
-  if (hasUsableHistory(profile)) {
-    const currentWeight = calcCurrentWeight(
-      currentDeltas.length,
-      profile.roundsPlayed
-    );
+  if (historicalProfile) {
     const blendedMean =
-      currentMean * currentWeight + profile.meanDelta * (1 - currentWeight);
+      currentMean * currentWeight +
+      historicalProfile.meanDelta * (1 - currentWeight);
     const blendedStd = blendStd(
       currentMean,
       currentStd,
-      profile.meanDelta,
-      profile.stdDelta,
+      historicalProfile.meanDelta,
+      historicalProfile.stdDelta,
       currentWeight
     );
 
@@ -251,7 +394,8 @@ function buildPlayerStats(
       currentScore: player.score,
       mean: blendedMean,
       std: blendedStd,
-      historicalSampleCount: profile.roundsPlayed,
+      historicalSampleCount: historicalProfile.roundsPlayed,
+      mechanics,
     };
   }
 
@@ -262,6 +406,7 @@ function buildPlayerStats(
       mean: currentMean,
       std: currentStd,
       historicalSampleCount: 0,
+      mechanics,
     };
   }
 
@@ -271,6 +416,7 @@ function buildPlayerStats(
     mean: currentMean,
     std: Math.abs(currentMean) * 0.5,
     historicalSampleCount: 0,
+    mechanics,
   };
 }
 
@@ -278,11 +424,13 @@ function buildSeed(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
   deltasByPlayer?: Record<string, number[]>,
-  predictionProfiles?: PredictionProfilesByPlayer
+  predictionProfiles?: PredictionProfilesByPlayer,
+  roundSamplesByPlayer?: Record<string, ForecastRoundSample[]>
 ): number {
   const seedText = players
     .map((p) => {
       const deltas = deltasByPlayer?.[p.id] ?? [];
+      const roundSamples = roundSamplesByPlayer?.[p.id] ?? [];
       const profile = predictionProfiles?.[p.id];
       const profileText = profile
         ? `${profile.roundsPlayed}:${profile.meanDelta.toFixed(
@@ -291,9 +439,12 @@ function buildSeed(
             .slice(0, 10)
             .join(",")}`
         : "";
+      const roundSampleText = roundSamples
+        .map((sample) => `${sample.totalCardsPlayed}/${sample.blitzPileRemaining}`)
+        .join(",");
       return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(
         ","
-      )}:${profileText}`;
+      )}:${roundSampleText}:${profileText}`;
     })
     .sort()
     .join("|");
@@ -303,6 +454,107 @@ function buildSeed(
     seed = Math.imul(seed ^ seedText.charCodeAt(i), 16777619) >>> 0;
   }
   return seed || 1;
+}
+
+function sampleRoundOutcome(
+  stats: PlayerStats,
+  rng: () => number
+): RoundOutcome {
+  if (!stats.mechanics) {
+    return {
+      delta: clampRoundScore(normalSample(stats.mean, stats.std, rng)),
+      blitzed: false,
+    };
+  }
+
+  const blitzed = rng() < stats.mechanics.blitzRate;
+  const cardsPlayed = clampCardsPlayed(
+    normalSample(
+      stats.mechanics.meanCardsPlayed,
+      stats.mechanics.stdCardsPlayed,
+      rng
+    )
+  );
+  const validCardsPlayed = blitzed
+    ? Math.max(cardsPlayed, GAME_RULES.MIN_CARDS_FOR_BLITZ)
+    : cardsPlayed;
+  const blitzPileRemaining = blitzed
+    ? 0
+    : clampActiveBlitzPile(
+        normalSample(
+          stats.mechanics.meanActiveBlitzPileRemaining,
+          stats.mechanics.stdActiveBlitzPileRemaining,
+          rng
+        )
+      );
+
+  return {
+    delta: clampRoundScore(validCardsPlayed - 2 * blitzPileRemaining),
+    blitzed,
+    cardsPlayed: validCardsPlayed,
+    blitzPileRemaining,
+  };
+}
+
+function forceOneBlitzer(
+  stats: PlayerStats[],
+  outcomes: RoundOutcome[],
+  rng: () => number
+): RoundOutcome[] {
+  const candidateIndexes = stats
+    .map((stat, index) => (stat.mechanics ? index : -1))
+    .filter((index) => index >= 0);
+  if (candidateIndexes.length === 0) return outcomes;
+
+  const weights = candidateIndexes.map((index) =>
+    Math.max(stats[index].mechanics?.blitzRate ?? 0, 0.01)
+  );
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+  let pick = rng() * totalWeight;
+  let forcedIndex = candidateIndexes[candidateIndexes.length - 1];
+
+  for (let i = 0; i < candidateIndexes.length; i++) {
+    pick -= weights[i];
+    if (pick <= 0) {
+      forcedIndex = candidateIndexes[i];
+      break;
+    }
+  }
+
+  const cardsPlayed = Math.max(
+    outcomes[forcedIndex].cardsPlayed ?? GAME_RULES.MIN_CARDS_FOR_BLITZ,
+    GAME_RULES.MIN_CARDS_FOR_BLITZ
+  );
+
+  return outcomes.map((outcome, index) =>
+    index === forcedIndex
+      ? {
+          ...outcome,
+          delta: clampRoundScore(cardsPlayed),
+          blitzed: true,
+          cardsPlayed,
+          blitzPileRemaining: 0,
+        }
+      : outcome
+  );
+}
+
+function sampleRoundOutcomes(
+  stats: PlayerStats[],
+  rng: () => number
+): RoundOutcome[] {
+  const hasMechanicsModel = stats.some((stat) => stat.mechanics);
+  const maxAttempts = hasMechanicsModel ? 25 : 1;
+  let outcomes: RoundOutcome[] = [];
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    outcomes = stats.map((stat) => sampleRoundOutcome(stat, rng));
+    if (!hasMechanicsModel || outcomes.some((outcome) => outcome.blitzed)) {
+      return outcomes;
+    }
+  }
+
+  return forceOneBlitzer(stats, outcomes, rng);
 }
 
 /**
@@ -334,7 +586,12 @@ export function calcRaceForecast(
   const orderedPlayers = [...players].sort((a, b) => a.id.localeCompare(b.id));
 
   const stats: PlayerStats[] = orderedPlayers.map((p) =>
-    buildPlayerStats(p, deltasByPlayer?.[p.id], options.predictionProfiles?.[p.id])
+    buildPlayerStats(
+      p,
+      deltasByPlayer?.[p.id],
+      options.predictionProfiles?.[p.id],
+      options.roundSamplesByPlayer?.[p.id]
+    )
   );
   const historicalSampleCount = stats.reduce(
     (sum, stat) => sum + stat.historicalSampleCount,
@@ -346,16 +603,27 @@ export function calcRaceForecast(
     .filter((count) => count > 0);
   const minimumHistoricalDepth =
     historicalDepths.length === stats.length ? Math.min(...historicalDepths) : 0;
+  const usesMechanicsModel = stats.some((stat) => stat.mechanics);
 
   const rng = makeRng(
-    buildSeed(players, winThreshold, deltasByPlayer, options.predictionProfiles)
+    buildSeed(
+      players,
+      winThreshold,
+      deltasByPlayer,
+      options.predictionProfiles,
+      options.roundSamplesByPlayer
+    )
   );
 
   const wins: Record<string, number> = {};
   const nextRoundWins: Record<string, number> = {};
+  const nextRoundBlitzWins: Record<string, number> = {};
+  const nextRoundSwings: Record<string, number> = {};
   const winningRounds: Record<string, number[]> = {};
   for (const p of players) wins[p.id] = 0;
   for (const p of players) nextRoundWins[p.id] = 0;
+  for (const p of players) nextRoundBlitzWins[p.id] = 0;
+  for (const p of players) nextRoundSwings[p.id] = 0;
   for (const p of players) winningRounds[p.id] = [];
   const gameEndRounds: number[] = [];
   let unresolvedCount = 0;
@@ -364,12 +632,15 @@ export function calcRaceForecast(
     const scores = stats.map((s) => s.currentScore);
     let winnerIndexes: number[] = [];
     let winningRound: number | null = null;
+    let winningOutcomes: RoundOutcome[] | null = null;
 
     for (let r = 0; r < MAX_FUTURE_ROUNDS; r++) {
+      const outcomes = sampleRoundOutcomes(stats, rng);
       for (let i = 0; i < stats.length; i++) {
-        scores[i] += clampRoundScore(
-          normalSample(stats[i].mean, stats[i].std, rng)
-        );
+        scores[i] += outcomes[i].delta;
+        if (r === 0 && outcomes[i].delta >= SWING_ROUND_SCORE) {
+          nextRoundSwings[stats[i].id]++;
+        }
       }
       // Check if any player crossed the threshold this round
       let bestScore = -Infinity;
@@ -387,6 +658,7 @@ export function calcRaceForecast(
       if (crossingIndexes.length > 0) {
         winnerIndexes = crossingIndexes;
         winningRound = roundsPlayed + r + 1;
+        winningOutcomes = outcomes;
         break;
       }
     }
@@ -400,6 +672,9 @@ export function calcRaceForecast(
         winningRounds[winnerId].push(winningRound);
         if (winningRound === roundsPlayed + 1) {
           nextRoundWins[winnerId] += splitWeight;
+          if (winningOutcomes?.[winnerIndex].blitzed) {
+            nextRoundBlitzWins[winnerId] += splitWeight;
+          }
         }
       }
 
@@ -428,6 +703,14 @@ export function calcRaceForecast(
         toPercent(nextRoundWins[p.id], SIMULATION_COUNT),
         winProbability
       ),
+      nextRoundBlitzWinProbability: Math.min(
+        toPercent(nextRoundBlitzWins[p.id], SIMULATION_COUNT),
+        winProbability
+      ),
+      nextRoundSwingProbability: toPercent(
+        nextRoundSwings[p.id],
+        SIMULATION_COUNT
+      ),
       winningRound: buildRange(winningRounds[p.id]),
     };
   }
@@ -444,6 +727,7 @@ export function calcRaceForecast(
     simulationCount: SIMULATION_COUNT,
     usesHistoricalData,
     historicalSampleCount,
+    usesMechanicsModel,
   };
 }
 


### PR DESCRIPTION
## Summary
- Derive per-player cards-played and blitz-pile samples from actual round data
- Use mechanics-aware sampling in the Monte Carlo forecast when cards/blitz data is available
- Add next-round blitz-out win probability and 20+ point swing probability
- Surface `Blitz-out path` and `20+ pt swing` readouts in Race Outlook

## Stack notes
- Stacked on #268 (`mwickett/history-blended-race-outlook`)
- This is the Dutch Blitz mechanics layer after the current-game Race Outlook and historical profile blend

## Claude review
- Claude reviewed the PR3 diff and found no blocking issues
- Addressed its major fidelity finding by enforcing the existing `GAME_RULES.MIN_CARDS_FOR_BLITZ` minimum whenever a simulated round is a blitz
- Added a regression test showing swing probability is intentionally independent from next-round win probability

## Verification
- `npm run lint`
- `npm test`
- `RESEND_API_KEY=re_dummy npx next build`

---
Integration/testing PR: #270 contains the full stack for end-to-end testing.