### PR TITLE
fix: state the sign-in-or-up flow explicitly

### DIFF
--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,14 @@ import { SignIn } from "@clerk/nextjs";
 export default function Page() {
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <SignIn />
+      {/*
+        Sign-up happens on this same route, at /sign-in/create. Stating that
+        explicitly matters: Clerk otherwise infers it, and setting a
+        NEXT_PUBLIC_CLERK_SIGN_UP_URL makes it infer that sign-up is a separate
+        page instead — at which point this component stops claiming /create and
+        bounces it back to /sign-in, leaving no way to sign up at all.
+      */}
+      <SignIn withSignUp />
     </div>
   );
 }


### PR DESCRIPTION
## Production hotfix — sign-up is currently unreachable

`https://www.blitzer.fun/sign-in/create` redirects to `/sign-in` and renders "Sign in to Blitzer". There is no reachable sign-up form on production right now. The nav's **Sign Up** button hits the same bounce, with `redirect_url` accreting on each hop.

## Cause

Setting `NEXT_PUBLIC_CLERK_SIGN_UP_URL` makes Clerk infer that sign-up lives on a *separate* page. `<SignIn />` then stops claiming `/sign-in/create` as its own step and redirects it back to `signInUrl`.

The variable was added to Production earlier today. `NEXT_PUBLIC_*` values are inlined at build time, so it sat inert in Vercel until #272 triggered a rebuild — which is why sign-up was verified working after the Clerk instance paths were repointed, and broke only on that deploy. It is not set in `.env.local`, so local development never showed it.

## Fix

`<SignIn withSignUp />` — *"Enable sign-in-or-up flow for `<SignIn />` component instance"* — states the intent in code rather than leaving it to be inferred from environment configuration.

## Verification

Reproduced locally by adding `NEXT_PUBLIC_CLERK_SIGN_UP_URL="/sign-in/create"` to `.env.local`, which produced the identical bounce:

| state | `/sign-in/create` |
|---|---|
| var set, before fix | → `/sign-in?redirect_url=…`, "Sign in to Blitzer" |
| var set, after fix | stays, "Create your account" |
| var unset, after fix | stays, "Create your account" |

Nav **Sign Up** → `/sign-in/create`, "Create your account". `/sign-in` still renders the sign-in step. The temporary `.env.local` change was reverted.

`npm run typecheck`, `npx eslint src --max-warnings=0`, `npx jest --runInBand --roots "<rootDir>/src"` — 28 suites, 215 tests.

## Follow-up

The fix makes the app correct regardless of the variable, but `NEXT_PUBLIC_CLERK_SIGN_UP_URL` is now redundant on every environment — the Clerk instance's own `sign_up_url` already points at `https://www.blitzer.fun/sign-in/create`. Worth removing from Production, Preview and Development so it cannot mislead later.