### PR TITLE
Integration: Race Outlook prediction stack

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { ScoringShell } from "@/components/scoring/ScoringShell";
-import { getGameById } from "@/server/queries";
+import { getGameById, getPredictionProfilesForGame } from "@/server/queries";
 import { notFound } from "next/navigation";
 import transformGameData, { GameWithPlayersAndScores } from "@/lib/gameLogic";
 import {
@@ -67,6 +67,9 @@ export default async function GameView(props: {
   // read-only spectator view of the same scoring UI.
   const isCircleMember =
     !!userId && !!game.organizationId && game.organizationId === orgId;
+  const predictionProfiles = isCircleMember
+    ? await getPredictionProfilesForGame(params.id)
+    : {};
 
   return (
     <section className="py-6">
@@ -84,6 +87,7 @@ export default async function GameView(props: {
         winnerId={displayScores.find((s) => s.isWinner)?.id}
         endedAt={game.endedAt?.toISOString()}
         canEdit={isCircleMember}
+        predictionProfiles={predictionProfiles}
         rounds={game.rounds.map((r) => ({
           id: r.id,
           scores: r.scores.map((s) => ({

--- a/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
+++ b/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
@@ -44,6 +44,22 @@ describe("WinProbabilityCard", () => {
             close: [12, 14, 16, 14, 14],
             far: [4, 8, 6, 6, 6],
           }}
+          roundSamplesByPlayer={{
+            close: [
+              { totalCardsPlayed: 22, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 24, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 26, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 24, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 24, blitzPileRemaining: 5 },
+            ],
+            far: [
+              { totalCardsPlayed: 14, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 18, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 16, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 16, blitzPileRemaining: 5 },
+              { totalCardsPlayed: 16, blitzPileRemaining: 5 },
+            ],
+          }}
           predictionProfiles={{
             close: {
               playerId: "close",
@@ -72,7 +88,9 @@ describe("WinProbabilityCard", () => {
     expect(screen.getByText("Race Outlook")).toBeInTheDocument();
     expect(screen.getByText("Likely ending")).toBeInTheDocument();
     expect(screen.getByText("Next-round danger")).toBeInTheDocument();
-    expect(screen.getByText(/Can close now/)).toBeInTheDocument();
+    expect(screen.getByText("Blitz-out path")).toBeInTheDocument();
+    expect(screen.getByText("20+ pt swing")).toBeInTheDocument();
+    expect(screen.getByText(/Blitz-out threat/)).toBeInTheDocument();
     expect(
       screen.getByText("History-backed from 24 prior player scores")
     ).toBeInTheDocument();

--- a/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
+++ b/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
@@ -40,17 +40,42 @@ describe("WinProbabilityCard", () => {
         players={players}
         roundsPlayed={5}
         winThreshold={75}
-        deltasByPlayer={{
-          close: [12, 14, 16, 14, 14],
-          far: [4, 8, 6, 6, 6],
-        }}
-      />
-    );
+          deltasByPlayer={{
+            close: [12, 14, 16, 14, 14],
+            far: [4, 8, 6, 6, 6],
+          }}
+          predictionProfiles={{
+            close: {
+              playerId: "close",
+              roundsPlayed: 12,
+              meanDelta: 14,
+              stdDelta: 2,
+              blitzRate: 0.5,
+              meanCardsPlayed: 24,
+              meanBlitzPileRemaining: 5,
+              recentDeltas: [12, 14, 16],
+            },
+            far: {
+              playerId: "far",
+              roundsPlayed: 12,
+              meanDelta: 6,
+              stdDelta: 2,
+              blitzRate: 0.2,
+              meanCardsPlayed: 18,
+              meanBlitzPileRemaining: 6,
+              recentDeltas: [4, 8, 6],
+            },
+          }}
+        />
+      );
 
     expect(screen.getByText("Race Outlook")).toBeInTheDocument();
     expect(screen.getByText("Likely ending")).toBeInTheDocument();
     expect(screen.getByText("Next-round danger")).toBeInTheDocument();
     expect(screen.getByText(/Can close now/)).toBeInTheDocument();
+    expect(
+      screen.getByText("History-backed from 24 prior player scores")
+    ).toBeInTheDocument();
     expect(screen.queryByText("Projected finish")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
+++ b/src/components/__tests__/scoring/WinProbabilityCard.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { WinProbabilityCard } from "../../scoring/graphs/WinProbabilityCard";
+import { type PlayerWithScore } from "../../scoring/types";
+
+const players: PlayerWithScore[] = [
+  {
+    id: "close",
+    name: "Alice",
+    color: "#ff0000",
+    isGuest: false,
+    userId: "close",
+    score: 70,
+  },
+  {
+    id: "far",
+    name: "Bob",
+    color: "#0000ff",
+    isGuest: false,
+    userId: "far",
+    score: 30,
+  },
+];
+
+describe("WinProbabilityCard", () => {
+  it("shows an unavailable state before enough current-game rounds", () => {
+    render(
+      <WinProbabilityCard
+        players={players}
+        roundsPlayed={2}
+        winThreshold={75}
+      />
+    );
+
+    expect(screen.getByText("Available after 3 rounds")).toBeInTheDocument();
+  });
+
+  it("renders the race outlook instead of the old projected finish section", () => {
+    render(
+      <WinProbabilityCard
+        players={players}
+        roundsPlayed={5}
+        winThreshold={75}
+        deltasByPlayer={{
+          close: [12, 14, 16, 14, 14],
+          far: [4, 8, 6, 6, 6],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Race Outlook")).toBeInTheDocument();
+    expect(screen.getByText("Likely ending")).toBeInTheDocument();
+    expect(screen.getByText("Next-round danger")).toBeInTheDocument();
+    expect(screen.getByText(/Can close now/)).toBeInTheDocument();
+    expect(screen.queryByText("Projected finish")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/scoring/BetweenRoundsView.tsx
+++ b/src/components/scoring/BetweenRoundsView.tsx
@@ -15,7 +15,10 @@ import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { useRoundEditing } from "./useRoundEditing";
 import { findPlayerScore } from "./utils";
 import { type PlayerWithScore, type RoundData } from "./types";
-import { type PredictionProfilesByPlayer } from "@/lib/scoring/probability";
+import {
+  type ForecastRoundSample,
+  type PredictionProfilesByPlayer,
+} from "@/lib/scoring/probability";
 
 interface BetweenRoundsViewProps {
   gameId: string;
@@ -49,13 +52,15 @@ export function BetweenRoundsView({
   };
 
   // Compute derived graph data from rounds
-  const { scoresByRound, deltasByRound } = useMemo(() => {
+  const { scoresByRound, deltasByRound, roundSamplesByPlayer } = useMemo(() => {
     const scores: Record<string, number[]> = {};
     const deltas: Record<string, number[]> = {};
+    const samples: Record<string, ForecastRoundSample[]> = {};
 
     for (const player of players) {
       scores[player.id] = [];
       deltas[player.id] = [];
+      samples[player.id] = [];
       let cumulative = 0;
 
       for (const round of rounds) {
@@ -64,10 +69,20 @@ export function BetweenRoundsView({
         cumulative += delta;
         scores[player.id].push(cumulative);
         deltas[player.id].push(delta);
+        if (s) {
+          samples[player.id].push({
+            totalCardsPlayed: s.totalCardsPlayed,
+            blitzPileRemaining: s.blitzPileRemaining,
+          });
+        }
       }
     }
 
-    return { scoresByRound: scores, deltasByRound: deltas };
+    return {
+      scoresByRound: scores,
+      deltasByRound: deltas,
+      roundSamplesByPlayer: samples,
+    };
   }, [players, rounds]);
 
   return (
@@ -91,6 +106,7 @@ export function BetweenRoundsView({
           winThreshold={winThreshold}
           deltasByPlayer={deltasByRound}
           predictionProfiles={predictionProfiles}
+          roundSamplesByPlayer={roundSamplesByPlayer}
         />
       </GraphCarousel>
 

--- a/src/components/scoring/BetweenRoundsView.tsx
+++ b/src/components/scoring/BetweenRoundsView.tsx
@@ -15,6 +15,7 @@ import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { useRoundEditing } from "./useRoundEditing";
 import { findPlayerScore } from "./utils";
 import { type PlayerWithScore, type RoundData } from "./types";
+import { type PredictionProfilesByPlayer } from "@/lib/scoring/probability";
 
 interface BetweenRoundsViewProps {
   gameId: string;
@@ -25,6 +26,7 @@ interface BetweenRoundsViewProps {
   onEnterScores: () => void;
   /** When false, render as a read-only spectator view (no entry/edit actions) */
   canEdit?: boolean;
+  predictionProfiles?: PredictionProfilesByPlayer;
 }
 
 export function BetweenRoundsView({
@@ -35,6 +37,7 @@ export function BetweenRoundsView({
   nextRoundNumber,
   onEnterScores,
   canEdit = true,
+  predictionProfiles,
 }: BetweenRoundsViewProps) {
   const posthog = usePostHog();
   const { editingRoundIndex, editError, handleEditRound, handleSaveEdit, cancelEdit } =
@@ -87,6 +90,7 @@ export function BetweenRoundsView({
           roundsPlayed={rounds.length}
           winThreshold={winThreshold}
           deltasByPlayer={deltasByRound}
+          predictionProfiles={predictionProfiles}
         />
       </GraphCarousel>
 

--- a/src/components/scoring/ScoringShell.tsx
+++ b/src/components/scoring/ScoringShell.tsx
@@ -12,6 +12,7 @@ import { findPlayerScore } from "./utils";
 import { useRoundEditing } from "./useRoundEditing";
 import { type PlayerWithScore, type RoundData, type RoundScoreData } from "./types";
 import { calcGameStats, type RoundResult } from "@/lib/scoring/gameStats";
+import { type PredictionProfilesByPlayer } from "@/lib/scoring/probability";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
 import { cloneGame } from "@/server/mutations/games";
 
@@ -26,6 +27,7 @@ interface ScoringShellProps {
   winnerId?: string;
   endedAt?: string;
   rounds: RoundData[];
+  predictionProfiles?: PredictionProfilesByPlayer;
   /**
    * When false, render as a read-only spectator view — for people viewing a
    * game outside their circle, or via a public shared link. No score entry,
@@ -43,6 +45,7 @@ export function ScoringShell({
   winnerId,
   endedAt,
   rounds,
+  predictionProfiles,
   canEdit = true,
 }: ScoringShellProps) {
   const router = useRouter();
@@ -226,6 +229,7 @@ export function ScoringShell({
         nextRoundNumber={optimisticRound ? currentRoundNumber + 1 : currentRoundNumber}
         onEnterScores={() => setShowEntry(true)}
         canEdit={canEdit}
+        predictionProfiles={predictionProfiles}
       />
     );
   }

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import { type PlayerWithScore } from "../types";
 import {
-  calcWinProbabilities,
-  calcProjectedFinishRound,
+  calcRaceForecast,
+  type ForecastRange,
+  type PlayerForecast,
+  type RaceForecast,
 } from "@/lib/scoring/probability";
 
 interface WinProbabilityCardProps {
@@ -18,9 +20,9 @@ export function WinProbabilityCard({
   winThreshold,
   deltasByPlayer,
 }: WinProbabilityCardProps) {
-  const probabilities = useMemo(
+  const forecast = useMemo(
     () =>
-      calcWinProbabilities(
+      calcRaceForecast(
         players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
         winThreshold,
         deltasByPlayer
@@ -30,16 +32,17 @@ export function WinProbabilityCard({
 
   const sorted = useMemo(
     () =>
-      probabilities
+      forecast
         ? [...players].sort(
             (a, b) =>
-              (probabilities[b.id] ?? 0) - (probabilities[a.id] ?? 0)
+              (forecast.players[b.id]?.winProbability ?? 0) -
+              (forecast.players[a.id]?.winProbability ?? 0)
           )
         : players,
-    [players, probabilities]
+    [players, forecast]
   );
 
-  if (!probabilities) {
+  if (!forecast) {
     return (
       <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
         <div className="text-base md:text-sm font-bold text-[#290806] mb-0.5">
@@ -52,78 +55,164 @@ export function WinProbabilityCard({
     );
   }
 
+  const topPlayerId = sorted[0]?.id;
+  const topNextThreat = getTopNextThreat(sorted, forecast);
+
   return (
     <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
       <div className="text-base md:text-sm font-bold text-[#290806] mb-0.5">
         Win Probability
       </div>
       <div className="text-[13px] md:text-xs text-[#8b5e3c] mb-3">
-        Simulated over {roundsPlayed} rounds of data
+        {getSubtitle(roundsPlayed, forecast)}
       </div>
 
       <div className="space-y-2">
         {sorted.map((player) => {
-          const pct = probabilities[player.id] ?? 0;
+          const playerForecast = forecast.players[player.id];
+          const pct = playerForecast?.winProbability ?? 0;
           return (
-            <div key={player.id} className="flex items-center gap-2">
-              <div
-                className="w-14 md:w-10 text-[13px] md:text-[11px] font-semibold text-right flex-shrink-0 truncate leading-tight"
-                style={{ color: player.color }}
-              >
-                {player.name}
-              </div>
-              <div className="flex-1 h-7 md:h-6 bg-[#f0e6d2] rounded-full overflow-hidden">
+            <div key={player.id} className="space-y-1">
+              <div className="flex items-center gap-2">
                 <div
-                  className="h-full rounded-full flex items-center justify-end pr-2 text-[13px] md:text-[11px] font-bold text-white min-w-[34px] md:min-w-[28px] tabular-nums"
-                  style={{
-                    width: `${Math.max(pct, 8)}%`,
-                    backgroundColor: player.color,
-                  }}
+                  className="w-14 md:w-10 text-[13px] md:text-[11px] font-semibold text-right flex-shrink-0 truncate leading-tight"
+                  style={{ color: player.color }}
                 >
-                  {pct}%
+                  {player.name}
                 </div>
+                <div className="flex-1 h-7 md:h-6 bg-[#f0e6d2] rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full flex items-center justify-end pr-2 text-[13px] md:text-[11px] font-bold text-white min-w-[34px] md:min-w-[28px] tabular-nums"
+                    style={{
+                      width: `${Math.max(pct, 8)}%`,
+                      backgroundColor: player.color,
+                    }}
+                  >
+                    {pct}%
+                  </div>
+                </div>
+              </div>
+              <div className="ml-16 md:ml-12 text-[12px] md:text-[11px] text-[#8b5e3c] truncate">
+                {getPlayerLabel(playerForecast, player.id === topPlayerId)} ·{" "}
+                {getWinningRoundText(playerForecast)}
               </div>
             </div>
           );
         })}
       </div>
 
-      {/* Projected finish */}
       <div className="mt-3 pt-3 border-t border-[#f0e6d2]">
         <div className="text-xs md:text-[11px] font-semibold text-[#8b5e3c] mb-2">
-          Projected finish
+          Race Outlook
         </div>
-        <div className="flex flex-wrap gap-x-4 gap-y-2 md:gap-3">
-          {sorted
-            .filter((p) => (probabilities[p.id] ?? 0) > 0)
-            .map((player) => {
-              const round = calcProjectedFinishRound(
-                player.score,
-                roundsPlayed,
-                winThreshold
-              );
-              return (
-                <div key={player.id} className="text-center">
-                  <div
-                    className="text-xl md:text-lg font-extrabold"
-                    style={{ color: player.color }}
-                  >
-                    ~R{round === Infinity ? "∞" : round}
-                  </div>
-                  <div
-                    className="text-[13px] md:text-[11px] text-[#8b5e3c] max-w-16 truncate"
-                  >
-                    {player.name}
-                  </div>
-                </div>
-              );
-            })}
+        <div className="grid grid-cols-2 gap-2">
+          <OutlookStat
+            label="Likely ending"
+            value={formatRoundRange(forecast.gameEndRound) ?? "Wide open"}
+          />
+          <OutlookStat
+            label="Next-round danger"
+            value={topNextThreat ? `${topNextThreat.pct}%` : "None"}
+            detail={topNextThreat?.player.name}
+            color={topNextThreat?.player.color}
+          />
         </div>
+        {forecast.unresolvedProbability > 0 && (
+          <div className="mt-2 text-[12px] md:text-[11px] text-[#8b5e3c]">
+            {forecast.unresolvedProbability}% still open after the forecast window
+          </div>
+        )}
       </div>
 
       <div className="text-xs md:text-[11px] text-[#8b5e3c] text-center mt-2 italic">
         Monte Carlo simulation · accounts for pace &amp; variance
       </div>
+    </div>
+  );
+}
+
+function formatRoundRange(range: ForecastRange | null): string | null {
+  if (!range) return null;
+  if (range.p25 === range.p75) return `R${range.median}`;
+  return `R${range.p25}-R${range.p75}`;
+}
+
+function getWinningRoundText(playerForecast?: PlayerForecast): string {
+  if (
+    playerForecast &&
+    playerForecast.winProbability === 0 &&
+    playerForecast.winningRound
+  ) {
+    return "tail path under 1%";
+  }
+  const roundText = formatRoundRange(playerForecast?.winningRound ?? null);
+  return roundText ? `wins around ${roundText}` : "needs a long path";
+}
+
+function getPlayerLabel(
+  playerForecast: PlayerForecast | undefined,
+  isTopPlayer: boolean
+): string {
+  if (!playerForecast || playerForecast.winProbability === 0) return "Long shot";
+  if (playerForecast.nextRoundWinProbability >= 25) return "Can close now";
+  if (playerForecast.nextRoundWinProbability >= 10) return "Next-round threat";
+  if (isTopPlayer && playerForecast.winProbability >= 45) return "Steady favorite";
+  if (playerForecast.winProbability >= 25) return "In the mix";
+  if (playerForecast.winProbability >= 10) return "Needs a swing round";
+  return "Chaos path";
+}
+
+function getSubtitle(roundsPlayed: number, forecast: RaceForecast): string {
+  const confidence =
+    forecast.confidence === "high"
+      ? "high confidence"
+      : forecast.confidence === "medium"
+        ? "medium confidence"
+        : "low confidence";
+  return `Simulated from ${roundsPlayed} rounds tonight · ${confidence}`;
+}
+
+function getTopNextThreat(
+  players: PlayerWithScore[],
+  forecast: RaceForecast
+): { player: PlayerWithScore; pct: number } | null {
+  let top: { player: PlayerWithScore; pct: number } | null = null;
+  for (const player of players) {
+    const pct = forecast.players[player.id]?.nextRoundWinProbability ?? 0;
+    if (pct > (top?.pct ?? 0)) {
+      top = { player, pct };
+    }
+  }
+  return top && top.pct > 0 ? top : null;
+}
+
+function OutlookStat({
+  label,
+  value,
+  detail,
+  color,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  color?: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[12px] md:text-[11px] text-[#8b5e3c] truncate">
+        {label}
+      </div>
+      <div
+        className="text-lg md:text-base font-extrabold tabular-nums truncate"
+        style={{ color: color ?? "#290806" }}
+      >
+        {value}
+      </div>
+      {detail && (
+        <div className="text-[12px] md:text-[11px] text-[#8b5e3c] truncate">
+          {detail}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -5,6 +5,7 @@ import {
   type ForecastRange,
   type PlayerForecast,
   type RaceForecast,
+  type PredictionProfilesByPlayer,
 } from "@/lib/scoring/probability";
 
 interface WinProbabilityCardProps {
@@ -12,6 +13,7 @@ interface WinProbabilityCardProps {
   roundsPlayed: number;
   winThreshold: number;
   deltasByPlayer?: Record<string, number[]>;
+  predictionProfiles?: PredictionProfilesByPlayer;
 }
 
 export function WinProbabilityCard({
@@ -19,15 +21,17 @@ export function WinProbabilityCard({
   roundsPlayed,
   winThreshold,
   deltasByPlayer,
+  predictionProfiles,
 }: WinProbabilityCardProps) {
   const forecast = useMemo(
     () =>
       calcRaceForecast(
         players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
         winThreshold,
-        deltasByPlayer
+        deltasByPlayer,
+        { predictionProfiles }
       ),
-    [players, roundsPlayed, winThreshold, deltasByPlayer]
+    [players, roundsPlayed, winThreshold, deltasByPlayer, predictionProfiles]
   );
 
   const sorted = useMemo(
@@ -122,10 +126,15 @@ export function WinProbabilityCard({
             {forecast.unresolvedProbability}% still open after the forecast window
           </div>
         )}
+        {forecast.usesHistoricalData && (
+          <div className="mt-2 text-[12px] md:text-[11px] text-[#8b5e3c]">
+            History-backed from {forecast.historicalSampleCount} prior player scores
+          </div>
+        )}
       </div>
 
       <div className="text-xs md:text-[11px] text-[#8b5e3c] text-center mt-2 italic">
-        Monte Carlo simulation · accounts for pace &amp; variance
+        Monte Carlo simulation · {getModelNote(forecast)}
       </div>
     </div>
   );
@@ -169,7 +178,22 @@ function getSubtitle(roundsPlayed: number, forecast: RaceForecast): string {
       : forecast.confidence === "medium"
         ? "medium confidence"
         : "low confidence";
-  return `Simulated from ${roundsPlayed} rounds tonight · ${confidence}`;
+  const source = forecast.usesHistoricalData
+    ? roundsPlayed > 0
+      ? `${formatRoundCount(roundsPlayed)} tonight + history`
+      : "player history"
+    : `${formatRoundCount(roundsPlayed)} tonight`;
+  return `Simulated from ${source} · ${confidence}`;
+}
+
+function getModelNote(forecast: RaceForecast): string {
+  return forecast.usesHistoricalData
+    ? "blends pace, variance & player history"
+    : "accounts for pace & variance";
+}
+
+function formatRoundCount(roundsPlayed: number): string {
+  return `${roundsPlayed} ${roundsPlayed === 1 ? "round" : "rounds"}`;
 }
 
 function getTopNextThreat(

--- a/src/components/scoring/graphs/WinProbabilityCard.tsx
+++ b/src/components/scoring/graphs/WinProbabilityCard.tsx
@@ -5,6 +5,7 @@ import {
   type ForecastRange,
   type PlayerForecast,
   type RaceForecast,
+  type ForecastRoundSample,
   type PredictionProfilesByPlayer,
 } from "@/lib/scoring/probability";
 
@@ -14,6 +15,7 @@ interface WinProbabilityCardProps {
   winThreshold: number;
   deltasByPlayer?: Record<string, number[]>;
   predictionProfiles?: PredictionProfilesByPlayer;
+  roundSamplesByPlayer?: Record<string, ForecastRoundSample[]>;
 }
 
 export function WinProbabilityCard({
@@ -22,6 +24,7 @@ export function WinProbabilityCard({
   winThreshold,
   deltasByPlayer,
   predictionProfiles,
+  roundSamplesByPlayer,
 }: WinProbabilityCardProps) {
   const forecast = useMemo(
     () =>
@@ -29,9 +32,16 @@ export function WinProbabilityCard({
         players.map((p) => ({ id: p.id, score: p.score, roundsPlayed })),
         winThreshold,
         deltasByPlayer,
-        { predictionProfiles }
+        { predictionProfiles, roundSamplesByPlayer }
       ),
-    [players, roundsPlayed, winThreshold, deltasByPlayer, predictionProfiles]
+    [
+      players,
+      roundsPlayed,
+      winThreshold,
+      deltasByPlayer,
+      predictionProfiles,
+      roundSamplesByPlayer,
+    ]
   );
 
   const sorted = useMemo(
@@ -61,6 +71,8 @@ export function WinProbabilityCard({
 
   const topPlayerId = sorted[0]?.id;
   const topNextThreat = getTopNextThreat(sorted, forecast);
+  const topBlitzThreat = getTopBlitzThreat(sorted, forecast);
+  const topSwingThreat = getTopSwingThreat(sorted, forecast);
 
   return (
     <div className="bg-white border-[1.5px] border-[#e6d7c3] rounded-xl p-4">
@@ -120,6 +132,18 @@ export function WinProbabilityCard({
             detail={topNextThreat?.player.name}
             color={topNextThreat?.player.color}
           />
+          <OutlookStat
+            label="Blitz-out path"
+            value={topBlitzThreat ? `${topBlitzThreat.pct}%` : "None"}
+            detail={topBlitzThreat?.player.name}
+            color={topBlitzThreat?.player.color}
+          />
+          <OutlookStat
+            label="20+ pt swing"
+            value={topSwingThreat ? `${topSwingThreat.pct}%` : "Quiet"}
+            detail={topSwingThreat?.player.name}
+            color={topSwingThreat?.player.color}
+          />
         </div>
         {forecast.unresolvedProbability > 0 && (
           <div className="mt-2 text-[12px] md:text-[11px] text-[#8b5e3c]">
@@ -163,8 +187,12 @@ function getPlayerLabel(
   isTopPlayer: boolean
 ): string {
   if (!playerForecast || playerForecast.winProbability === 0) return "Long shot";
+  if (playerForecast.nextRoundBlitzWinProbability >= 10) {
+    return "Blitz-out threat";
+  }
   if (playerForecast.nextRoundWinProbability >= 25) return "Can close now";
   if (playerForecast.nextRoundWinProbability >= 10) return "Next-round threat";
+  if (playerForecast.nextRoundSwingProbability >= 35) return "Swing threat";
   if (isTopPlayer && playerForecast.winProbability >= 45) return "Steady favorite";
   if (playerForecast.winProbability >= 25) return "In the mix";
   if (playerForecast.winProbability >= 10) return "Needs a swing round";
@@ -187,6 +215,11 @@ function getSubtitle(roundsPlayed: number, forecast: RaceForecast): string {
 }
 
 function getModelNote(forecast: RaceForecast): string {
+  if (forecast.usesMechanicsModel) {
+    return forecast.usesHistoricalData
+      ? "models cards, blitz pile & player history"
+      : "models cards, blitz pile & variance";
+  }
   return forecast.usesHistoricalData
     ? "blends pace, variance & player history"
     : "accounts for pace & variance";
@@ -203,6 +236,34 @@ function getTopNextThreat(
   let top: { player: PlayerWithScore; pct: number } | null = null;
   for (const player of players) {
     const pct = forecast.players[player.id]?.nextRoundWinProbability ?? 0;
+    if (pct > (top?.pct ?? 0)) {
+      top = { player, pct };
+    }
+  }
+  return top && top.pct > 0 ? top : null;
+}
+
+function getTopBlitzThreat(
+  players: PlayerWithScore[],
+  forecast: RaceForecast
+): { player: PlayerWithScore; pct: number } | null {
+  let top: { player: PlayerWithScore; pct: number } | null = null;
+  for (const player of players) {
+    const pct = forecast.players[player.id]?.nextRoundBlitzWinProbability ?? 0;
+    if (pct > (top?.pct ?? 0)) {
+      top = { player, pct };
+    }
+  }
+  return top && top.pct > 0 ? top : null;
+}
+
+function getTopSwingThreat(
+  players: PlayerWithScore[],
+  forecast: RaceForecast
+): { player: PlayerWithScore; pct: number } | null {
+  let top: { player: PlayerWithScore; pct: number } | null = null;
+  for (const player of players) {
+    const pct = forecast.players[player.id]?.nextRoundSwingProbability ?? 0;
     if (pct > (top?.pct ?? 0)) {
       top = { player, pct };
     }

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -340,6 +340,73 @@ describe("calcRaceForecast", () => {
     expect(forecast!.gameEndRound?.median).toBe(6);
   });
 
+  it("tracks next-round blitz-out wins and swing potential from score mechanics", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "close", score: 55, roundsPlayed: 3 },
+        { id: "steady", score: 30, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        close: [25, 25, 25],
+        steady: [10, 10, 10],
+      },
+      {
+        roundSamplesByPlayer: {
+          close: [
+            { totalCardsPlayed: 25, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 25, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 25, blitzPileRemaining: 0 },
+          ],
+          steady: [
+            { totalCardsPlayed: 20, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 20, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 20, blitzPileRemaining: 5 },
+          ],
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.usesMechanicsModel).toBe(true);
+    expect(forecast!.players.close.nextRoundWinProbability).toBe(100);
+    expect(forecast!.players.close.nextRoundBlitzWinProbability).toBe(100);
+    expect(forecast!.players.close.nextRoundSwingProbability).toBe(100);
+    expect(forecast!.players.steady.nextRoundSwingProbability).toBe(0);
+  });
+
+  it("keeps swing probability separate from next-round win probability", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "leader", score: 70, roundsPlayed: 3 },
+        { id: "trailer", score: 10, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        leader: [5, 5, 5],
+        trailer: [30, 30, 30],
+      },
+      {
+        roundSamplesByPlayer: {
+          leader: [
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+          ],
+          trailer: [
+            { totalCardsPlayed: 30, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 30, blitzPileRemaining: 0 },
+            { totalCardsPlayed: 30, blitzPileRemaining: 0 },
+          ],
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.trailer.nextRoundWinProbability).toBe(0);
+    expect(forecast!.players.trailer.nextRoundSwingProbability).toBe(100);
+  });
+
   it("returns player outcomes plus unresolved outcomes that sum to 100", () => {
     const forecast = calcRaceForecast(
       [

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -183,6 +183,121 @@ describe("calcRaceForecast", () => {
     ).toBeNull();
   });
 
+  it("can use historical profiles for an early low-confidence forecast", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "fast", score: 10, roundsPlayed: 1 },
+        { id: "steady", score: 10, roundsPlayed: 1 },
+      ],
+      75,
+      {
+        fast: [10],
+        steady: [10],
+      },
+      {
+        predictionProfiles: {
+          fast: {
+            playerId: "fast",
+            roundsPlayed: 20,
+            meanDelta: 18,
+            stdDelta: 4,
+            blitzRate: 0.6,
+            meanCardsPlayed: 24,
+            meanBlitzPileRemaining: 3,
+            recentDeltas: [20, 18, 16],
+          },
+          steady: {
+            playerId: "steady",
+            roundsPlayed: 20,
+            meanDelta: 8,
+            stdDelta: 3,
+            blitzRate: 0.2,
+            meanCardsPlayed: 18,
+            meanBlitzPileRemaining: 5,
+            recentDeltas: [8, 9, 7],
+          },
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.usesHistoricalData).toBe(true);
+    expect(forecast!.historicalSampleCount).toBe(40);
+    expect(forecast!.confidence).toBe("low");
+    expect(forecast!.players.fast.winProbability).toBeGreaterThan(
+      forecast!.players.steady.winProbability
+    );
+  });
+
+  it("ignores profiles without enough history for an early forecast", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "fast", score: 10, roundsPlayed: 1 },
+        { id: "steady", score: 10, roundsPlayed: 1 },
+      ],
+      75,
+      {
+        fast: [10],
+        steady: [10],
+      },
+      {
+        predictionProfiles: {
+          fast: {
+            playerId: "fast",
+            roundsPlayed: 4,
+            meanDelta: 18,
+            stdDelta: 4,
+            blitzRate: 0.6,
+            meanCardsPlayed: 24,
+            meanBlitzPileRemaining: 3,
+            recentDeltas: [20, 18, 16],
+          },
+        },
+      }
+    );
+
+    expect(forecast).toBeNull();
+  });
+
+  it("does not mark shallow per-player history as high confidence", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "a", score: 50, roundsPlayed: 5 },
+        { id: "b", score: 45, roundsPlayed: 5 },
+        { id: "c", score: 40, roundsPlayed: 5 },
+        { id: "d", score: 35, roundsPlayed: 5 },
+      ],
+      75,
+      {
+        a: [10, 10, 10, 10, 10],
+        b: [9, 9, 9, 9, 9],
+        c: [8, 8, 8, 8, 8],
+        d: [7, 7, 7, 7, 7],
+      },
+      {
+        predictionProfiles: Object.fromEntries(
+          ["a", "b", "c", "d"].map((id, index) => [
+            id,
+            {
+              playerId: id,
+              roundsPlayed: 5,
+              meanDelta: 10 - index,
+              stdDelta: 1,
+              blitzRate: 0.4,
+              meanCardsPlayed: 20,
+              meanBlitzPileRemaining: 4,
+              recentDeltas: [10 - index],
+            },
+          ])
+        ),
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.historicalSampleCount).toBe(20);
+    expect(forecast!.confidence).not.toBe("high");
+  });
+
   it("keeps unresolved simulations explicit instead of crediting the leader", () => {
     const forecast = calcRaceForecast(
       [

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -23,6 +23,21 @@ describe("clampRoundScore", () => {
 });
 
 describe("allocateOutcomePercents", () => {
+  it("returns zero percentages when there are no outcomes to allocate", () => {
+    expect(
+      allocateOutcomePercents(
+        [
+          ["a", 0],
+          ["b", 0],
+        ],
+        0
+      )
+    ).toEqual({
+      a: 0,
+      b: 0,
+    });
+  });
+
   it("uses a stable tie-break when rounded percentages need a remainder bump", () => {
     const counts: [string, number][] = [
       ["b", 2250],
@@ -318,6 +333,43 @@ describe("calcRaceForecast", () => {
     expect(forecastSum(forecast!)).toBe(100);
   });
 
+  it("keeps simulating volatile players even when their average delta is not positive", () => {
+    const forecast = calcRaceForecast(
+      [{ id: "volatile", score: 74, roundsPlayed: 3 }],
+      75,
+      {
+        volatile: [-20, 20, 0],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.volatile.winProbability).toBeGreaterThan(0);
+    expect(
+      forecast!.players.volatile.nextRoundWinProbability
+    ).toBeGreaterThan(0);
+  });
+
+  it("splits exact same-round winning-score ties between tied players", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "b", score: 30, roundsPlayed: 3 },
+        { id: "a", score: 30, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        a: [15, 15, 15],
+        b: [15, 15, 15],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.a.winProbability).toBe(50);
+    expect(forecast!.players.b.winProbability).toBe(50);
+    expect(forecast!.players.a.winningRound?.median).toBe(6);
+    expect(forecast!.players.b.winningRound?.median).toBe(6);
+    expect(forecastSum(forecast!)).toBe(100);
+  });
+
   it("derives next-round threat and winning-round range from the same pass", () => {
     const forecast = calcRaceForecast(
       [
@@ -373,6 +425,45 @@ describe("calcRaceForecast", () => {
     expect(forecast!.players.close.nextRoundBlitzWinProbability).toBe(100);
     expect(forecast!.players.close.nextRoundSwingProbability).toBe(100);
     expect(forecast!.players.steady.nextRoundSwingProbability).toBe(0);
+  });
+
+  it("conditions mechanics-mode future rounds on at least one blitzer", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "a", score: 70, roundsPlayed: 3 },
+        { id: "b", score: 70, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        a: [5, 5, 5],
+        b: [5, 5, 5],
+      },
+      {
+        roundSamplesByPlayer: {
+          a: [
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+          ],
+          b: [
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+            { totalCardsPlayed: 15, blitzPileRemaining: 5 },
+          ],
+        },
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.usesMechanicsModel).toBe(true);
+    expect(
+      forecast!.players.a.nextRoundWinProbability +
+        forecast!.players.b.nextRoundWinProbability
+    ).toBe(100);
+    expect(
+      forecast!.players.a.nextRoundBlitzWinProbability +
+        forecast!.players.b.nextRoundBlitzWinProbability
+    ).toBe(100);
   });
 
   it("keeps swing probability separate from next-round win probability", () => {

--- a/src/lib/__tests__/probability.test.ts
+++ b/src/lib/__tests__/probability.test.ts
@@ -1,21 +1,45 @@
 import {
+  allocateOutcomePercents,
   calcWinProbabilities,
-  calcProjectedFinishRound,
+  calcRaceForecast,
+  clampRoundScore,
 } from "../scoring/probability";
 
-describe("calcProjectedFinishRound", () => {
-  it("projects finish round based on average pace", () => {
-    // 50 points in 5 rounds = 10/round, need 75, so ~7.5 → round 8
-    expect(calcProjectedFinishRound(50, 5, 75)).toBe(8);
-  });
+function forecastSum(forecast: NonNullable<ReturnType<typeof calcRaceForecast>>) {
+  return (
+    Object.values(forecast.players).reduce(
+      (sum, player) => sum + player.winProbability,
+      0
+    ) + forecast.unresolvedProbability
+  );
+}
 
-  it("returns Infinity for zero or negative pace", () => {
-    expect(calcProjectedFinishRound(-10, 5, 75)).toBe(Infinity);
-    expect(calcProjectedFinishRound(0, 5, 75)).toBe(Infinity);
+describe("clampRoundScore", () => {
+  it("keeps simulated round scores inside Dutch Blitz scoring bounds", () => {
+    expect(clampRoundScore(-100)).toBe(-20);
+    expect(clampRoundScore(100)).toBe(40);
+    expect(clampRoundScore(4.6)).toBe(5);
   });
+});
 
-  it("returns current round if already past threshold", () => {
-    expect(calcProjectedFinishRound(80, 5, 75)).toBe(5);
+describe("allocateOutcomePercents", () => {
+  it("uses a stable tie-break when rounded percentages need a remainder bump", () => {
+    const counts: [string, number][] = [
+      ["b", 2250],
+      ["a", 4350],
+      ["__unresolved", 3400],
+    ];
+
+    expect(allocateOutcomePercents(counts, 10_000)).toEqual({
+      a: 44,
+      b: 22,
+      __unresolved: 34,
+    });
+    expect(allocateOutcomePercents([...counts].reverse(), 10_000)).toEqual({
+      a: 44,
+      b: 22,
+      __unresolved: 34,
+    });
   });
 });
 
@@ -42,8 +66,6 @@ describe("calcWinProbabilities", () => {
     );
     expect(result).not.toBeNull();
     expect(result!["1"]).toBeGreaterThan(result!["2"]);
-    const sum = Object.values(result!).reduce((a, b) => a + b, 0);
-    expect(sum).toBe(100);
   });
 
   it("gives 0% to players with negative pace (no deltas)", () => {
@@ -84,6 +106,20 @@ describe("calcWinProbabilities", () => {
     const r1 = calcWinProbabilities(players, 75, deltas);
     const r2 = calcWinProbabilities(players, 75, deltas);
     expect(r1).toEqual(r2);
+  });
+
+  it("is deterministic for the same players in a different order", () => {
+    const players = [
+      { id: "b", score: 35, roundsPlayed: 5 },
+      { id: "a", score: 40, roundsPlayed: 5 },
+    ];
+    const deltas = {
+      a: [10, 8, 7, 9, 6],
+      b: [5, 12, 3, 8, 7],
+    };
+    const original = calcWinProbabilities(players, 75, deltas);
+    const reordered = calcWinProbabilities([...players].reverse(), 75, deltas);
+    expect(original).toEqual(reordered);
   });
 
   describe("with per-round deltas (Monte Carlo)", () => {
@@ -137,5 +173,74 @@ describe("calcWinProbabilities", () => {
       const sum = Object.values(result!).reduce((a, b) => a + b, 0);
       expect(sum).toBe(100);
     });
+  });
+});
+
+describe("calcRaceForecast", () => {
+  it("returns null when fewer than 3 rounds have been played", () => {
+    expect(
+      calcRaceForecast([{ id: "1", score: 10, roundsPlayed: 2 }], 75)
+    ).toBeNull();
+  });
+
+  it("keeps unresolved simulations explicit instead of crediting the leader", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "leader", score: 3, roundsPlayed: 3 },
+        { id: "trailing", score: 0, roundsPlayed: 3 },
+      ],
+      75,
+      {
+        leader: [1, 1, 1],
+        trailing: [0, 0, 0],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.leader.winProbability).toBe(0);
+    expect(forecast!.unresolvedProbability).toBe(100);
+    expect(forecast!.gameEndRound).toBeNull();
+    expect(forecastSum(forecast!)).toBe(100);
+  });
+
+  it("derives next-round threat and winning-round range from the same pass", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "close", score: 70, roundsPlayed: 5 },
+        { id: "far", score: 30, roundsPlayed: 5 },
+      ],
+      75,
+      {
+        close: [12, 14, 16, 14, 14],
+        far: [4, 8, 6, 6, 6],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecast!.players.close.nextRoundWinProbability).toBeGreaterThan(90);
+    expect(forecast!.players.close.nextRoundWinProbability).toBeLessThanOrEqual(
+      forecast!.players.close.winProbability
+    );
+    expect(forecast!.players.close.winningRound?.median).toBe(6);
+    expect(forecast!.gameEndRound?.median).toBe(6);
+  });
+
+  it("returns player outcomes plus unresolved outcomes that sum to 100", () => {
+    const forecast = calcRaceForecast(
+      [
+        { id: "1", score: 30, roundsPlayed: 4 },
+        { id: "2", score: 25, roundsPlayed: 4 },
+        { id: "3", score: 20, roundsPlayed: 4 },
+      ],
+      75,
+      {
+        "1": [8, 7, 9, 6],
+        "2": [5, 8, 6, 6],
+        "3": [4, 5, 6, 5],
+      }
+    );
+
+    expect(forecast).not.toBeNull();
+    expect(forecastSum(forecast!)).toBe(100);
   });
 });

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,16 +1,8 @@
-export function calcProjectedFinishRound(
-  currentScore: number,
-  roundsPlayed: number,
-  winThreshold: number
-): number {
-  if (currentScore >= winThreshold) return roundsPlayed;
-  const pace = roundsPlayed > 0 ? currentScore / roundsPlayed : 0;
-  if (pace <= 0) return Infinity;
-  return Math.ceil(winThreshold / pace);
-}
-
 const SIMULATION_COUNT = 10_000;
 const MAX_FUTURE_ROUNDS = 50;
+const UNRESOLVED_OUTCOME_ID = "__unresolved";
+export const MIN_SIMULATED_ROUND_SCORE = -20;
+export const MAX_SIMULATED_ROUND_SCORE = 40;
 
 // Seeded PRNG (xoshiro128**) for deterministic Monte Carlo results.
 // Ensures identical inputs always produce identical probabilities,
@@ -43,6 +35,13 @@ function normalSample(mean: number, std: number, rng: () => number): number {
   return mean + std * z;
 }
 
+export function clampRoundScore(score: number): number {
+  return Math.max(
+    MIN_SIMULATED_ROUND_SCORE,
+    Math.min(MAX_SIMULATED_ROUND_SCORE, Math.round(score))
+  );
+}
+
 function mean(values: number[]): number {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
@@ -61,29 +60,143 @@ interface PlayerStats {
   std: number;
 }
 
+export interface ForecastRange {
+  p25: number;
+  median: number;
+  p75: number;
+}
+
+export type ForecastConfidence = "low" | "medium" | "high";
+
+export interface PlayerForecast {
+  id: string;
+  winProbability: number;
+  nextRoundWinProbability: number;
+  winningRound: ForecastRange | null;
+}
+
+export interface RaceForecast {
+  players: Record<string, PlayerForecast>;
+  gameEndRound: ForecastRange | null;
+  unresolvedProbability: number;
+  confidence: ForecastConfidence;
+  simulationCount: number;
+}
+
+function percentile(sortedValues: number[], percentileValue: number): number {
+  if (sortedValues.length === 0) return Infinity;
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.floor((sortedValues.length - 1) * percentileValue))
+  );
+  return sortedValues[index];
+}
+
+function buildRange(values: number[]): ForecastRange | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p25: percentile(sorted, 0.25),
+    median: percentile(sorted, 0.5),
+    p75: percentile(sorted, 0.75),
+  };
+}
+
+function toPercent(count: number, total: number): number {
+  return Math.round((count / total) * 100);
+}
+
+function outcomeSortKey(id: string): string {
+  return id === UNRESOLVED_OUTCOME_ID ? "\uffff" : id;
+}
+
+export function allocateOutcomePercents(
+  counts: [string, number][],
+  total: number
+): Record<string, number> {
+  const exact = counts.map(([id, count]) => ({
+    id,
+    value: total === 0 ? 0 : (count / total) * 100,
+  }));
+  const result = Object.fromEntries(
+    exact.map(({ id, value }) => [id, Math.floor(value)])
+  );
+  let remainder =
+    100 - Object.values(result).reduce((sum, value) => sum + value, 0);
+
+  for (const { id } of exact
+    .map((entry) => ({
+      ...entry,
+      fraction: entry.value - Math.floor(entry.value),
+    }))
+    .sort(
+      (a, b) =>
+        b.fraction - a.fraction ||
+        outcomeSortKey(a.id).localeCompare(outcomeSortKey(b.id))
+    )) {
+    if (remainder <= 0) break;
+    result[id]++;
+    remainder--;
+  }
+
+  return result;
+}
+
+function calcConfidence(
+  roundsPlayed: number,
+  unresolvedProbability: number
+): ForecastConfidence {
+  if (roundsPlayed < 5 || unresolvedProbability >= 25) return "low";
+  if (roundsPlayed < 8 || unresolvedProbability >= 10) return "medium";
+  return "high";
+}
+
+function buildSeed(
+  players: { id: string; score: number; roundsPlayed: number }[],
+  winThreshold: number,
+  deltasByPlayer?: Record<string, number[]>
+): number {
+  const seedText = players
+    .map((p) => {
+      const deltas = deltasByPlayer?.[p.id] ?? [];
+      return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(",")}`;
+    })
+    .sort()
+    .join("|");
+
+  let seed = winThreshold >>> 0;
+  for (let i = 0; i < seedText.length; i++) {
+    seed = Math.imul(seed ^ seedText.charCodeAt(i), 16777619) >>> 0;
+  }
+  return seed || 1;
+}
+
 /**
- * Monte Carlo win-probability estimation.
+ * Monte Carlo race forecast.
  *
  * For each simulation we sample future round scores from a normal distribution
- * fitted to each player's historical per-round deltas, then check who crosses
- * the win threshold first. The fraction of simulations won gives the probability.
+ * fitted to each player's current-game per-round deltas, then check who crosses
+ * the win threshold first. All returned forecast facts come from the same
+ * simulation pass so the percentages and round ranges stay coherent.
  *
  * When per-round deltas are available the model captures both scoring pace *and*
  * variance, which the old pace-ratio approach ignored entirely.
  *
- * Falls back to the simpler pace-ratio heuristic when deltas are unavailable
- * (e.g. when only aggregate score + roundsPlayed are known).
+ * Falls back to aggregate score + roundsPlayed when deltas are unavailable.
  */
-export function calcWinProbabilities(
+export function calcRaceForecast(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
   deltasByPlayer?: Record<string, number[]>
-): Record<string, number> | null {
+): RaceForecast | null {
   if (players.length === 0) return null;
-  if (players[0].roundsPlayed < 3) return null;
+  const roundsPlayed = players[0].roundsPlayed;
+  if (roundsPlayed < 3) return null;
+
+  const orderedPlayers = [...players].sort((a, b) => a.id.localeCompare(b.id));
 
   // Build per-player stats from deltas when available
-  const stats: PlayerStats[] = players.map((p) => {
+  const stats: PlayerStats[] = orderedPlayers.map((p) => {
     const deltas = deltasByPlayer?.[p.id];
     if (deltas && deltas.length >= 2) {
       const m = mean(deltas);
@@ -97,24 +210,46 @@ export function calcWinProbabilities(
 
   // If every player has non-positive mean, no one is progressing
   if (stats.every((s) => s.mean <= 0)) {
-    return Object.fromEntries(players.map((p) => [p.id, 0]));
+    return {
+      players: Object.fromEntries(
+        players.map((p) => [
+          p.id,
+          {
+            id: p.id,
+            winProbability: 0,
+            nextRoundWinProbability: 0,
+            winningRound: null,
+          },
+        ])
+      ),
+      gameEndRound: null,
+      unresolvedProbability: 100,
+      confidence: "low",
+      simulationCount: SIMULATION_COUNT,
+    };
   }
 
-  // Deterministic seed from current game state
-  const seed =
-    players.reduce((h, p) => h * 31 + Math.round(p.score * 100), 7) >>> 0;
-  const rng = makeRng(seed);
+  const rng = makeRng(buildSeed(players, winThreshold, deltasByPlayer));
 
   const wins: Record<string, number> = {};
+  const nextRoundWins: Record<string, number> = {};
+  const winningRounds: Record<string, number[]> = {};
   for (const p of players) wins[p.id] = 0;
+  for (const p of players) nextRoundWins[p.id] = 0;
+  for (const p of players) winningRounds[p.id] = [];
+  const gameEndRounds: number[] = [];
+  let unresolvedCount = 0;
 
   for (let sim = 0; sim < SIMULATION_COUNT; sim++) {
     const scores = stats.map((s) => s.currentScore);
     let winnerId: string | null = null;
+    let winningRound: number | null = null;
 
     for (let r = 0; r < MAX_FUTURE_ROUNDS; r++) {
       for (let i = 0; i < stats.length; i++) {
-        scores[i] += normalSample(stats[i].mean, stats[i].std, rng);
+        scores[i] += clampRoundScore(
+          normalSample(stats[i].mean, stats[i].std, rng)
+        );
       }
       // Check if any player crossed the threshold this round
       let bestScore = -Infinity;
@@ -122,28 +257,67 @@ export function calcWinProbabilities(
         if (scores[i] >= winThreshold && scores[i] > bestScore) {
           bestScore = scores[i];
           winnerId = stats[i].id;
+          winningRound = roundsPlayed + r + 1;
         }
       }
       if (winnerId) break;
     }
 
-    if (winnerId) wins[winnerId]++;
+    if (winnerId && winningRound !== null) {
+      wins[winnerId]++;
+      winningRounds[winnerId].push(winningRound);
+      gameEndRounds.push(winningRound);
+      if (winningRound === roundsPlayed + 1) {
+        nextRoundWins[winnerId]++;
+      }
+    } else {
+      unresolvedCount++;
+    }
   }
 
-  // Convert counts to integer percentages
-  const result: Record<string, number> = {};
+  const outcomePercents = allocateOutcomePercents(
+    [
+      ...players.map((p) => [p.id, wins[p.id]] as [string, number]),
+      [UNRESOLVED_OUTCOME_ID, unresolvedCount],
+    ],
+    SIMULATION_COUNT
+  );
+  const unresolvedProbability = outcomePercents[UNRESOLVED_OUTCOME_ID] ?? 0;
+  const forecastPlayers: Record<string, PlayerForecast> = {};
+
   for (const p of players) {
-    result[p.id] = Math.round((wins[p.id] / SIMULATION_COUNT) * 100);
+    const winProbability = outcomePercents[p.id] ?? 0;
+    forecastPlayers[p.id] = {
+      id: p.id,
+      winProbability,
+      nextRoundWinProbability: Math.min(
+        toPercent(nextRoundWins[p.id], SIMULATION_COUNT),
+        winProbability
+      ),
+      winningRound: buildRange(winningRounds[p.id]),
+    };
   }
 
-  // Fix rounding to sum to exactly 100
-  const sum = Object.values(result).reduce((a, b) => a + b, 0);
-  if (sum !== 100 && sum > 0) {
-    const maxId = Object.entries(result).reduce((a, b) =>
-      b[1] > a[1] ? b : a
-    )[0];
-    result[maxId] += 100 - sum;
-  }
+  return {
+    players: forecastPlayers,
+    gameEndRound: buildRange(gameEndRounds),
+    unresolvedProbability,
+    confidence: calcConfidence(roundsPlayed, unresolvedProbability),
+    simulationCount: SIMULATION_COUNT,
+  };
+}
 
-  return result;
+export function calcWinProbabilities(
+  players: { id: string; score: number; roundsPlayed: number }[],
+  winThreshold: number,
+  deltasByPlayer?: Record<string, number[]>
+): Record<string, number> | null {
+  const forecast = calcRaceForecast(players, winThreshold, deltasByPlayer);
+  if (!forecast) return null;
+  return Object.fromEntries(
+    Object.values(forecast.players).map((player) => [
+      player.id,
+      player.winProbability,
+    ])
+  );
 }

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,10 +1,17 @@
+import { GAME_RULES } from "@/lib/validation/gameRules";
+
 const SIMULATION_COUNT = 10_000;
 const MAX_FUTURE_ROUNDS = 50;
 const UNRESOLVED_OUTCOME_ID = "__unresolved";
 const MIN_HISTORICAL_ROUNDS = 5;
 const HISTORY_BLEND_ROUND_CAP = 8;
+const SWING_ROUND_SCORE = 20;
 export const MIN_SIMULATED_ROUND_SCORE = -20;
 export const MAX_SIMULATED_ROUND_SCORE = 40;
+export const MIN_SIMULATED_CARDS_PLAYED = 0;
+export const MAX_SIMULATED_CARDS_PLAYED = GAME_RULES.MAX_CARDS_PLAYED;
+export const MIN_SIMULATED_BLITZ_PILE_REMAINING = 1;
+export const MAX_SIMULATED_BLITZ_PILE_REMAINING = GAME_RULES.MAX_BLITZ_PILE;
 
 // Seeded PRNG (xoshiro128**) for deterministic Monte Carlo results.
 // Ensures identical inputs always produce identical probabilities,
@@ -44,6 +51,20 @@ export function clampRoundScore(score: number): number {
   );
 }
 
+function clampCardsPlayed(cardsPlayed: number): number {
+  return Math.max(
+    MIN_SIMULATED_CARDS_PLAYED,
+    Math.min(MAX_SIMULATED_CARDS_PLAYED, Math.round(cardsPlayed))
+  );
+}
+
+function clampActiveBlitzPile(blitzPileRemaining: number): number {
+  return Math.max(
+    MIN_SIMULATED_BLITZ_PILE_REMAINING,
+    Math.min(MAX_SIMULATED_BLITZ_PILE_REMAINING, Math.round(blitzPileRemaining))
+  );
+}
+
 function mean(values: number[]): number {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
@@ -61,6 +82,25 @@ interface PlayerStats {
   mean: number;
   std: number;
   historicalSampleCount: number;
+  mechanics?: PlayerMechanicsStats;
+}
+
+interface PlayerMechanicsStats {
+  blitzRate: number;
+  meanCardsPlayed: number;
+  stdCardsPlayed: number;
+  meanActiveBlitzPileRemaining: number;
+  stdActiveBlitzPileRemaining: number;
+}
+
+interface RoundOutcome {
+  delta: number;
+  blitzed: boolean;
+}
+
+export interface ForecastRoundSample {
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
 }
 
 export interface PredictionProfile {
@@ -88,6 +128,8 @@ export interface PlayerForecast {
   id: string;
   winProbability: number;
   nextRoundWinProbability: number;
+  nextRoundBlitzWinProbability: number;
+  nextRoundSwingProbability: number;
   winningRound: ForecastRange | null;
 }
 
@@ -99,10 +141,12 @@ export interface RaceForecast {
   simulationCount: number;
   usesHistoricalData: boolean;
   historicalSampleCount: number;
+  usesMechanicsModel: boolean;
 }
 
 interface RaceForecastOptions {
   predictionProfiles?: PredictionProfilesByPlayer;
+  roundSamplesByPlayer?: Record<string, ForecastRoundSample[]>;
 }
 
 function percentile(sortedValues: number[], percentileValue: number): number {
@@ -210,10 +254,101 @@ function blendStd(
   return Math.sqrt(variance);
 }
 
+function calcActiveBlitzPileMean(
+  meanBlitzPileRemaining: number,
+  blitzRate: number
+): number {
+  if (blitzRate >= 0.95) return MIN_SIMULATED_BLITZ_PILE_REMAINING;
+  return clampActiveBlitzPile(meanBlitzPileRemaining / (1 - blitzRate));
+}
+
+function buildCurrentMechanics(
+  samples: ForecastRoundSample[] | undefined
+): PlayerMechanicsStats | undefined {
+  if (!samples || samples.length === 0) return undefined;
+
+  const cardsPlayed = samples.map((sample) => sample.totalCardsPlayed);
+  const activeBlitzPiles = samples
+    .map((sample) => sample.blitzPileRemaining)
+    .filter((pile) => pile > 0);
+  const meanCardsPlayed = mean(cardsPlayed);
+  const meanActiveBlitzPileRemaining =
+    activeBlitzPiles.length > 0
+      ? mean(activeBlitzPiles)
+      : MIN_SIMULATED_BLITZ_PILE_REMAINING;
+
+  return {
+    blitzRate:
+      samples.filter((sample) => sample.blitzPileRemaining === 0).length /
+      samples.length,
+    meanCardsPlayed,
+    stdCardsPlayed: stddev(cardsPlayed, meanCardsPlayed),
+    meanActiveBlitzPileRemaining,
+    stdActiveBlitzPileRemaining: stddev(
+      activeBlitzPiles,
+      meanActiveBlitzPileRemaining
+    ),
+  };
+}
+
+function buildHistoricalMechanics(
+  profile: PredictionProfile | undefined
+): PlayerMechanicsStats | undefined {
+  if (!hasUsableHistory(profile)) return undefined;
+
+  return {
+    blitzRate: profile.blitzRate,
+    meanCardsPlayed: profile.meanCardsPlayed,
+    stdCardsPlayed: Math.max(4, profile.stdDelta * 0.7),
+    meanActiveBlitzPileRemaining: calcActiveBlitzPileMean(
+      profile.meanBlitzPileRemaining,
+      profile.blitzRate
+    ),
+    stdActiveBlitzPileRemaining: Math.max(1.5, profile.stdDelta * 0.2),
+  };
+}
+
+function blendMechanics(
+  current: PlayerMechanicsStats | undefined,
+  historical: PlayerMechanicsStats | undefined,
+  currentWeight: number
+): PlayerMechanicsStats | undefined {
+  if (current && !historical) return current;
+  if (!current && historical) return historical;
+  if (!current || !historical) return undefined;
+
+  return {
+    blitzRate:
+      current.blitzRate * currentWeight +
+      historical.blitzRate * (1 - currentWeight),
+    meanCardsPlayed:
+      current.meanCardsPlayed * currentWeight +
+      historical.meanCardsPlayed * (1 - currentWeight),
+    stdCardsPlayed: blendStd(
+      current.meanCardsPlayed,
+      current.stdCardsPlayed,
+      historical.meanCardsPlayed,
+      historical.stdCardsPlayed,
+      currentWeight
+    ),
+    meanActiveBlitzPileRemaining:
+      current.meanActiveBlitzPileRemaining * currentWeight +
+      historical.meanActiveBlitzPileRemaining * (1 - currentWeight),
+    stdActiveBlitzPileRemaining: blendStd(
+      current.meanActiveBlitzPileRemaining,
+      current.stdActiveBlitzPileRemaining,
+      historical.meanActiveBlitzPileRemaining,
+      historical.stdActiveBlitzPileRemaining,
+      currentWeight
+    ),
+  };
+}
+
 function buildPlayerStats(
   player: { id: string; score: number; roundsPlayed: number },
   deltas: number[] | undefined,
-  profile: PredictionProfile | undefined
+  profile: PredictionProfile | undefined,
+  roundSamples: ForecastRoundSample[] | undefined
 ): PlayerStats {
   const currentDeltas = deltas ?? [];
   const currentMean =
@@ -226,19 +361,25 @@ function buildPlayerStats(
     currentDeltas.length >= 2
       ? stddev(currentDeltas, currentMean)
       : Math.abs(currentMean) * 0.5;
+  const historicalProfile = hasUsableHistory(profile) ? profile : undefined;
+  const currentWeight = historicalProfile
+    ? calcCurrentWeight(currentDeltas.length, historicalProfile.roundsPlayed)
+    : 1;
+  const mechanics = blendMechanics(
+    buildCurrentMechanics(roundSamples),
+    buildHistoricalMechanics(historicalProfile),
+    currentWeight
+  );
 
-  if (hasUsableHistory(profile)) {
-    const currentWeight = calcCurrentWeight(
-      currentDeltas.length,
-      profile.roundsPlayed
-    );
+  if (historicalProfile) {
     const blendedMean =
-      currentMean * currentWeight + profile.meanDelta * (1 - currentWeight);
+      currentMean * currentWeight +
+      historicalProfile.meanDelta * (1 - currentWeight);
     const blendedStd = blendStd(
       currentMean,
       currentStd,
-      profile.meanDelta,
-      profile.stdDelta,
+      historicalProfile.meanDelta,
+      historicalProfile.stdDelta,
       currentWeight
     );
 
@@ -247,7 +388,8 @@ function buildPlayerStats(
       currentScore: player.score,
       mean: blendedMean,
       std: blendedStd,
-      historicalSampleCount: profile.roundsPlayed,
+      historicalSampleCount: historicalProfile.roundsPlayed,
+      mechanics,
     };
   }
 
@@ -258,6 +400,7 @@ function buildPlayerStats(
       mean: currentMean,
       std: currentStd,
       historicalSampleCount: 0,
+      mechanics,
     };
   }
 
@@ -267,6 +410,7 @@ function buildPlayerStats(
     mean: currentMean,
     std: Math.abs(currentMean) * 0.5,
     historicalSampleCount: 0,
+    mechanics,
   };
 }
 
@@ -274,11 +418,13 @@ function buildSeed(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
   deltasByPlayer?: Record<string, number[]>,
-  predictionProfiles?: PredictionProfilesByPlayer
+  predictionProfiles?: PredictionProfilesByPlayer,
+  roundSamplesByPlayer?: Record<string, ForecastRoundSample[]>
 ): number {
   const seedText = players
     .map((p) => {
       const deltas = deltasByPlayer?.[p.id] ?? [];
+      const roundSamples = roundSamplesByPlayer?.[p.id] ?? [];
       const profile = predictionProfiles?.[p.id];
       const profileText = profile
         ? `${profile.roundsPlayed}:${profile.meanDelta.toFixed(
@@ -287,9 +433,12 @@ function buildSeed(
             .slice(0, 10)
             .join(",")}`
         : "";
+      const roundSampleText = roundSamples
+        .map((sample) => `${sample.totalCardsPlayed}/${sample.blitzPileRemaining}`)
+        .join(",");
       return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(
         ","
-      )}:${profileText}`;
+      )}:${roundSampleText}:${profileText}`;
     })
     .sort()
     .join("|");
@@ -299,6 +448,44 @@ function buildSeed(
     seed = Math.imul(seed ^ seedText.charCodeAt(i), 16777619) >>> 0;
   }
   return seed || 1;
+}
+
+function sampleRoundOutcome(
+  stats: PlayerStats,
+  rng: () => number
+): RoundOutcome {
+  if (!stats.mechanics) {
+    return {
+      delta: clampRoundScore(normalSample(stats.mean, stats.std, rng)),
+      blitzed: false,
+    };
+  }
+
+  const blitzed = rng() < stats.mechanics.blitzRate;
+  const cardsPlayed = clampCardsPlayed(
+    normalSample(
+      stats.mechanics.meanCardsPlayed,
+      stats.mechanics.stdCardsPlayed,
+      rng
+    )
+  );
+  const validCardsPlayed = blitzed
+    ? Math.max(cardsPlayed, GAME_RULES.MIN_CARDS_FOR_BLITZ)
+    : cardsPlayed;
+  const blitzPileRemaining = blitzed
+    ? 0
+    : clampActiveBlitzPile(
+        normalSample(
+          stats.mechanics.meanActiveBlitzPileRemaining,
+          stats.mechanics.stdActiveBlitzPileRemaining,
+          rng
+        )
+      );
+
+  return {
+    delta: clampRoundScore(validCardsPlayed - 2 * blitzPileRemaining),
+    blitzed,
+  };
 }
 
 /**
@@ -330,7 +517,12 @@ export function calcRaceForecast(
   const orderedPlayers = [...players].sort((a, b) => a.id.localeCompare(b.id));
 
   const stats: PlayerStats[] = orderedPlayers.map((p) =>
-    buildPlayerStats(p, deltasByPlayer?.[p.id], options.predictionProfiles?.[p.id])
+    buildPlayerStats(
+      p,
+      deltasByPlayer?.[p.id],
+      options.predictionProfiles?.[p.id],
+      options.roundSamplesByPlayer?.[p.id]
+    )
   );
   const historicalSampleCount = stats.reduce(
     (sum, stat) => sum + stat.historicalSampleCount,
@@ -342,6 +534,7 @@ export function calcRaceForecast(
     .filter((count) => count > 0);
   const minimumHistoricalDepth =
     historicalDepths.length === stats.length ? Math.min(...historicalDepths) : 0;
+  const usesMechanicsModel = stats.some((stat) => stat.mechanics);
 
   // If every player has non-positive mean, no one is progressing
   if (stats.every((s) => s.mean <= 0)) {
@@ -351,10 +544,12 @@ export function calcRaceForecast(
           p.id,
           {
             id: p.id,
-            winProbability: 0,
-            nextRoundWinProbability: 0,
-            winningRound: null,
-          },
+              winProbability: 0,
+              nextRoundWinProbability: 0,
+              nextRoundBlitzWinProbability: 0,
+              nextRoundSwingProbability: 0,
+              winningRound: null,
+            },
         ])
       ),
       gameEndRound: null,
@@ -363,18 +558,29 @@ export function calcRaceForecast(
       simulationCount: SIMULATION_COUNT,
       usesHistoricalData,
       historicalSampleCount,
+      usesMechanicsModel,
     };
   }
 
   const rng = makeRng(
-    buildSeed(players, winThreshold, deltasByPlayer, options.predictionProfiles)
+    buildSeed(
+      players,
+      winThreshold,
+      deltasByPlayer,
+      options.predictionProfiles,
+      options.roundSamplesByPlayer
+    )
   );
 
   const wins: Record<string, number> = {};
   const nextRoundWins: Record<string, number> = {};
+  const nextRoundBlitzWins: Record<string, number> = {};
+  const nextRoundSwings: Record<string, number> = {};
   const winningRounds: Record<string, number[]> = {};
   for (const p of players) wins[p.id] = 0;
   for (const p of players) nextRoundWins[p.id] = 0;
+  for (const p of players) nextRoundBlitzWins[p.id] = 0;
+  for (const p of players) nextRoundSwings[p.id] = 0;
   for (const p of players) winningRounds[p.id] = [];
   const gameEndRounds: number[] = [];
   let unresolvedCount = 0;
@@ -383,12 +589,15 @@ export function calcRaceForecast(
     const scores = stats.map((s) => s.currentScore);
     let winnerId: string | null = null;
     let winningRound: number | null = null;
+    let winnerBlitzed = false;
 
     for (let r = 0; r < MAX_FUTURE_ROUNDS; r++) {
+      const outcomes = stats.map((s) => sampleRoundOutcome(s, rng));
       for (let i = 0; i < stats.length; i++) {
-        scores[i] += clampRoundScore(
-          normalSample(stats[i].mean, stats[i].std, rng)
-        );
+        scores[i] += outcomes[i].delta;
+        if (r === 0 && outcomes[i].delta >= SWING_ROUND_SCORE) {
+          nextRoundSwings[stats[i].id]++;
+        }
       }
       // Check if any player crossed the threshold this round
       let bestScore = -Infinity;
@@ -397,6 +606,7 @@ export function calcRaceForecast(
           bestScore = scores[i];
           winnerId = stats[i].id;
           winningRound = roundsPlayed + r + 1;
+          winnerBlitzed = outcomes[i].blitzed;
         }
       }
       if (winnerId) break;
@@ -408,6 +618,9 @@ export function calcRaceForecast(
       gameEndRounds.push(winningRound);
       if (winningRound === roundsPlayed + 1) {
         nextRoundWins[winnerId]++;
+        if (winnerBlitzed) {
+          nextRoundBlitzWins[winnerId]++;
+        }
       }
     } else {
       unresolvedCount++;
@@ -433,6 +646,14 @@ export function calcRaceForecast(
         toPercent(nextRoundWins[p.id], SIMULATION_COUNT),
         winProbability
       ),
+      nextRoundBlitzWinProbability: Math.min(
+        toPercent(nextRoundBlitzWins[p.id], SIMULATION_COUNT),
+        winProbability
+      ),
+      nextRoundSwingProbability: toPercent(
+        nextRoundSwings[p.id],
+        SIMULATION_COUNT
+      ),
       winningRound: buildRange(winningRounds[p.id]),
     };
   }
@@ -449,6 +670,7 @@ export function calcRaceForecast(
     simulationCount: SIMULATION_COUNT,
     usesHistoricalData,
     historicalSampleCount,
+    usesMechanicsModel,
   };
 }
 

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -1,6 +1,8 @@
 const SIMULATION_COUNT = 10_000;
 const MAX_FUTURE_ROUNDS = 50;
 const UNRESOLVED_OUTCOME_ID = "__unresolved";
+const MIN_HISTORICAL_ROUNDS = 5;
+const HISTORY_BLEND_ROUND_CAP = 8;
 export const MIN_SIMULATED_ROUND_SCORE = -20;
 export const MAX_SIMULATED_ROUND_SCORE = 40;
 
@@ -58,7 +60,21 @@ interface PlayerStats {
   currentScore: number;
   mean: number;
   std: number;
+  historicalSampleCount: number;
 }
+
+export interface PredictionProfile {
+  playerId: string;
+  roundsPlayed: number;
+  meanDelta: number;
+  stdDelta: number;
+  blitzRate: number;
+  meanCardsPlayed: number;
+  meanBlitzPileRemaining: number;
+  recentDeltas: number[];
+}
+
+export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
 
 export interface ForecastRange {
   p25: number;
@@ -81,6 +97,12 @@ export interface RaceForecast {
   unresolvedProbability: number;
   confidence: ForecastConfidence;
   simulationCount: number;
+  usesHistoricalData: boolean;
+  historicalSampleCount: number;
+}
+
+interface RaceForecastOptions {
+  predictionProfiles?: PredictionProfilesByPlayer;
 }
 
 function percentile(sortedValues: number[], percentileValue: number): number {
@@ -144,22 +166,130 @@ export function allocateOutcomePercents(
 
 function calcConfidence(
   roundsPlayed: number,
-  unresolvedProbability: number
+  unresolvedProbability: number,
+  minimumHistoricalDepth: number
 ): ForecastConfidence {
   if (roundsPlayed < 5 || unresolvedProbability >= 25) return "low";
+  if (minimumHistoricalDepth >= 12 && unresolvedProbability < 10) return "high";
   if (roundsPlayed < 8 || unresolvedProbability >= 10) return "medium";
   return "high";
+}
+
+function hasUsableHistory(
+  profile: PredictionProfile | undefined
+): profile is PredictionProfile {
+  return Boolean(profile && profile.roundsPlayed >= MIN_HISTORICAL_ROUNDS);
+}
+
+function calcCurrentWeight(
+  currentRounds: number,
+  historicalSampleCount: number
+): number {
+  if (currentRounds <= 0) return 0;
+  const cappedHistoryRounds = Math.min(
+    historicalSampleCount,
+    HISTORY_BLEND_ROUND_CAP
+  );
+  const raw = currentRounds / (currentRounds + cappedHistoryRounds);
+  return Math.min(0.85, Math.max(0.35, raw));
+}
+
+function blendStd(
+  currentMean: number,
+  currentStd: number,
+  historicalMean: number,
+  historicalStd: number,
+  currentWeight: number
+): number {
+  const blendedMean =
+    currentMean * currentWeight + historicalMean * (1 - currentWeight);
+  const variance =
+    currentWeight * (currentStd ** 2 + (currentMean - blendedMean) ** 2) +
+    (1 - currentWeight) *
+      (historicalStd ** 2 + (historicalMean - blendedMean) ** 2);
+  return Math.sqrt(variance);
+}
+
+function buildPlayerStats(
+  player: { id: string; score: number; roundsPlayed: number },
+  deltas: number[] | undefined,
+  profile: PredictionProfile | undefined
+): PlayerStats {
+  const currentDeltas = deltas ?? [];
+  const currentMean =
+    currentDeltas.length > 0
+      ? mean(currentDeltas)
+      : player.roundsPlayed > 0
+        ? player.score / player.roundsPlayed
+        : 0;
+  const currentStd =
+    currentDeltas.length >= 2
+      ? stddev(currentDeltas, currentMean)
+      : Math.abs(currentMean) * 0.5;
+
+  if (hasUsableHistory(profile)) {
+    const currentWeight = calcCurrentWeight(
+      currentDeltas.length,
+      profile.roundsPlayed
+    );
+    const blendedMean =
+      currentMean * currentWeight + profile.meanDelta * (1 - currentWeight);
+    const blendedStd = blendStd(
+      currentMean,
+      currentStd,
+      profile.meanDelta,
+      profile.stdDelta,
+      currentWeight
+    );
+
+    return {
+      id: player.id,
+      currentScore: player.score,
+      mean: blendedMean,
+      std: blendedStd,
+      historicalSampleCount: profile.roundsPlayed,
+    };
+  }
+
+  if (currentDeltas.length >= 2) {
+    return {
+      id: player.id,
+      currentScore: player.score,
+      mean: currentMean,
+      std: currentStd,
+      historicalSampleCount: 0,
+    };
+  }
+
+  return {
+    id: player.id,
+    currentScore: player.score,
+    mean: currentMean,
+    std: Math.abs(currentMean) * 0.5,
+    historicalSampleCount: 0,
+  };
 }
 
 function buildSeed(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
-  deltasByPlayer?: Record<string, number[]>
+  deltasByPlayer?: Record<string, number[]>,
+  predictionProfiles?: PredictionProfilesByPlayer
 ): number {
   const seedText = players
     .map((p) => {
       const deltas = deltasByPlayer?.[p.id] ?? [];
-      return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(",")}`;
+      const profile = predictionProfiles?.[p.id];
+      const profileText = profile
+        ? `${profile.roundsPlayed}:${profile.meanDelta.toFixed(
+            3
+          )}:${profile.stdDelta.toFixed(3)}:${profile.recentDeltas
+            .slice(0, 10)
+            .join(",")}`
+        : "";
+      return `${p.id}:${p.score}:${p.roundsPlayed}:${deltas.join(
+        ","
+      )}:${profileText}`;
     })
     .sort()
     .join("|");
@@ -187,26 +317,31 @@ function buildSeed(
 export function calcRaceForecast(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
-  deltasByPlayer?: Record<string, number[]>
+  deltasByPlayer?: Record<string, number[]>,
+  options: RaceForecastOptions = {}
 ): RaceForecast | null {
   if (players.length === 0) return null;
   const roundsPlayed = players[0].roundsPlayed;
-  if (roundsPlayed < 3) return null;
+  const hasHistoricalEvidence = players.some((p) =>
+    hasUsableHistory(options.predictionProfiles?.[p.id])
+  );
+  if (roundsPlayed < 3 && !hasHistoricalEvidence) return null;
 
   const orderedPlayers = [...players].sort((a, b) => a.id.localeCompare(b.id));
 
-  // Build per-player stats from deltas when available
-  const stats: PlayerStats[] = orderedPlayers.map((p) => {
-    const deltas = deltasByPlayer?.[p.id];
-    if (deltas && deltas.length >= 2) {
-      const m = mean(deltas);
-      const s = stddev(deltas, m);
-      return { id: p.id, currentScore: p.score, mean: m, std: s };
-    }
-    // Fallback: infer mean from aggregate, assume moderate variance
-    const m = p.roundsPlayed > 0 ? p.score / p.roundsPlayed : 0;
-    return { id: p.id, currentScore: p.score, mean: m, std: Math.abs(m) * 0.5 };
-  });
+  const stats: PlayerStats[] = orderedPlayers.map((p) =>
+    buildPlayerStats(p, deltasByPlayer?.[p.id], options.predictionProfiles?.[p.id])
+  );
+  const historicalSampleCount = stats.reduce(
+    (sum, stat) => sum + stat.historicalSampleCount,
+    0
+  );
+  const usesHistoricalData = historicalSampleCount > 0;
+  const historicalDepths = stats
+    .map((stat) => stat.historicalSampleCount)
+    .filter((count) => count > 0);
+  const minimumHistoricalDepth =
+    historicalDepths.length === stats.length ? Math.min(...historicalDepths) : 0;
 
   // If every player has non-positive mean, no one is progressing
   if (stats.every((s) => s.mean <= 0)) {
@@ -226,10 +361,14 @@ export function calcRaceForecast(
       unresolvedProbability: 100,
       confidence: "low",
       simulationCount: SIMULATION_COUNT,
+      usesHistoricalData,
+      historicalSampleCount,
     };
   }
 
-  const rng = makeRng(buildSeed(players, winThreshold, deltasByPlayer));
+  const rng = makeRng(
+    buildSeed(players, winThreshold, deltasByPlayer, options.predictionProfiles)
+  );
 
   const wins: Record<string, number> = {};
   const nextRoundWins: Record<string, number> = {};
@@ -302,17 +441,29 @@ export function calcRaceForecast(
     players: forecastPlayers,
     gameEndRound: buildRange(gameEndRounds),
     unresolvedProbability,
-    confidence: calcConfidence(roundsPlayed, unresolvedProbability),
+    confidence: calcConfidence(
+      roundsPlayed,
+      unresolvedProbability,
+      minimumHistoricalDepth
+    ),
     simulationCount: SIMULATION_COUNT,
+    usesHistoricalData,
+    historicalSampleCount,
   };
 }
 
 export function calcWinProbabilities(
   players: { id: string; score: number; roundsPlayed: number }[],
   winThreshold: number,
-  deltasByPlayer?: Record<string, number[]>
+  deltasByPlayer?: Record<string, number[]>,
+  options: RaceForecastOptions = {}
 ): Record<string, number> | null {
-  const forecast = calcRaceForecast(players, winThreshold, deltasByPlayer);
+  const forecast = calcRaceForecast(
+    players,
+    winThreshold,
+    deltasByPlayer,
+    options
+  );
   if (!forecast) return null;
   return Object.fromEntries(
     Object.values(forecast.players).map((player) => [

--- a/src/lib/scoring/probability.ts
+++ b/src/lib/scoring/probability.ts
@@ -96,6 +96,8 @@ interface PlayerMechanicsStats {
 interface RoundOutcome {
   delta: number;
   blitzed: boolean;
+  cardsPlayed?: number;
+  blitzPileRemaining?: number;
 }
 
 export interface ForecastRoundSample {
@@ -180,9 +182,13 @@ export function allocateOutcomePercents(
   counts: [string, number][],
   total: number
 ): Record<string, number> {
+  if (total <= 0) {
+    return Object.fromEntries(counts.map(([id]) => [id, 0]));
+  }
+
   const exact = counts.map(([id, count]) => ({
     id,
-    value: total === 0 ? 0 : (count / total) * 100,
+    value: (count / total) * 100,
   }));
   const result = Object.fromEntries(
     exact.map(({ id, value }) => [id, Math.floor(value)])
@@ -485,7 +491,70 @@ function sampleRoundOutcome(
   return {
     delta: clampRoundScore(validCardsPlayed - 2 * blitzPileRemaining),
     blitzed,
+    cardsPlayed: validCardsPlayed,
+    blitzPileRemaining,
   };
+}
+
+function forceOneBlitzer(
+  stats: PlayerStats[],
+  outcomes: RoundOutcome[],
+  rng: () => number
+): RoundOutcome[] {
+  const candidateIndexes = stats
+    .map((stat, index) => (stat.mechanics ? index : -1))
+    .filter((index) => index >= 0);
+  if (candidateIndexes.length === 0) return outcomes;
+
+  const weights = candidateIndexes.map((index) =>
+    Math.max(stats[index].mechanics?.blitzRate ?? 0, 0.01)
+  );
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+  let pick = rng() * totalWeight;
+  let forcedIndex = candidateIndexes[candidateIndexes.length - 1];
+
+  for (let i = 0; i < candidateIndexes.length; i++) {
+    pick -= weights[i];
+    if (pick <= 0) {
+      forcedIndex = candidateIndexes[i];
+      break;
+    }
+  }
+
+  const cardsPlayed = Math.max(
+    outcomes[forcedIndex].cardsPlayed ?? GAME_RULES.MIN_CARDS_FOR_BLITZ,
+    GAME_RULES.MIN_CARDS_FOR_BLITZ
+  );
+
+  return outcomes.map((outcome, index) =>
+    index === forcedIndex
+      ? {
+          ...outcome,
+          delta: clampRoundScore(cardsPlayed),
+          blitzed: true,
+          cardsPlayed,
+          blitzPileRemaining: 0,
+        }
+      : outcome
+  );
+}
+
+function sampleRoundOutcomes(
+  stats: PlayerStats[],
+  rng: () => number
+): RoundOutcome[] {
+  const hasMechanicsModel = stats.some((stat) => stat.mechanics);
+  const maxAttempts = hasMechanicsModel ? 25 : 1;
+  let outcomes: RoundOutcome[] = [];
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    outcomes = stats.map((stat) => sampleRoundOutcome(stat, rng));
+    if (!hasMechanicsModel || outcomes.some((outcome) => outcome.blitzed)) {
+      return outcomes;
+    }
+  }
+
+  return forceOneBlitzer(stats, outcomes, rng);
 }
 
 /**
@@ -536,32 +605,6 @@ export function calcRaceForecast(
     historicalDepths.length === stats.length ? Math.min(...historicalDepths) : 0;
   const usesMechanicsModel = stats.some((stat) => stat.mechanics);
 
-  // If every player has non-positive mean, no one is progressing
-  if (stats.every((s) => s.mean <= 0)) {
-    return {
-      players: Object.fromEntries(
-        players.map((p) => [
-          p.id,
-          {
-            id: p.id,
-              winProbability: 0,
-              nextRoundWinProbability: 0,
-              nextRoundBlitzWinProbability: 0,
-              nextRoundSwingProbability: 0,
-              winningRound: null,
-            },
-        ])
-      ),
-      gameEndRound: null,
-      unresolvedProbability: 100,
-      confidence: "low",
-      simulationCount: SIMULATION_COUNT,
-      usesHistoricalData,
-      historicalSampleCount,
-      usesMechanicsModel,
-    };
-  }
-
   const rng = makeRng(
     buildSeed(
       players,
@@ -587,12 +630,12 @@ export function calcRaceForecast(
 
   for (let sim = 0; sim < SIMULATION_COUNT; sim++) {
     const scores = stats.map((s) => s.currentScore);
-    let winnerId: string | null = null;
+    let winnerIndexes: number[] = [];
     let winningRound: number | null = null;
-    let winnerBlitzed = false;
+    let winningOutcomes: RoundOutcome[] | null = null;
 
     for (let r = 0; r < MAX_FUTURE_ROUNDS; r++) {
-      const outcomes = stats.map((s) => sampleRoundOutcome(s, rng));
+      const outcomes = sampleRoundOutcomes(stats, rng);
       for (let i = 0; i < stats.length; i++) {
         scores[i] += outcomes[i].delta;
         if (r === 0 && outcomes[i].delta >= SWING_ROUND_SCORE) {
@@ -601,27 +644,41 @@ export function calcRaceForecast(
       }
       // Check if any player crossed the threshold this round
       let bestScore = -Infinity;
+      const crossingIndexes: number[] = [];
       for (let i = 0; i < stats.length; i++) {
-        if (scores[i] >= winThreshold && scores[i] > bestScore) {
+        if (scores[i] < winThreshold) continue;
+        if (scores[i] > bestScore) {
           bestScore = scores[i];
-          winnerId = stats[i].id;
-          winningRound = roundsPlayed + r + 1;
-          winnerBlitzed = outcomes[i].blitzed;
+          crossingIndexes.length = 0;
+          crossingIndexes.push(i);
+        } else if (scores[i] === bestScore) {
+          crossingIndexes.push(i);
         }
       }
-      if (winnerId) break;
+      if (crossingIndexes.length > 0) {
+        winnerIndexes = crossingIndexes;
+        winningRound = roundsPlayed + r + 1;
+        winningOutcomes = outcomes;
+        break;
+      }
     }
 
-    if (winnerId && winningRound !== null) {
-      wins[winnerId]++;
-      winningRounds[winnerId].push(winningRound);
-      gameEndRounds.push(winningRound);
-      if (winningRound === roundsPlayed + 1) {
-        nextRoundWins[winnerId]++;
-        if (winnerBlitzed) {
-          nextRoundBlitzWins[winnerId]++;
+    if (winnerIndexes.length > 0 && winningRound !== null) {
+      const splitWeight = 1 / winnerIndexes.length;
+
+      for (const winnerIndex of winnerIndexes) {
+        const winnerId = stats[winnerIndex].id;
+        wins[winnerId] += splitWeight;
+        winningRounds[winnerId].push(winningRound);
+        if (winningRound === roundsPlayed + 1) {
+          nextRoundWins[winnerId] += splitWeight;
+          if (winningOutcomes?.[winnerIndex].blitzed) {
+            nextRoundBlitzWins[winnerId] += splitWeight;
+          }
         }
       }
+
+      gameEndRounds.push(winningRound);
     } else {
       unresolvedCount++;
     }

--- a/src/server/__tests__/predictionProfiles.test.ts
+++ b/src/server/__tests__/predictionProfiles.test.ts
@@ -1,0 +1,286 @@
+import {
+  buildPredictionProfiles,
+  getPredictionProfilesForGame,
+  HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+  RECENT_DELTA_LIMIT,
+} from "../queries/predictionProfiles";
+import prisma from "@/server/db/db";
+import { auth } from "@clerk/nextjs/server";
+
+jest.mock("@/server/db/db", () => {
+  const mockPrisma = {
+    game: {
+      findUnique: jest.fn(),
+    },
+    score: {
+      findMany: jest.fn(),
+    },
+  };
+  return {
+    __esModule: true,
+    default: mockPrisma,
+  };
+});
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+describe("buildPredictionProfiles", () => {
+  it("summarizes score samples by user and guest player id", () => {
+    const profiles = buildPredictionProfiles(["user-1", "guest-1"], [
+      {
+        userId: "user-1",
+        guestId: null,
+        totalCardsPlayed: 20,
+        blitzPileRemaining: 0,
+      },
+      {
+        userId: "user-1",
+        guestId: null,
+        totalCardsPlayed: 10,
+        blitzPileRemaining: 5,
+      },
+      {
+        userId: null,
+        guestId: "guest-1",
+        totalCardsPlayed: 30,
+        blitzPileRemaining: 0,
+      },
+      {
+        userId: "other-user",
+        guestId: null,
+        totalCardsPlayed: 40,
+        blitzPileRemaining: 0,
+      },
+    ]);
+
+    expect(profiles["user-1"]).toMatchObject({
+      playerId: "user-1",
+      roundsPlayed: 2,
+      meanDelta: 10,
+      blitzRate: 0.5,
+      meanCardsPlayed: 15,
+      meanBlitzPileRemaining: 2.5,
+      recentDeltas: [20, 0],
+    });
+    expect(profiles["user-1"].stdDelta).toBeCloseTo(14.142, 3);
+
+    expect(profiles["guest-1"]).toMatchObject({
+      playerId: "guest-1",
+      roundsPlayed: 1,
+      meanDelta: 30,
+      stdDelta: 0,
+      blitzRate: 1,
+      meanCardsPlayed: 30,
+      meanBlitzPileRemaining: 0,
+      recentDeltas: [30],
+    });
+    expect(profiles).not.toHaveProperty("other-user");
+  });
+
+  it("keeps recent deltas capped while retaining aggregate sample counts", () => {
+    const samples = Array.from({ length: RECENT_DELTA_LIMIT + 5 }, (_, index) => ({
+      userId: "user-1",
+      guestId: null,
+      totalCardsPlayed: index,
+      blitzPileRemaining: 0,
+    }));
+
+    const profiles = buildPredictionProfiles(["user-1"], samples);
+
+    expect(profiles["user-1"].roundsPlayed).toBe(RECENT_DELTA_LIMIT + 5);
+    expect(profiles["user-1"].recentDeltas).toHaveLength(RECENT_DELTA_LIMIT);
+    expect(profiles["user-1"].recentDeltas.slice(0, 3)).toEqual([0, 1, 2]);
+    expect(profiles["user-1"].recentDeltas.at(-1)).toBe(RECENT_DELTA_LIMIT - 1);
+  });
+});
+
+describe("getPredictionProfilesForGame", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "clerk-user",
+      orgId: "org-1",
+    });
+  });
+
+  it("does not fetch score history when the viewer is not authenticated", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: null,
+      orgId: null,
+    });
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when no active circle is selected", async () => {
+    (auth as unknown as jest.Mock).mockResolvedValue({
+      userId: "clerk-user",
+      orgId: null,
+    });
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when the game is missing", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history for legacy games without a circle", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: null,
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history for a different active circle", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-2",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch score history when a game has no resolvable players", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: null, guestId: null }],
+    });
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+    expect(prisma.score.findMany).not.toHaveBeenCalled();
+  });
+
+  it("fetches prior same-circle score samples for current user and guest players", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [
+        { userId: "user-1", guestId: null },
+        { userId: null, guestId: "guest-1" },
+      ],
+    });
+    (prisma.score.findMany as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          userId: "user-1",
+          guestId: null,
+          totalCardsPlayed: 20,
+          blitzPileRemaining: 0,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          userId: null,
+          guestId: "guest-1",
+          totalCardsPlayed: 25,
+          blitzPileRemaining: 5,
+        },
+      ]);
+
+    const profiles = await getPredictionProfilesForGame("game-1");
+
+    expect(prisma.score.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        userId: "user-1",
+        round: {
+          gameId: { not: "game-1" },
+          game: {
+            organizationId: "org-1",
+            isFinished: true,
+          },
+        },
+      },
+      select: {
+        userId: true,
+        guestId: true,
+        totalCardsPlayed: true,
+        blitzPileRemaining: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+    });
+    expect(prisma.score.findMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        guestId: "guest-1",
+        round: {
+          gameId: { not: "game-1" },
+          game: {
+            organizationId: "org-1",
+            isFinished: true,
+          },
+        },
+      },
+      select: {
+        userId: true,
+        guestId: true,
+        totalCardsPlayed: true,
+        blitzPileRemaining: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+    });
+    expect(profiles["user-1"].recentDeltas).toEqual([20]);
+    expect(profiles["guest-1"].recentDeltas).toEqual([15]);
+  });
+
+  it("supports user-only games without adding a guest query", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: "user-1", guestId: null }],
+    });
+    (prisma.score.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+
+    expect(prisma.score.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.score.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "user-1" }),
+      })
+    );
+  });
+
+  it("supports guest-only games without adding a user query", async () => {
+    (prisma.game.findUnique as jest.Mock).mockResolvedValue({
+      id: "game-1",
+      organizationId: "org-1",
+      players: [{ userId: null, guestId: "guest-1" }],
+    });
+    (prisma.score.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getPredictionProfilesForGame("game-1")).resolves.toEqual({});
+
+    expect(prisma.score.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.score.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ guestId: "guest-1" }),
+      })
+    );
+  });
+});

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -8,4 +8,5 @@ export {
   getHighestAndLowestScore,
   getCumulativeScore,
   getLongestAndShortestGamesByRounds,
+  getPredictionProfilesForGame,
 } from "./queries/index";

--- a/src/server/queries/index.ts
+++ b/src/server/queries/index.ts
@@ -6,3 +6,9 @@ export {
   getCumulativeScore,
   getLongestAndShortestGamesByRounds,
 } from "./stats";
+export {
+  buildPredictionProfiles,
+  getPredictionProfilesForGame,
+  type PredictionProfile,
+  type PredictionProfilesByPlayer,
+} from "./predictionProfiles";

--- a/src/server/queries/predictionProfiles.ts
+++ b/src/server/queries/predictionProfiles.ts
@@ -4,6 +4,12 @@ import { auth } from "@clerk/nextjs/server";
 import { type Prisma } from "@/generated/prisma/client";
 import prisma from "@/server/db/db";
 import { calculateRoundScore } from "@/lib/validation/gameRules";
+import {
+  type PredictionProfile,
+  type PredictionProfilesByPlayer,
+} from "@/lib/scoring/probability";
+
+export type { PredictionProfile, PredictionProfilesByPlayer };
 
 export const HISTORY_SAMPLE_LIMIT_PER_PLAYER = 120;
 export const RECENT_DELTA_LIMIT = 40;
@@ -14,19 +20,6 @@ export interface PredictionScoreSample {
   totalCardsPlayed: number;
   blitzPileRemaining: number;
 }
-
-export interface PredictionProfile {
-  playerId: string;
-  roundsPlayed: number;
-  meanDelta: number;
-  stdDelta: number;
-  blitzRate: number;
-  meanCardsPlayed: number;
-  meanBlitzPileRemaining: number;
-  recentDeltas: number[];
-}
-
-export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
 
 function mean(values: number[]): number {
   if (values.length === 0) return 0;

--- a/src/server/queries/predictionProfiles.ts
+++ b/src/server/queries/predictionProfiles.ts
@@ -1,0 +1,187 @@
+import "server-only";
+
+import { auth } from "@clerk/nextjs/server";
+import { type Prisma } from "@/generated/prisma/client";
+import prisma from "@/server/db/db";
+import { calculateRoundScore } from "@/lib/validation/gameRules";
+
+export const HISTORY_SAMPLE_LIMIT_PER_PLAYER = 120;
+export const RECENT_DELTA_LIMIT = 40;
+
+export interface PredictionScoreSample {
+  userId: string | null;
+  guestId: string | null;
+  totalCardsPlayed: number;
+  blitzPileRemaining: number;
+}
+
+export interface PredictionProfile {
+  playerId: string;
+  roundsPlayed: number;
+  meanDelta: number;
+  stdDelta: number;
+  blitzRate: number;
+  meanCardsPlayed: number;
+  meanBlitzPileRemaining: number;
+  recentDeltas: number[];
+}
+
+export type PredictionProfilesByPlayer = Record<string, PredictionProfile>;
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function stddev(values: number[], avg: number): number {
+  if (values.length < 2) return 0;
+  const variance =
+    values.reduce((sum, value) => sum + (value - avg) ** 2, 0) /
+    (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+function getSamplePlayerId(sample: PredictionScoreSample): string | null {
+  return sample.userId ?? sample.guestId ?? null;
+}
+
+export function buildPredictionProfiles(
+  playerIds: string[],
+  samples: PredictionScoreSample[]
+): PredictionProfilesByPlayer {
+  const samplesByPlayer = new Map<string, PredictionScoreSample[]>();
+
+  for (const playerId of playerIds) {
+    samplesByPlayer.set(playerId, []);
+  }
+
+  for (const sample of samples) {
+    const playerId = getSamplePlayerId(sample);
+    if (!playerId || !samplesByPlayer.has(playerId)) continue;
+    samplesByPlayer.get(playerId)?.push(sample);
+  }
+
+  return Object.fromEntries(
+    [...samplesByPlayer.entries()]
+      .filter(([, playerSamples]) => playerSamples.length > 0)
+      .map(([playerId, playerSamples]) => {
+        const deltas = playerSamples.map(calculateRoundScore);
+        const deltaMean = mean(deltas);
+
+        return [
+          playerId,
+          {
+            playerId,
+            roundsPlayed: playerSamples.length,
+            meanDelta: deltaMean,
+            stdDelta: stddev(deltas, deltaMean),
+            blitzRate:
+              playerSamples.filter((sample) => sample.blitzPileRemaining === 0)
+                .length / playerSamples.length,
+            meanCardsPlayed: mean(
+              playerSamples.map((sample) => sample.totalCardsPlayed)
+            ),
+            meanBlitzPileRemaining: mean(
+              playerSamples.map((sample) => sample.blitzPileRemaining)
+            ),
+            recentDeltas: deltas.slice(0, RECENT_DELTA_LIMIT),
+          },
+        ];
+      })
+  );
+}
+
+export async function getPredictionProfilesForGame(
+  gameId: string
+): Promise<PredictionProfilesByPlayer> {
+  const [session, game] = await Promise.all([
+    auth(),
+    prisma.game.findUnique({
+      where: { id: gameId },
+      select: {
+        id: true,
+        organizationId: true,
+        players: {
+          select: {
+            userId: true,
+            guestId: true,
+          },
+        },
+      },
+    }),
+  ]);
+
+  // Forecast history is optional enrichment: return no profiles instead of
+  // throwing so public/spectator game pages can keep rendering safely.
+  if (!session.userId || !session.orgId || !game?.organizationId) {
+    return {};
+  }
+
+  if (game.organizationId !== session.orgId) {
+    return {};
+  }
+
+  const userIds = game.players
+    .map((player) => player.userId)
+    .filter((id): id is string => Boolean(id));
+  const guestIds = game.players
+    .map((player) => player.guestId)
+    .filter((id): id is string => Boolean(id));
+  const playerIds = [...userIds, ...guestIds];
+
+  if (playerIds.length === 0) {
+    return {};
+  }
+
+  const historyScope = {
+    round: {
+      // Deliberately exclude this game; live in-game rounds are supplied by
+      // the scoring UI and will be blended separately by the forecast model.
+      gameId: { not: gameId },
+      game: {
+        organizationId: game.organizationId,
+        isFinished: true,
+      },
+    },
+  };
+
+  const scoreSelect = {
+    userId: true,
+    guestId: true,
+    totalCardsPlayed: true,
+    blitzPileRemaining: true,
+  } as const;
+  const scoreOrder: Prisma.ScoreOrderByWithRelationInput[] = [
+    { createdAt: "desc" },
+    { id: "desc" },
+  ];
+
+  const samplesByPlayer = await Promise.all([
+    ...userIds.map((userId) =>
+      prisma.score.findMany({
+        where: {
+          userId,
+          ...historyScope,
+        },
+        select: scoreSelect,
+        orderBy: scoreOrder,
+        take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+      })
+    ),
+    ...guestIds.map((guestId) =>
+      prisma.score.findMany({
+        where: {
+          guestId,
+          ...historyScope,
+        },
+        select: scoreSelect,
+        orderBy: scoreOrder,
+        take: HISTORY_SAMPLE_LIMIT_PER_PLAYER,
+      })
+    ),
+  ]);
+
+  const samples = samplesByPlayer.flat();
+
+  return buildPredictionProfiles(playerIds, samples);
+}


### PR DESCRIPTION
## Summary
This integration PR contains the full Race Outlook prediction stack for end-to-end testing:

- #266 current-game Race Outlook forecast
- #267 permission-gated historical prediction profiles
- #268 history-blended Race Outlook
- #269 Dutch Blitz mechanics forecast

Use this branch/PR to test the full experience together. The smaller PRs remain useful as review slices.

## Verification already run on the stacked tip
- `npm run lint`
- `npm test`
- `RESEND_API_KEY=re_dummy npx next build`

## Note
I created this from the top of the stack (`mwickett/dutch-blitz-mechanics-forecast`) so it contains every commit in the series.