### PR TITLE
chore: ignore vercel env pull output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ tunnel.log
 !.env.example
 # ensure tests env never tracked
 .env.test
+# `vercel env pull <file>` writes names like preview.env / dev.env, which the
+# leading-dot patterns above do not match. Safe alongside !.env.example, since
+# that name does not end in .env.
+*.env
 
 
 # vercel


### PR DESCRIPTION
## Summary

`vercel env pull <file>` writes output names like `preview.env` / `dev.env`. The existing env rules are all leading-dot patterns (`.env`, `.env*.local`, `.env.*`), so none of them match that shape — a pulled env file full of secrets sits in the repo as an ordinary untracked file and can be committed by accident.

Adds `*.env` to the existing env block in `.gitignore`.

## Why not the `.env*` that `vercel link` appends

`vercel link` appends `.env*` to the end of the file. That is both redundant (lines 35-38 already cover those names) and actively wrong here: it sorts *after* `!.env.example`, so it overrides that exemption. Verified with `git check-ignore --no-index -v .env.example`, which reports the appended `.env*` as the matching rule. The breakage is currently latent only because `.env.example` is already tracked, and git does not ignore tracked files.

`*.env` does not have this problem — `.env.example` does not end in `.env`.

## Verification

`git check-ignore --no-index -v` after the change:

| file | result |
|---|---|
| `preview.env` | ignored via `*.env` |
| `dev.env` | ignored via `*.env` |
| `.env` / `.env.local` / `.env.test` | ignored |
| `.env.example` | matches `!.env.example` — exemption intact |