### PR TITLE
Support eight-player game setup

### DIFF
--- a/src/app/games/new/page.tsx
+++ b/src/app/games/new/page.tsx
@@ -1,9 +1,10 @@
 "use server";
 
 import { Suspense } from "react";
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import prisma from "@/server/db/db";
 import NewGameChooser from "./newGameChooser";
+import { getOrgMemberClerkIds } from "@/server/clerkOrgs";
 
 export default async function NewGamePage() {
   const { userId, orgId } = await auth();
@@ -16,16 +17,7 @@ export default async function NewGamePage() {
     return <div>Please join a circle first</div>;
   }
 
-  // Get circle members from Clerk
-  const client = await clerkClient();
-  const memberships = await client.organizations.getOrganizationMembershipList({
-    organizationId: orgId,
-  });
-
-  // Extract Clerk user IDs from memberships
-  const clerkUserIds = memberships.data
-    .map((m) => m.publicUserData?.userId)
-    .filter((id): id is string => !!id);
+  const clerkUserIds = Array.from(await getOrgMemberClerkIds(orgId));
 
   // Look up Prisma users by their clerk_user_ids
   const users = await prisma.user.findMany({

--- a/src/components/__tests__/scoring/ColorPicker.test.tsx
+++ b/src/components/__tests__/scoring/ColorPicker.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ColorPicker } from "../../scoring/ColorPicker";
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
+
+describe("ColorPicker", () => {
+  it("disables colors used by other players by default", () => {
+    render(
+      <ColorPicker
+        value={null}
+        onChange={jest.fn()}
+        usedColors={[ACCENT_COLORS[0].value]}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Blue (taken)" })
+    ).toBeDisabled();
+  });
+
+  it("allows selecting an already-used color when duplicates are allowed", () => {
+    const onChange = jest.fn();
+
+    render(
+      <ColorPicker
+        value={null}
+        onChange={onChange}
+        usedColors={[ACCENT_COLORS[0].value]}
+        allowDuplicateColors
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Blue" }));
+
+    expect(onChange).toHaveBeenCalledWith(ACCENT_COLORS[0].value);
+  });
+});

--- a/src/components/__tests__/scoring/useGameColors.test.tsx
+++ b/src/components/__tests__/scoring/useGameColors.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  useGameColors,
+  type ColorStepPlayer,
+} from "../../scoring/useGameColors";
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
+
+function buildPlayers(count: number): ColorStepPlayer[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `p${index + 1}`,
+    name: `Player ${index + 1}`,
+    isGuest: false,
+    isCurrentUser: index === 0,
+    defaultColor: null,
+  }));
+}
+
+function GameColorsHarness({ players }: { players: ColorStepPlayer[] }) {
+  const { colors, updateColor } = useGameColors(players);
+
+  return (
+    <div>
+      {players.map((player) => (
+        <output key={player.id} data-testid={player.id}>
+          {colors[player.id]}
+        </output>
+      ))}
+      <button
+        type="button"
+        onClick={() =>
+          updateColor(players[players.length - 1].id, ACCENT_COLORS[0].value)
+        }
+      >
+        Set last player blue
+      </button>
+    </div>
+  );
+}
+
+describe("useGameColors", () => {
+  it("cascades color conflicts while the palette can stay unique", () => {
+    render(<GameColorsHarness players={buildPlayers(4)} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set last player blue" })
+    );
+
+    expect(screen.getByTestId("p1")).not.toHaveTextContent(
+      ACCENT_COLORS[0].value
+    );
+    expect(screen.getByTestId("p4")).toHaveTextContent(ACCENT_COLORS[0].value);
+  });
+
+  it("allows duplicate colors for eight-player expansion games", () => {
+    render(<GameColorsHarness players={buildPlayers(8)} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set last player blue" })
+    );
+
+    expect(screen.getByTestId("p1")).toHaveTextContent(ACCENT_COLORS[0].value);
+    expect(screen.getByTestId("p8")).toHaveTextContent(ACCENT_COLORS[0].value);
+  });
+});

--- a/src/components/scoring/ColorPicker.tsx
+++ b/src/components/scoring/ColorPicker.tsx
@@ -6,15 +6,20 @@ export function ColorPicker({
   value,
   onChange,
   usedColors = [],
+  allowDuplicateColors = false,
 }: {
   value: string | null;
   onChange: (color: string) => void;
   usedColors?: string[];
+  allowDuplicateColors?: boolean;
 }) {
   return (
     <div className="flex gap-2 flex-wrap">
       {ACCENT_COLORS.map((c) => {
-        const isUsed = usedColors.includes(c.value) && c.value !== value;
+        const isUsed =
+          !allowDuplicateColors &&
+          usedColors.includes(c.value) &&
+          c.value !== value;
         const isSelected = value === c.value;
         return (
           <button

--- a/src/components/scoring/GameColorStep.tsx
+++ b/src/components/scoring/GameColorStep.tsx
@@ -7,6 +7,7 @@ import { useGameColors, type ColorStepPlayer } from "./useGameColors";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { PlayCircle, ArrowLeft } from "lucide-react";
+import { ACCENT_COLORS } from "@/lib/scoring/colors";
 
 interface GameColorStepProps {
   players: ColorStepPlayer[];
@@ -17,6 +18,7 @@ interface GameColorStepProps {
 export function GameColorStep({ players, onConfirm, onBack }: GameColorStepProps) {
   const { colors, updateColor } = useGameColors(players);
   const [saveAsDefault, setSaveAsDefault] = useState(true);
+  const allowDuplicateColors = players.length > ACCENT_COLORS.length;
 
   const getInitials = (name: string) => name.substring(0, 2).toUpperCase();
 
@@ -65,6 +67,7 @@ export function GameColorStep({ players, onConfirm, onBack }: GameColorStepProps
               value={colors[player.id] ?? null}
               onChange={(color) => updateColor(player.id, color)}
               usedColors={usedByOthers}
+              allowDuplicateColors={allowDuplicateColors}
             />
 
             {player.isCurrentUser && (

--- a/src/components/scoring/useGameColors.ts
+++ b/src/components/scoring/useGameColors.ts
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { assignColorsToPlayers } from "@/lib/scoring/colors";
+import { ACCENT_COLORS, assignColorsToPlayers } from "@/lib/scoring/colors";
 import { resolveColorCascade } from "@/lib/scoring/colorCascade";
 
 export interface ColorStepPlayer {
@@ -15,6 +15,7 @@ export interface ColorStepPlayer {
 }
 
 export function useGameColors(players: ColorStepPlayer[]) {
+  const allowDuplicateColors = players.length > ACCENT_COLORS.length;
   const [colors, setColors] = useState<Record<string, string>>(() => {
     const inputs = players.map((p) => ({
       id: p.id,
@@ -24,8 +25,12 @@ export function useGameColors(players: ColorStepPlayer[]) {
   });
 
   const updateColor = useCallback((playerId: string, newColor: string) => {
-    setColors((prev) => resolveColorCascade(prev, playerId, newColor));
-  }, []);
+    setColors((prev) =>
+      allowDuplicateColors
+        ? { ...prev, [playerId]: newColor }
+        : resolveColorCascade(prev, playerId, newColor)
+    );
+  }, [allowDuplicateColors]);
 
   return { colors, updateColor };
 }


### PR DESCRIPTION
## Summary
- reuse the paginated Circle membership helper on the new-game page so larger circles are available when setting up games
- allow duplicate player colors once a game has more players than the six-color palette, which keeps seven/eight-player expansion games editable instead of treating every other color as unavailable
- add focused tests for color-picker duplicate behavior and the game-color hook's eight-player path

## Notes
There was no hard four-player cap in the DB, server action, or scoring flow. The practical gaps were around larger setup flows: membership fetching and color selection once the palette is exhausted.

## Tests
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`
